### PR TITLE
Cherry pick v1.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # NVIDIA Container Toolkit Changelog
 
 * Add support for extracting device major number from `/proc/devices` if `nvidia` is used as a device name over `nvidia-frontend`.
+* Add support for selecting IMEX channels using the NVIDIA_IMEX_CHANNELS environement variable.
 
 ## v1.14.5
 * Fix `nvidia-ctk runtime configure --cdi.enabled` for Docker. This was incorrectly setting `experimental = true` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # NVIDIA Container Toolkit Changelog
 
+## v1.14.6
 * Add support for extracting device major number from `/proc/devices` if `nvidia` is used as a device name over `nvidia-frontend`.
 * Add support for selecting IMEX channels using the NVIDIA_IMEX_CHANNELS environement variable.
 

--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -126,6 +126,9 @@ func doPrestart() {
 	if len(nvidia.MigMonitorDevices) > 0 {
 		args = append(args, fmt.Sprintf("--mig-monitor=%s", nvidia.MigMonitorDevices))
 	}
+	if len(nvidia.ImexChannels) > 0 {
+		args = append(args, fmt.Sprintf("--imex-channel=%s", nvidia.ImexChannels))
+	}
 
 	for _, cap := range strings.Split(nvidia.DriverCapabilities, ",") {
 		if len(cap) == 0 {

--- a/versions.mk
+++ b/versions.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 LIB_NAME := nvidia-container-toolkit
-LIB_VERSION := 1.14.5
+LIB_VERSION := 1.14.6
 LIB_TAG :=
 
 # The package version is the combination of the library version and tag.


### PR DESCRIPTION
This cherry-picks the following changes to the release-1.14 branch:

* #375 -- Add IMEX support

And bumps the version to v1.14.6

This requires https://github.com/NVIDIA/libnvidia-container/pull/243