### PR TITLE
Support container runtime other than runc

### DIFF
--- a/cmd/nvidia-container-runtime/runtime_factory.go
+++ b/cmd/nvidia-container-runtime/runtime_factory.go
@@ -17,7 +17,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/oci"
 )
@@ -26,7 +31,18 @@ const (
 	ociSpecFileName          = "config.json"
 	dockerRuncExecutableName = "docker-runc"
 	runcExecutableName       = "runc"
+	nvidiaRuntimeName        = "nvidia"
+	runcRuntimeName          = "runc"
+	dockerDefaultConfig      = "/etc/docker/daemon.json"
 )
+
+type dockerDaemon struct {
+	Runtimes map[string]dockerRuntime `json:"runtimes,omitempty"`
+}
+
+type dockerRuntime struct {
+	Path *string `json:"path,omitempty"`
+}
 
 // newRuntime is a factory method that constructs a runtime based on the selected configuration.
 func newRuntime(argv []string) (oci.Runtime, error) {
@@ -35,12 +51,18 @@ func newRuntime(argv []string) (oci.Runtime, error) {
 		return nil, fmt.Errorf("error constructing OCI specification: %v", err)
 	}
 
-	runc, err := newRuncRuntime()
+	runtime, err := newDefaultRuntime()
 	if err != nil {
-		return nil, fmt.Errorf("error constructing runc runtime: %v", err)
+		logger.Errorf("Error constructing default runtime: %v", err)
+
+		runc, err := newRuncRuntime()
+		if err != nil {
+			return nil, fmt.Errorf("error constructing runc runtime: %v", err)
+		}
+		runtime = runc
 	}
 
-	r, err := newNvidiaContainerRuntimeWithLogger(logger.Logger, runc, ociSpec)
+	r, err := newNvidiaContainerRuntimeWithLogger(logger.Logger, runtime, ociSpec)
 	if err != nil {
 		return nil, fmt.Errorf("error constructing NVIDIA Container Runtime: %v", err)
 	}
@@ -70,5 +92,49 @@ func newRuncRuntime() (oci.Runtime, error) {
 		logger.Logger,
 		dockerRuncExecutableName,
 		runcExecutableName,
+	)
+}
+
+func dockerRuntimeExecutablePath(name string) (string, error) {
+	file, err := os.Open(dockerDefaultConfig)
+	if err != nil {
+		return "", err
+	}
+
+	bytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return "", err
+	}
+
+	daemon := dockerDaemon{}
+	if err := json.Unmarshal(bytes, &daemon); err != nil {
+		return "", err
+	}
+
+	return *daemon.Runtimes[name].Path, nil
+}
+
+// newDefaultRuntime locates the default runtime binary and wraps it in a SyscallExecRuntime
+func newDefaultRuntime() (oci.Runtime, error) {
+	cmd := exec.Command("docker", "info", "--format", "{{.DefaultRuntime}}")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error getting docker default runtime: %v", err)
+	}
+	defaultRuntimeName := strings.TrimSpace(string(output))
+	if defaultRuntimeName == nvidiaRuntimeName || defaultRuntimeName == runcRuntimeName {
+		return nil, fmt.Errorf("docker default runtime is %v, bail out: %v", defaultRuntimeName, err)
+	}
+	candidates := []string{}
+	defaultRuntimeExecutablePath, err := dockerRuntimeExecutablePath(defaultRuntimeName)
+	if err != nil {
+		logger.Errorf("Error getting docker default runtime (%v)'s executable path: %v", defaultRuntimeName, err)
+		candidates = append(candidates, defaultRuntimeName)
+	} else {
+		candidates = append(candidates, defaultRuntimeExecutablePath)
+	}
+	return oci.NewLowLevelRuntimeWithLogger(
+		logger.Logger,
+		candidates...,
 	)
 }


### PR DESCRIPTION
One can choose low-level container runtime other than `runc` as the default container runtime, e.g. `crun`. The following code shows my configuration.

```
ubuntu@guiltless-dunnock:~$ cat /etc/docker/daemon.json
{
    "default-runtime": "crun",
    "runtimes": {
        "nvidia": {
            "path": "nvidia-container-runtime",
            "runtimeArgs": []
        },
        "crun": {
            "path": "/usr/local/bin/crun"
        }
    }
}
```

But if one runs a container with `--runtime nvidia`, it always falls to `runc`. This changeset corrects the behavior and chooses the default runtime if possible, then fall back to `runc`.

Logs (`/var/log/nvidia-container-runtime.log`) of running an `nginx` container using `nvidia` runtime (`docker run --runtime nvidia nginx`).
```
2022/02/14 14:52:07 Using bundle directory: 
2022/02/14 14:52:07 Using OCI specification file path: config.json
2022/02/14 14:52:07 Looking for runtime binary '/usr/local/bin/crun'
2022/02/14 14:52:07 Found runtime binary '/usr/local/bin/crun'
2022/02/14 14:52:07 Running nvidia-container-runtime

2022/02/14 14:52:07 No modification required
2022/02/14 14:52:07 Forwarding command to runtime
2022/02/14 14:52:07 Using bundle directory: 
2022/02/14 14:52:07 Using OCI specification file path: config.json
2022/02/14 14:52:07 Looking for runtime binary '/usr/local/bin/crun'
2022/02/14 14:52:07 Found runtime binary '/usr/local/bin/crun'
2022/02/14 14:52:07 Running nvidia-container-runtime

2022/02/14 14:52:07 No modification required
2022/02/14 14:52:07 Forwarding command to runtime
2022/02/14 14:52:07 Using bundle directory: 
2022/02/14 14:52:07 Using OCI specification file path: config.json
2022/02/14 14:52:07 Looking for runtime binary '/usr/local/bin/crun'
2022/02/14 14:52:07 Found runtime binary '/usr/local/bin/crun'
2022/02/14 14:52:07 Running nvidia-container-runtime

2022/02/14 14:52:07 No modification required
2022/02/14 14:52:07 Forwarding command to runtime
```