### PR TITLE
skip error when bundleDir not exist

### DIFF
--- a/cmd/nvidia-container-runtime/runtime_factory.go
+++ b/cmd/nvidia-container-runtime/runtime_factory.go
@@ -161,7 +161,9 @@ func getOCISpecFilePath(bundleDir string) (string, error) {
 		logger.Infof("Bundle directory path is empty, using working directory.")
 		workingDirectory, err := os.Getwd()
 		if err != nil {
-			return "", fmt.Errorf("error getting working directory: %v", err)
+			// don't return error here, the later oci.spec.load for 'runc create' will raise it.
+			logger.Errorf("error getting working directory: %v", err)
+			return "", nil
 		}
 		bundleDir = workingDirectory
 	}


### PR DESCRIPTION
Only `runc create` consumes ocispec, while `runc kill` doesn't. We should remove the logic for runc kill process.
We met the error that when container created and being killed,
`nvidia-container-runtime` will read `config.json` before execute `runc kill`, and return error if the file is deleted by upstream CRI runtime. In this case, the CRI shim process will stuck forever with the following error:

`containerd[2465]: level=error msg="StopContainer for
 \ " cf7396ff556e07a953248961ea5aba74c06bb6f1d61b7480166cb86f860d6b71 \ " failed",  error="
failed to stop container
 \ " cf7396ff556e07a953248961ea5aba74c06bb6f1d61b7480166cb86f860d6b71 \ " :
 unknown error after kill: /usr/bin/nvidia-container-runtime did not
 terminate successfully: exit status 1: Error running [
/usr/bin/nvidia-container-runtime --root /run/containerd/runc/k8s.io
 --log /run/
containerd/io.containerd.runtime.v2.task/k8s.io/
cf7396ff556e07a953248961ea5aba74c06bb6f1d61b7480166cb86f860d6b71/log.json
 --log-format json
 --systemd-cgroup kill
 cf7396ff556e07a953248961ea5aba74c06bb6f1d61b7480166cb86f860d6b71 9]: error
 creating runtime: error constructing OCI specification: error getting OCI
 specification file path: error getting working directory: getwd: no such
 file or directory\n: unknown"
`