### PR TITLE
Add config search path option to driver root

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -53,6 +53,7 @@ type options struct {
 	vendor               string
 	class                string
 
+	configSearchPaths  cli.StringSlice
 	librarySearchPaths cli.StringSlice
 
 	csv struct {
@@ -86,6 +87,11 @@ func (m command) build() *cli.Command {
 	}
 
 	c.Flags = []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:        "config-search-path",
+			Usage:       "Specify the path to search for config files when discovering the entities that should be included in the CDI specification.",
+			Destination: &opts.configSearchPaths,
+		},
 		&cli.StringFlag{
 			Name:        "output",
 			Usage:       "Specify the file to output the generated CDI specification to. If this is '' the specification is output to STDOUT",
@@ -260,6 +266,7 @@ func (m command) generateSpec(opts *options) (spec.Interface, error) {
 		nvcdi.WithLdconfigPath(opts.ldconfigPath),
 		nvcdi.WithDeviceNamers(deviceNamers...),
 		nvcdi.WithMode(opts.mode),
+		nvcdi.WithConfigSearchPaths(opts.configSearchPaths.Value()),
 		nvcdi.WithLibrarySearchPaths(opts.librarySearchPaths.Value()),
 		nvcdi.WithCSVFiles(opts.csv.files.Value()),
 		nvcdi.WithCSVIgnorePatterns(opts.csv.ignorePatterns.Value()),

--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -61,11 +61,7 @@ func NewGraphicsMountsDiscoverer(logger logger.Interface, driver *root.Driver, n
 
 	jsonMounts := NewMounts(
 		logger,
-		lookup.NewFileLocator(
-			lookup.WithLogger(logger),
-			lookup.WithRoot(driver.Root),
-			lookup.WithSearchPaths("/etc", "/usr/share"),
-		),
+		driver.Configs(),
 		driver.Root,
 		[]string{
 			"glvnd/egl_vendor.d/10_nvidia.json",
@@ -292,11 +288,7 @@ func newXorgDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCTKPa
 
 	xorgConfig := NewMounts(
 		logger,
-		lookup.NewFileLocator(
-			lookup.WithLogger(logger),
-			lookup.WithRoot(driver.Root),
-			lookup.WithSearchPaths("/usr/share"),
-		),
+		driver.Configs(),
 		driver.Root,
 		[]string{"X11/xorg.conf.d/10-nvidia.conf"},
 	)

--- a/internal/lookup/root/options.go
+++ b/internal/lookup/root/options.go
@@ -37,3 +37,9 @@ func WithLibrarySearchPaths(paths ...string) Option {
 		d.librarySearchPaths = paths
 	}
 }
+
+func WithConfigSearchPaths(paths ...string) Option {
+	return func(d *Driver) {
+		d.configSearchPaths = paths
+	}
+}

--- a/internal/lookup/root/root.go
+++ b/internal/lookup/root/root.go
@@ -53,6 +53,15 @@ func (r *Driver) Libraries() lookup.Locator {
 	)
 }
 
+// Configs returns a locator for driver configs.
+func (r *Driver) Configs() lookup.Locator {
+	return lookup.NewFileLocator(
+		lookup.WithLogger(r.logger),
+		lookup.WithRoot(r.Root),
+		lookup.WithSearchPaths("/etc", "/usr/share"),
+	)
+}
+
 // normalizeSearchPaths takes a list of paths and normalized these.
 // Each of the elements in the list is expanded if it is a path list and the
 // resultant list is returned.

--- a/internal/lookup/root/root.go
+++ b/internal/lookup/root/root.go
@@ -30,6 +30,8 @@ type Driver struct {
 	Root string
 	// librarySearchPaths specifies explicit search paths for discovering libraries.
 	librarySearchPaths []string
+	// configSearchPaths specified explicit search paths for discovering driver config files.
+	configSearchPaths []string
 }
 
 // New creates a new Driver root using the specified options.
@@ -54,11 +56,20 @@ func (r *Driver) Libraries() lookup.Locator {
 }
 
 // Configs returns a locator for driver configs.
+// If configSearchPaths is specified, these paths are used as absolute paths,
+// otherwise, /etc and /usr/share are searched.
 func (r *Driver) Configs() lookup.Locator {
+	searchRoot := r.Root
+	searchPaths := []string{"/etc", "/usr/share"}
+	if len(r.configSearchPaths) > 0 {
+		searchRoot = "/"
+		searchPaths = normalizeSearchPaths(r.configSearchPaths...)
+	}
+
 	return lookup.NewFileLocator(
 		lookup.WithLogger(r.logger),
-		lookup.WithRoot(r.Root),
-		lookup.WithSearchPaths("/etc", "/usr/share"),
+		lookup.WithRoot(searchRoot),
+		lookup.WithSearchPaths(searchPaths...),
 	)
 }
 

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -50,6 +50,7 @@ type nvcdilib struct {
 	devRoot            string
 	nvidiaCTKPath      string
 	ldconfigPath       string
+	configSearchPaths  []string
 	librarySearchPaths []string
 
 	csvFiles          []string

--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -126,6 +126,13 @@ func WithCSVIgnorePatterns(csvIgnorePatterns []string) Option {
 	}
 }
 
+// WithConfigSearchPaths sets the search paths for config files.
+func WithConfigSearchPaths(paths []string) Option {
+	return func(o *nvcdilib) {
+		o.configSearchPaths = paths
+	}
+}
+
 // WithLibrarySearchPaths sets the library search paths.
 // This is currently only used for CSV-mode.
 func WithLibrarySearchPaths(paths []string) Option {


### PR DESCRIPTION
This changes adds a `Configs()` method to the Driver root abstraction that can be used to locate config files.

In addition a `--config-search-path` option is added to the `nvidia-ctk cdi generate` command to allow this to be overridden.
