### PR TITLE
Remove centos7 container-toolkit image

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -224,13 +224,6 @@ test-packaging:
         OUT_IMAGE_VERSION: "${DEVEL_RELEASE_IMAGE_VERSION}"
 
 # Define the release jobs
-release:staging-centos7:
-  extends:
-    - .release:staging
-    - .dist-centos7
-  needs:
-    - image-centos7
-
 release:staging-ubi8:
   extends:
     - .release:staging

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,6 @@ jobs:
       matrix:
         dist:
           - ubuntu20.04
-          - centos7
           - ubi8
           - packaging
         ispr:
@@ -85,8 +84,6 @@ jobs:
         exclude:
           - ispr: true
             dist: ubi8
-          - ispr: true
-            dist: centos7
     needs: packages
     steps:
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,14 +128,6 @@ package-ubuntu18.04-ppc64le:
   script:
     - make -f build/container/Makefile build-${DIST}
 
-image-centos7:
-  extends:
-    - .image-build
-    - .package-artifacts
-    - .dist-centos7
-  needs:
-    - package-centos7-x86_64
-
 image-ubi8:
   extends:
     - .image-build

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -69,11 +69,6 @@ variables:
     - regctl registry login "${OUT_REGISTRY}" -u "${OUT_REGISTRY_USER}" -p "${OUT_REGISTRY_TOKEN}"
     - make -f build/container/Makefile IMAGE=${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION}-${DIST} OUT_IMAGE=${OUT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}-${DIST} push-${DIST}
 
-image-centos7:
-  extends:
-    - .dist-centos7
-    - .image-pull
-
 image-ubi8:
   extends:
     - .dist-ubi8
@@ -132,14 +127,6 @@ image-packaging:
       - policy_evaluation.json
 
 # Define the scan targets
-scan-centos7-amd64:
-  extends:
-    - .dist-centos7
-    - .platform-amd64
-    - .scan
-  needs:
-    - image-centos7
-
 scan-ubuntu20.04-amd64:
   extends:
     - .dist-ubuntu20.04
@@ -243,11 +230,6 @@ release:staging-ubuntu20.04:
 
 # Define the external release targets
 # Release to NGC
-release:ngc-centos7:
-  extends:
-    - .dist-centos7
-    - .release:ngc
-
 release:ngc-ubuntu20.04:
   extends:
     - .dist-ubuntu20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Set the default `--device-name-strategy` for the `nvidia-ctk cdi generate` command to `[index, uuid]`.
 * Remove `libnvidia-container0` jetpack dependency included for legacy Tegra-based systems.
 
+* [toolkit-container] Remove centos7 image. The ubi8 image can be used on all RPM-based platforms.
+
 ## v1.15.0-rc.3
 * Fix bug in `nvidia-ctk hook update-ldcache` where default `--ldconfig-path` value was not applied.
 

--- a/build/container/Makefile
+++ b/build/container/Makefile
@@ -45,7 +45,7 @@ OUT_IMAGE = $(OUT_IMAGE_NAME):$(OUT_IMAGE_TAG)
 
 ##### Public rules #####
 DEFAULT_PUSH_TARGET := ubuntu20.04
-DISTRIBUTIONS := ubuntu20.04 ubi8 centos7
+DISTRIBUTIONS := ubuntu20.04 ubi8
 
 META_TARGETS := packaging
 
@@ -117,10 +117,6 @@ build-ubuntu%: PACKAGE_DIST = ubuntu18.04
 build-ubi8: BASE_DIST := ubi8
 build-ubi8: DOCKERFILE_SUFFIX := centos
 build-ubi8: PACKAGE_DIST = centos7
-
-build-centos7: BASE_DIST = $(*)
-build-centos7: DOCKERFILE_SUFFIX := centos
-build-centos7: PACKAGE_DIST = $(BASE_DIST)
 
 build-packaging: BASE_DIST := ubuntu20.04
 build-packaging: DOCKERFILE_SUFFIX := packaging

--- a/build/container/multi-arch.mk
+++ b/build/container/multi-arch.mk
@@ -16,9 +16,6 @@ PUSH_ON_BUILD ?= false
 DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD)
 DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64,linux/arm64
 
-# We only have x86_64 packages for centos7
-build-centos7: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
-
 # We only generate amd64 image for ubuntu18.04
 build-ubuntu18.04: DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
 


### PR DESCRIPTION
Centos7 is almost EOL and from the point of view of the container-toolkit, we already include the centos7 packages in the ubi8 image.

This change removes the centos7 images from the release process.

Note that we still use centos7 to build our RPM packages to ensure a wider compatibility.