### PR TITLE
Add dev-root option to toolkit container

### DIFF
--- a/pkg/nvcdi/transform/root/driver-root.go
+++ b/pkg/nvcdi/transform/root/driver-root.go
@@ -1,0 +1,99 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package root
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/transform"
+)
+
+type DriverOption func(*driverOptions)
+
+func WithDriverRoot(root string) DriverOption {
+	return func(do *driverOptions) {
+		do.driverRoot = root
+	}
+}
+
+func WithTargetDriverRoot(root string) DriverOption {
+	return func(do *driverOptions) {
+		do.targetDriverRoot = root
+	}
+}
+
+func WithDevRoot(root string) DriverOption {
+	return func(do *driverOptions) {
+		do.devRoot = root
+	}
+}
+
+func WithTargetDevRoot(root string) DriverOption {
+	return func(do *driverOptions) {
+		do.targetDevRoot = root
+	}
+}
+
+type driverOptions struct {
+	driverRoot       string
+	targetDriverRoot string
+	devRoot          string
+	targetDevRoot    string
+}
+
+// NewDriverTransformer creates a transformer for transforming driver specifications.
+func NewDriverTransformer(opts ...DriverOption) transform.Transformer {
+	d := &driverOptions{}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.driverRoot == "" {
+		d.driverRoot = "/"
+	}
+	if d.targetDriverRoot == "" {
+		d.targetDriverRoot = "/"
+	}
+	if d.devRoot == "" {
+		d.devRoot = d.driverRoot
+	}
+	if d.targetDevRoot == "" {
+		d.targetDevRoot = d.targetDriverRoot
+	}
+
+	var transformers []transform.Transformer
+
+	if d.targetDevRoot != d.targetDriverRoot {
+		devRootTransformer := New(
+			WithRoot(ensureDev(d.devRoot)),
+			WithTargetRoot(ensureDev(d.targetDevRoot)),
+		)
+		transformers = append(transformers, devRootTransformer)
+	}
+
+	driverRootTransformer := New(
+		WithRoot(d.driverRoot),
+		WithTargetRoot(d.targetDriverRoot),
+	)
+	transformers = append(transformers, driverRootTransformer)
+
+	return transform.Merge(transformers...)
+}
+
+func ensureDev(p string) string {
+	return filepath.Join(strings.TrimSuffix(filepath.Clean(p), "/dev"), "/dev")
+}

--- a/pkg/nvcdi/transform/root/driver-root_test.go
+++ b/pkg/nvcdi/transform/root/driver-root_test.go
@@ -1,0 +1,208 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"tags.cncf.io/container-device-interface/specs-go"
+)
+
+func TestDriverTransformer(t *testing.T) {
+	testCases := []struct {
+		description      string
+		driverRoot       string
+		targetDriverRoot string
+		devRoot          string
+		targetDevRoot    string
+		spec             *specs.Spec
+		expectedError    error
+		expectedSpec     *specs.Spec
+	}{
+		{
+			description:      "dev root not specified",
+			driverRoot:       "/driver-root",
+			targetDriverRoot: "/host/driver/root/",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/driver-root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/driver-root/dev/host/path",
+							Path:     "/driver-root/dev/container/path",
+						},
+					},
+				},
+			},
+			expectedSpec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/host/driver/root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/host/driver/root/dev/host/path",
+							Path:     "/driver-root/dev/container/path",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "dev driver root matches",
+			driverRoot:       "/driver-root",
+			targetDriverRoot: "/host/driver/root/",
+			devRoot:          "/driver-root",
+			targetDevRoot:    "/host/driver/root/",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/driver-root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/driver-root/dev/host/path",
+							Path:     "/driver-root/dev/container/path",
+						},
+					},
+				},
+			},
+			expectedSpec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/host/driver/root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/host/driver/root/dev/host/path",
+							Path:     "/driver-root/dev/container/path",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "dev driver root matches separate target dev root",
+			driverRoot:       "/driver-root",
+			targetDriverRoot: "/host/driver/root/",
+			devRoot:          "/driver-root",
+			targetDevRoot:    "/host/dev/root/",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/driver-root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/driver-root/dev/host/path",
+							Path:     "/driver-root/dev/container/path",
+						},
+					},
+				},
+			},
+			expectedSpec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/host/driver/root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/host/dev/root/dev/host/path",
+							Path:     "/driver-root/dev/container/path",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "dev root specified with explicit target",
+			driverRoot:       "/driver-root",
+			targetDriverRoot: "/host/driver/root/",
+			devRoot:          "/",
+			targetDevRoot:    "/dev/root/",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/driver-root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/dev/host/path",
+							Path:     "/dev/container/path",
+						},
+					},
+				},
+			},
+			expectedSpec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{
+						{
+							HostPath:      "/host/driver/root/host/path",
+							ContainerPath: "/driver-root/container/path",
+						},
+					},
+					DeviceNodes: []*specs.DeviceNode{
+						{
+							HostPath: "/dev/root/dev/host/path",
+							Path:     "/dev/container/path",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			transformer := NewDriverTransformer(
+				WithDriverRoot(tc.driverRoot),
+				WithTargetDriverRoot(tc.targetDriverRoot),
+				WithDevRoot(tc.devRoot),
+				WithTargetDevRoot(tc.targetDevRoot),
+			)
+
+			err := transformer.Transform(tc.spec)
+
+			require.ErrorIs(t, err, tc.expectedError)
+			require.EqualValues(t, tc.expectedSpec, tc.spec)
+		})
+	}
+}


### PR DESCRIPTION
This adds support for using the toolkit container in environments where the "driverRoot" does not represent a chrootable filesystem.

For example, if the NVIDIA driver libraries are available at `/opt/nvidia/driver` on the host, but the device nodes are created at `/dev` on the host. Assuming these are mounted readOnly as follows into the toolkit container:
* `/opt/nvidia/driver` -> `/driver-root` 
* `/` -> `/host`

Setting the following envvars:
* `NVIDIA_DRIVER_ROOT=/opt/nvidia/driver`
* `DRIVER_ROOT_CTR_PATH=/driver-root`
* `NVIDIA_DEV_ROOT=/`
* `DEV_ROOT_CRT_PATH=/host`

will allow the CDI specification generation to complete and generate a valid CDI spec.

See https://github.com/NVIDIA/nvidia-container-toolkit/issues/209#issuecomment-1943441883