### PR TITLE
Golang 1.17 compat

### DIFF
--- a/cmd/nvidia-ctk/config/config.go
+++ b/cmd/nvidia-ctk/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 	createdefault "github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk/config/create-default"
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk/config/flags"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/errors"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 )
 
@@ -141,7 +141,7 @@ func setFlagToKeyValue(setFlag string) (string, interface{}, error) {
 
 	field, err := getField(key)
 	if err != nil {
-		return key, nil, fmt.Errorf("%w: %w", errInvalidConfigOption, err)
+		return key, nil, errors.Join(err, errInvalidConfigOption)
 	}
 
 	kind := field.Kind()
@@ -157,7 +157,7 @@ func setFlagToKeyValue(setFlag string) (string, interface{}, error) {
 	case reflect.Bool:
 		b, err := strconv.ParseBool(value)
 		if err != nil {
-			return key, value, fmt.Errorf("%w: %w", errInvalidFormat, err)
+			return key, value, errors.Join(err, errInvalidFormat)
 		}
 		return key, b, err
 	case reflect.String:
@@ -172,7 +172,7 @@ func setFlagToKeyValue(setFlag string) (string, interface{}, error) {
 			for _, v := range valueParts {
 				vi, err := strconv.ParseInt(v, 10, 0)
 				if err != nil {
-					return key, nil, fmt.Errorf("%w: %w", errInvalidFormat, err)
+					return key, nil, errors.Join(err, errInvalidFormat)
 				}
 				output = append(output, vi)
 			}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,27 @@
+/**
+# Copyright 2023 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package errors
+
+import (
+	"errors"
+)
+
+// New provides a wrapper for errors.New.
+// This allows this internal package to be used as a drop-in replacement for the stdlib package.
+func New(text string) error {
+	return errors.New(text)
+}

--- a/internal/errors/errors_legacy.go
+++ b/internal/errors/errors_legacy.go
@@ -1,0 +1,36 @@
+//go:build !go1.20
+
+/**
+# Copyright 2023 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package errors
+
+import "fmt"
+
+// Join provides a legacy implementation for errors.Join.
+func Join(errs ...error) error {
+	var all error
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if all == nil {
+			all = err
+		}
+		all = fmt.Errorf("%v %w", all, err)
+	}
+	return all
+}

--- a/internal/errors/errors_modern.go
+++ b/internal/errors/errors_modern.go
@@ -1,0 +1,28 @@
+//go:build go1.20
+
+/**
+# Copyright 2023 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package errors
+
+import (
+	"errors"
+)
+
+// Join wraps errors.Join for newer golang versions.
+func Join(errs ...error) error {
+	return errors.Join(errs...)
+}

--- a/internal/lookup/merge.go
+++ b/internal/lookup/merge.go
@@ -16,7 +16,7 @@
 
 package lookup
 
-import "errors"
+import "github.com/NVIDIA/nvidia-container-toolkit/internal/errors"
 
 type first []Locator
 
@@ -34,14 +34,14 @@ func First(locators ...Locator) Locator {
 
 // Locate returns the results for the first locator that returns a non-empty non-error result.
 func (f first) Locate(pattern string) ([]string, error) {
-	var allErrors []error
+	var allErrors error
 	for _, l := range f {
 		if l == nil {
 			continue
 		}
 		candidates, err := l.Locate(pattern)
 		if err != nil {
-			allErrors = append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 			continue
 		}
 		if len(candidates) > 0 {
@@ -49,5 +49,5 @@ func (f first) Locate(pattern string) ([]string, error) {
 		}
 	}
 
-	return nil, errors.Join(allErrors...)
+	return nil, allErrors
 }

--- a/internal/modifier/cdi/registry.go
+++ b/internal/modifier/cdi/registry.go
@@ -17,12 +17,12 @@
 package cdi
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/errors"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/oci"
 )

--- a/internal/runtime/logger.go
+++ b/internal/runtime/logger.go
@@ -17,7 +17,6 @@
 package runtime
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/errors"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 )
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -18,13 +18,13 @@ package runtime
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/errors"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/info"
 )
 


### PR DESCRIPTION
Some customers need to build the components of the NVIDIA Container Toolkit from source using Golang 1.17.

This MR defines some minor change that allow the project to be built using Go 1.17, with an `internal/errors` package being used to provide basic `errors.Join` functionality. This is the only feature we currently use from Go 1.20.

Migrated from https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/516