### PR TITLE
Modify params for docker build

### DIFF
--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -79,7 +79,8 @@ docker-all: $(AMD64_TARGETS) $(X86_64_TARGETS) \
 --%: TARGET_PLATFORM = $(*)
 --%: VERSION = $(patsubst $(OS)%-$(ARCH),%,$(TARGET_PLATFORM))
 --%: BASEIMAGE = $(OS):$(VERSION)
---%: BUILDIMAGE = nvidia/$(LIB_NAME)/$(OS)$(VERSION)-$(ARCH)
+--%: BUILDIMAGE = nvidia$(LIB_NAME)/$(OS)$(VERSION)-$(ARCH)
+--%: DOCKER = docker
 --%: DOCKERFILE = $(CURDIR)/docker/Dockerfile.$(OS)
 --%: ARTIFACTS_DIR = $(DIST_DIR)/$(OS)$(VERSION)/$(ARCH)
 --%: docker-build-%


### PR DESCRIPTION
#### Resolves 2 errors with docker.mk:

1. `/bin/bash: line 1: build: command not found` caused by unset $(DOCKER)
2. `ERROR: invalid tag "nvidia//centos7-x86_64"` caused by earlier $(BUILDIMAGE) 

Signed-off-by: Varun Venkatesh <varunv@nvidia.com>

