### PR TITLE
Add GOLANGCI_LINT_CACHE to docker make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ $(DOCKER_TARGETS): docker-%:
 		--rm \
 		-e GOCACHE=/tmp/.cache/go \
 		-e GOMODCACHE=/tmp/.cache/gomod \
+		-e GOLANGCI_LINT_CACHE=/tmp/.cache/golangci-lint \
 		-v $(PWD):/work \
 		-w /work \
 		--user $$(id -u):$$(id -g) \
@@ -124,6 +125,7 @@ PHONY: .shell
 		-ti \
 		-e GOCACHE=/tmp/.cache/go \
 		-e GOMODCACHE=/tmp/.cache/gomod \
+		-e GOLANGCI_LINT_CACHE=/tmp/.cache/golangci-lint \
 		-v $(PWD):/work \
 		-w /work \
 		--user $$(id -u):$$(id -g) \


### PR DESCRIPTION
Before the change:
```
docker run \
        --rm \
        -ti \
        -e GOCACHE=/tmp/.cache/go \
        -e GOMODCACHE=/tmp/.cache/gomod \
        -v /Users/elezar/src/container-toolkit:/work \
        -w /work \
        --user $(id -u):$(id -g) \
        ghcr.io/nvidia/k8s-test-infra:devel-go1.20.5
I have no name!@bf871339fa93:/work$ make check
golangci-lint run ./...
2024/03/15 06:48:53 failed to initialize build cache at /.cache/golangci-lint: mkdir /.cache: permission denied
make: *** [Makefile:91: golangci-lint] Error 1
I have no name!@bf871339fa93:/work$```
```
After the change:
```
➜  container-toolkit git:(fix-golangci-lint-in-shell) ✗ make .shell
docker run \
        --rm \
        -ti \
        -e GOCACHE=/tmp/.cache/go \
        -e GOMODCACHE=/tmp/.cache/gomod \
        -e GOLANGCI_LINT_CACHE=/tmp/.cache/golangci-lint \
        -v /Users/elezar/src/container-toolkit:/work \
        -w /work \
        --user $(id -u):$(id -g) \
        ghcr.io/nvidia/k8s-test-infra:devel-go1.20.5
I have no name!@b30a2c81c75a:/work$ make check
golangci-lint run ./...
I have no name!@b30a2c81c75a:/work$
```