### PR TITLE
Add NVIDIA_VISIBLE_DEVICES=void to CDI specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   CDI spec to be generated that includes GPUs by index and UUID.
 * Set the default `--device-name-strategy` for the `nvidia-ctk cdi generate` command to `[index, uuid]`.
 * Remove `libnvidia-container0` jetpack dependency included for legacy Tegra-based systems.
+* Add `NVIDIA_VISIBLE_DEVICES=void` to generated CDI specifications.
 
 * [toolkit-container] Remove centos7 image. The ubi8 image can be used on all RPM-based platforms.
 

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -22,6 +22,7 @@ import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvlib/pkg/nvml"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/root"
@@ -160,6 +161,17 @@ func (l *wrapper) GetSpec() (spec.Interface, error) {
 		spec.WithClass(l.class),
 		spec.WithMergedDeviceOptions(l.mergedDeviceOptions...),
 	)
+}
+
+// GetCommonEdits returns the wrapped edits and adds additional edits on top.
+func (m *wrapper) GetCommonEdits() (*cdi.ContainerEdits, error) {
+	edits, err := m.Interface.GetCommonEdits()
+	if err != nil {
+		return nil, err
+	}
+	edits.Env = append(edits.Env, "NVIDIA_VISIBLE_DEVICES=void")
+
+	return edits, nil
 }
 
 // resolveMode resolves the mode for CDI spec generation based on the current system.


### PR DESCRIPTION
This change ensures taht NVIDIA_VISIBLE_DEVICES=void is included in generated CDI specs. This prevents the NVIDIA Container Runtime Hook from injecting devices if NVIDIA_VISIBLE_DEVICES=all is set.