### PR TITLE
[R550 driver support] add fallback logic to device.Exists(name)

### DIFF
--- a/internal/info/proc/devices/devices.go
+++ b/internal/info/proc/devices/devices.go
@@ -67,7 +67,7 @@ func (d devices) Count() int {
 
 // Exists checks if a Device with a given name exists or not
 func (d devices) Exists(name Name) bool {
-	_, exists := d[name]
+	_, exists := d.Get(name)
 	return exists
 }
 


### PR DESCRIPTION
We missed to add the same fallback logic to the Exists method as was added to the Get method.

The gpu-operator-validator container uses the Exists method to assert the presence of `/dev/(nvidia|nvidia-frontend)`