### PR TITLE
Cherry-pick changes for v1.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # NVIDIA Container Toolkit Changelog
 
 ## v1.14.5
+* Fix `nvidia-ctk runtime configure --cdi.enabled` for Docker. This was incorrectly setting `experimental = true` instead
+  of setting `features.cdi = true`.
 
 ## v1.14.4
 * Include `nvidia/nvoptix.bin` in list of graphics mounts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NVIDIA Container Toolkit Changelog
 
+## v1.14.5
+
 ## v1.14.4
 * Include `nvidia/nvoptix.bin` in list of graphics mounts.
 * Include `vulkan/icd.d/nvidia_layers.json` in list of graphics mounts.

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -149,6 +149,7 @@ func (m command) build() *cli.Command {
 		},
 		&cli.BoolFlag{
 			Name:        "cdi.enabled",
+			Aliases:     []string{"cdi.enable"},
 			Usage:       "Enable CDI in the configured runtime",
 			Destination: &config.cdi.enabled,
 		},
@@ -310,7 +311,7 @@ func enableCDI(config *config, cfg engine.Interface) error {
 	case "containerd":
 		return cfg.Set("enable_cdi", true)
 	case "docker":
-		return cfg.Set("experimental", true)
+		return cfg.Set("features", map[string]bool{"cdi": true})
 	}
 	return fmt.Errorf("enabling CDI in %s is not supported", config.runtime)
 }

--- a/versions.mk
+++ b/versions.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 LIB_NAME := nvidia-container-toolkit
-LIB_VERSION := 1.14.4
+LIB_VERSION := 1.14.5
 LIB_TAG :=
 
 # The package version is the combination of the library version and tag.


### PR DESCRIPTION
This bumps the version to `v1.14.5` and cherry picks the following changes from `main`:
* [!541](https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/541): Fix `nvidia-ctk runtime configure --cdi.enabled` for Docker.