### PR TITLE
Specify DRIVER_ROOT consistently

### DIFF
--- a/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
+++ b/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
@@ -87,7 +87,7 @@ func (m command) build() *cli.Command {
 			Usage:       "The path to the driver root. `DRIVER_ROOT`/dev is searched for NVIDIA device nodes.",
 			Value:       "/",
 			Destination: &cfg.driverRoot,
-			EnvVars:     []string{"DRIVER_ROOT"},
+			EnvVars:     []string{"NVIDIA_DRIVER_ROOT", "DRIVER_ROOT"},
 		},
 		&cli.BoolFlag{
 			Name:        "watch",

--- a/cmd/nvidia-ctk/system/create-device-nodes/create-device-nodes.go
+++ b/cmd/nvidia-ctk/system/create-device-nodes/create-device-nodes.go
@@ -69,7 +69,7 @@ func (m command) build() *cli.Command {
 			Usage:       "the path to the driver root. Device nodes will be created at `DRIVER_ROOT`/dev",
 			Value:       "/",
 			Destination: &opts.driverRoot,
-			EnvVars:     []string{"DRIVER_ROOT"},
+			EnvVars:     []string{"NVIDIA_DRIVER_ROOT", "DRIVER_ROOT"},
 		},
 		&cli.BoolFlag{
 			Name:        "control-devices",

--- a/cmd/nvidia-ctk/system/print-ldcache/print-ldcache.go
+++ b/cmd/nvidia-ctk/system/print-ldcache/print-ldcache.go
@@ -62,7 +62,7 @@ func (m command) build() *cli.Command {
 			Usage:       "the path to the driver root. Device nodes will be created at `DRIVER_ROOT`/dev",
 			Value:       "/",
 			Destination: &opts.driverRoot,
-			EnvVars:     []string{"DRIVER_ROOT"},
+			EnvVars:     []string{"NVIDIA_DRIVER_ROOT", "DRIVER_ROOT"},
 		},
 	}
 

--- a/tools/container/toolkit/toolkit.go
+++ b/tools/container/toolkit/toolkit.go
@@ -118,10 +118,11 @@ func main() {
 
 	flags := []cli.Flag{
 		&cli.StringFlag{
-			Name:        "nvidia-driver-root",
+			Name:        "driver-root",
+			Aliases:     []string{"nvidia-driver-root"},
 			Value:       DefaultNvidiaDriverRoot,
 			Destination: &opts.DriverRoot,
-			EnvVars:     []string{"NVIDIA_DRIVER_ROOT"},
+			EnvVars:     []string{"NVIDIA_DRIVER_ROOT", "DRIVER_ROOT"},
 		},
 		&cli.StringFlag{
 			Name:        "driver-root-ctr-path",


### PR DESCRIPTION
This change ensures that CLI tools that require the path to the driver root accept both the NVIDIA_DRIVER_ROOT and DRIVER_ROOT environment variables in addition to the --driver-root command line argument.