### PR TITLE
Remove additional libnvidia-container0 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow multiple device naming strategies for `nvidia-ctk cdi generate` command. This allows a single
   CDI spec to be generated that includes GPUs by index and UUID.
 * Set the default `--device-name-strategy` for the `nvidia-ctk cdi generate` command to `[index, uuid]`.
+* Remove `libnvidia-container0` jetpack dependency included for legacy Tegra-based systems.
 
 ## v1.15.0-rc.3
 * Fix bug in `nvidia-ctk hook update-ldcache` where default `--ldconfig-path` value was not applied.

--- a/build/container/Dockerfile.ubuntu
+++ b/build/container/Dockerfile.ubuntu
@@ -75,14 +75,6 @@ ARG PACKAGE_VERSION
 ARG TARGETARCH
 ENV PACKAGE_ARCH ${TARGETARCH}
 
-ARG LIBNVIDIA_CONTAINER_REPO="https://nvidia.github.io/libnvidia-container/stable"
-ARG LIBNVIDIA_CONTAINER0_VERSION
-RUN if [ "${PACKAGE_ARCH}" = "arm64" ]; then \
-        curl -L ${LIBNVIDIA_CONTAINER_REPO}/${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container0_${LIBNVIDIA_CONTAINER0_VERSION}_${PACKAGE_ARCH}.deb \
-            --output ${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container0_${LIBNVIDIA_CONTAINER0_VERSION}_${PACKAGE_ARCH}.deb && \
-        dpkg -i ${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container0_${LIBNVIDIA_CONTAINER0_VERSION}_${PACKAGE_ARCH}.deb; \
-    fi
-
 RUN dpkg -i \
     ${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container1_1.*.deb \
     ${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container-tools_1.*.deb \

--- a/build/container/Makefile
+++ b/build/container/Makefile
@@ -99,7 +99,6 @@ $(BUILD_TARGETS): build-%: $(ARTIFACTS_ROOT)
 		--build-arg BASE_DIST="$(BASE_DIST)" \
 		--build-arg CUDA_VERSION="$(CUDA_VERSION)" \
 		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
-		--build-arg LIBNVIDIA_CONTAINER0_VERSION="$(LIBNVIDIA_CONTAINER0_DEPENDENCY)" \
 		--build-arg PACKAGE_DIST="$(PACKAGE_DIST)" \
 		--build-arg PACKAGE_VERSION="$(PACKAGE_VERSION)" \
 		--build-arg VERSION="$(VERSION)" \
@@ -114,7 +113,6 @@ $(BUILD_TARGETS): build-%: $(ARTIFACTS_ROOT)
 build-ubuntu%: BASE_DIST = $(*)
 build-ubuntu%: DOCKERFILE_SUFFIX := ubuntu
 build-ubuntu%: PACKAGE_DIST = ubuntu18.04
-build-ubuntu%: LIBNVIDIA_CONTAINER0_DEPENDENCY=$(LIBNVIDIA_CONTAINER0_VERSION)
 
 build-ubi8: BASE_DIST := ubi8
 build-ubi8: DOCKERFILE_SUFFIX := centos

--- a/versions.mk
+++ b/versions.mk
@@ -27,9 +27,6 @@ PACKAGE_REVISION := 1
 NVIDIA_DOCKER_VERSION := 2.14.0
 NVIDIA_CONTAINER_RUNTIME_VERSION := 3.14.0
 
-# Specify the expected libnvidia-container0 version for arm64-based ubuntu builds.
-LIBNVIDIA_CONTAINER0_VERSION := 0.10.0+jetpack
-
 CUDA_VERSION := 12.3.1
 GOLANG_VERSION := 1.20.5
 


### PR DESCRIPTION
This change removes the additional libnvidia-container0=0.10.0+jetpack dependency that was introduced for Tegra-based systems. These have since been migrated to CDI-based direct injection using the NVIDIA Container Runtime.