### PR TITLE
Prepare changes for v1.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.15.1
 
+* Use : as a config --set list separator. This fixes a bug in modifying lists in the config file with the `nvidia-ctk config` command.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `RUNTIME_CONFIG_OVERRIDE` (`--runtime-config-override`) to the `nvidia-ctk runtime configure` command and the toolkit container to allow for containerd runtime options to be set directly. This can be used to override the `SystemdCroup` option explicitly, for example.
 * Ensure consistent construction of libraries for CDI spec generation.
 * Ensure that `nvidia-ctk cdi transform` creates specs with world-readable permissions.
+* Remove provenance information from published images.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NVIDIA Container Toolkit Changelog
 
+## v1.15.1
+
+
 ## v1.15.0
 
 * Remove `nvidia-container-runtime` and `nvidia-docker2` packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Use : as a config --set list separator. This fixes a bug in modifying lists in the config file with the `nvidia-ctk config` command.
 * Add `RUNTIME_CONFIG_OVERRIDE` (`--runtime-config-override`) to the `nvidia-ctk runtime configure` command and the toolkit container to allow for containerd runtime options to be set directly. This can be used to override the `SystemdCroup` option explicitly, for example.
 * Ensure consistent construction of libraries for CDI spec generation.
+* Ensure that `nvidia-ctk cdi transform` creates specs with world-readable permissions.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Ensure consistent construction of libraries for CDI spec generation.
 * Ensure that `nvidia-ctk cdi transform` creates specs with world-readable permissions.
 * Remove provenance information from published images.
+* Fix bug in processing of `--log=` argument of `nvidia-container-runtime`.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Remove provenance information from published images.
 * Fix bug in processing of `--log=` argument of `nvidia-container-runtime`.
 * Reduce verbosity of logging in the NVIDIA Container Runtime especially for non-`create` commands.
+* Extract runtime options from default runtime if runc is not present in config.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use : as a config --set list separator. This fixes a bug in modifying lists in the config file with the `nvidia-ctk config` command.
 * Add `RUNTIME_CONFIG_OVERRIDE` (`--runtime-config-override`) to the `nvidia-ctk runtime configure` command and the toolkit container to allow for containerd runtime options to be set directly. This can be used to override the `SystemdCroup` option explicitly, for example.
+* Ensure consistent construction of libraries for CDI spec generation.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.15.1
 
 * Use : as a config --set list separator. This fixes a bug in modifying lists in the config file with the `nvidia-ctk config` command.
+* Add `RUNTIME_CONFIG_OVERRIDE` (`--runtime-config-override`) to the `nvidia-ctk runtime configure` command and the toolkit container to allow for containerd runtime options to be set directly. This can be used to override the `SystemdCroup` option explicitly, for example.
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Ensure that `nvidia-ctk cdi transform` creates specs with world-readable permissions.
 * Remove provenance information from published images.
 * Fix bug in processing of `--log=` argument of `nvidia-container-runtime`.
+* Reduce verbosity of logging in the NVIDIA Container Runtime especially for non-`create` commands.
 
 ## v1.15.0
 

--- a/cmd/nvidia-ctk/config/config_test.go
+++ b/cmd/nvidia-ctk/config/config_test.go
@@ -25,11 +25,12 @@ import (
 func TestSetFlagToKeyValue(t *testing.T) {
 	// TODO: We need to enable this test again since switching to reflect.
 	testCases := []struct {
-		description   string
-		setFlag       string
-		expectedKey   string
-		expectedValue interface{}
-		expectedError error
+		description      string
+		setFlag          string
+		setListSeparator string
+		expectedKey      string
+		expectedValue    interface{}
+		expectedError    error
 	}{
 		{
 			description:   "option not present returns an error",
@@ -106,22 +107,34 @@ func TestSetFlagToKeyValue(t *testing.T) {
 			expectedValue: []string{"string-value"},
 		},
 		{
-			description:   "[]string option returns multiple values",
-			setFlag:       "nvidia-container-cli.environment=first,second",
-			expectedKey:   "nvidia-container-cli.environment",
-			expectedValue: []string{"first", "second"},
+			description:      "[]string option returns multiple values",
+			setFlag:          "nvidia-container-cli.environment=first,second",
+			setListSeparator: ",",
+			expectedKey:      "nvidia-container-cli.environment",
+			expectedValue:    []string{"first", "second"},
 		},
 		{
-			description:   "[]string option returns values with equals",
-			setFlag:       "nvidia-container-cli.environment=first=1,second=2",
-			expectedKey:   "nvidia-container-cli.environment",
-			expectedValue: []string{"first=1", "second=2"},
+			description:      "[]string option returns values with equals",
+			setFlag:          "nvidia-container-cli.environment=first=1,second=2",
+			setListSeparator: ",",
+			expectedKey:      "nvidia-container-cli.environment",
+			expectedValue:    []string{"first=1", "second=2"},
+		},
+		{
+			description:      "[]string option returns multiple values semi-colon",
+			setFlag:          "nvidia-container-cli.environment=first;second",
+			setListSeparator: ";",
+			expectedKey:      "nvidia-container-cli.environment",
+			expectedValue:    []string{"first", "second"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			k, v, err := setFlagToKeyValue(tc.setFlag)
+			if tc.setListSeparator == "" {
+				tc.setListSeparator = ","
+			}
+			k, v, err := setFlagToKeyValue(tc.setFlag, tc.setListSeparator)
 			require.ErrorIs(t, err, tc.expectedError)
 			require.EqualValues(t, tc.expectedKey, k)
 			require.EqualValues(t, tc.expectedValue, v)

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -92,6 +92,7 @@ ARTIFACTS_ROOT ?= $(shell realpath --relative-to=$(CURDIR) $(DIST_DIR))
 $(BUILD_TARGETS): build-%: $(ARTIFACTS_ROOT)
 	DOCKER_BUILDKIT=1 \
 		$(DOCKER) $(BUILDX) build --pull \
+		--provenance=false --sbom=false \
 		$(DOCKER_BUILD_OPTIONS) \
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \

--- a/internal/info/auto.go
+++ b/internal/info/auto.go
@@ -17,66 +17,40 @@
 package info
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config/image"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 )
 
-type resolver struct {
-	logger logger.Interface
-	info   info.PropertyExtractor
-}
-
 // ResolveAutoMode determines the correct mode for the platform if set to "auto"
 func ResolveAutoMode(logger logger.Interface, mode string, image image.CUDA) (rmode string) {
-	nvinfo := info.New()
-	nvmllib := nvml.New()
-	devicelib := device.New(
-		device.WithNvml(nvmllib),
-	)
-
-	info := additionalInfo{
-		Interface: nvinfo,
-		nvmllib:   nvmllib,
-		devicelib: devicelib,
-	}
-
-	r := resolver{
-		logger: logger,
-		info:   info,
-	}
-	return r.resolveMode(mode, image)
+	return resolveMode(logger, mode, image, nil)
 }
 
-// resolveMode determines the correct mode for the platform if set to "auto"
-func (r resolver) resolveMode(mode string, image image.CUDA) (rmode string) {
+func resolveMode(logger logger.Interface, mode string, image image.CUDA, propertyExtractor info.PropertyExtractor) (rmode string) {
 	if mode != "auto" {
-		r.logger.Infof("Using requested mode '%s'", mode)
+		logger.Infof("Using requested mode '%s'", mode)
 		return mode
 	}
 	defer func() {
-		r.logger.Infof("Auto-detected mode as '%v'", rmode)
+		logger.Infof("Auto-detected mode as '%v'", rmode)
 	}()
 
 	if image.OnlyFullyQualifiedCDIDevices() {
 		return "cdi"
 	}
 
-	isTegra, reason := r.info.HasTegraFiles()
-	r.logger.Debugf("Is Tegra-based system? %v: %v", isTegra, reason)
+	nvinfo := info.New(
+		info.WithLogger(logger),
+		info.WithPropertyExtractor(propertyExtractor),
+	)
 
-	hasNVML, reason := r.info.HasNvml()
-	r.logger.Debugf("Has NVML? %v: %v", hasNVML, reason)
-
-	usesNVGPUModule, reason := r.info.UsesOnlyNVGPUModule()
-	r.logger.Debugf("Uses nvgpu kernel module? %v: %v", usesNVGPUModule, reason)
-
-	if (isTegra && !hasNVML) || usesNVGPUModule {
+	switch nvinfo.ResolvePlatform() {
+	case info.PlatformNVML, info.PlatformWSL:
+		return "legacy"
+	case info.PlatformTegra:
 		return "csv"
 	}
-
 	return "legacy"
 }

--- a/internal/info/auto_test.go
+++ b/internal/info/auto_test.go
@@ -203,9 +203,15 @@ func TestResolveAutoMode(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			info := &info.PropertyExtractorMock{
+			properties := &info.PropertyExtractorMock{
 				HasNvmlFunc: func() (bool, string) {
 					return tc.info["nvml"], "nvml"
+				},
+				HasDXCoreFunc: func() (bool, string) {
+					return tc.info["dxcore"], "dxcore"
+				},
+				IsTegraSystemFunc: func() (bool, string) {
+					return tc.info["tegra"], "tegra"
 				},
 				HasTegraFilesFunc: func() (bool, string) {
 					return tc.info["tegra"], "tegra"
@@ -213,11 +219,6 @@ func TestResolveAutoMode(t *testing.T) {
 				UsesOnlyNVGPUModuleFunc: func() (bool, string) {
 					return tc.info["nvgpu"], "nvgpu"
 				},
-			}
-
-			r := resolver{
-				logger: logger,
-				info:   info,
 			}
 
 			var mounts []specs.Mount
@@ -232,7 +233,7 @@ func TestResolveAutoMode(t *testing.T) {
 				image.WithEnvMap(tc.envmap),
 				image.WithMounts(mounts),
 			)
-			mode := r.resolveMode(tc.mode, image)
+			mode := resolveMode(logger, tc.mode, image, properties)
 			require.EqualValues(t, tc.expectedMode, mode)
 		})
 	}

--- a/internal/logger/api.go
+++ b/internal/logger/api.go
@@ -24,4 +24,5 @@ type Interface interface {
 	Infof(string, ...interface{})
 	Warning(...interface{})
 	Warningf(string, ...interface{})
+	Tracef(string, ...interface{})
 }

--- a/internal/logger/lib.go
+++ b/internal/logger/lib.go
@@ -45,3 +45,6 @@ func (l *NullLogger) Warning(...interface{}) {}
 
 // Warningf is a no-op for the null logger
 func (l *NullLogger) Warningf(string, ...interface{}) {}
+
+// Tracef is a no-op for the null logger
+func (l *NullLogger) Tracef(string, ...interface{}) {}

--- a/internal/oci/runtime.go
+++ b/internal/oci/runtime.go
@@ -16,10 +16,11 @@
 
 package oci
 
-//go:generate moq -stub -out runtime_mock.go . Runtime
-
 // Runtime is an interface for a runtime shim. The Exec method accepts a list
 // of command line arguments, and returns an error / nil.
+//
+//go:generate moq -rm -stub -out runtime_mock.go . Runtime
 type Runtime interface {
 	Exec([]string) error
+	String() string
 }

--- a/internal/oci/runtime_low_level.go
+++ b/internal/oci/runtime_low_level.go
@@ -31,8 +31,6 @@ func NewLowLevelRuntime(logger logger.Interface, candidates []string) (Runtime, 
 	if err != nil {
 		return nil, fmt.Errorf("error locating runtime: %v", err)
 	}
-
-	logger.Infof("Using low-level runtime %v", runtimePath)
 	return NewRuntimeForPath(logger, runtimePath)
 }
 
@@ -45,13 +43,12 @@ func findRuntime(logger logger.Interface, candidates []string) (string, error) {
 
 	locator := lookup.NewExecutableLocator(logger, "/")
 	for _, candidate := range candidates {
-		logger.Debugf("Looking for runtime binary '%v'", candidate)
+		logger.Tracef("Looking for runtime binary '%v'", candidate)
 		targets, err := locator.Locate(candidate)
 		if err == nil && len(targets) > 0 {
-			logger.Debugf("Found runtime binary '%v'", targets)
+			logger.Tracef("Found runtime binary '%v'", targets)
 			return targets[0], nil
 		}
-		logger.Debugf("Runtime binary '%v' not found: %v (targets=%v)", candidate, err, targets)
 	}
 
 	return "", fmt.Errorf("no runtime binary found from candidate list: %v", candidates)

--- a/internal/oci/runtime_mock.go
+++ b/internal/oci/runtime_mock.go
@@ -20,6 +20,9 @@ var _ Runtime = &RuntimeMock{}
 //			ExecFunc: func(strings []string) error {
 //				panic("mock out the Exec method")
 //			},
+//			StringFunc: func() string {
+//				panic("mock out the String method")
+//			},
 //		}
 //
 //		// use mockedRuntime in code that requires Runtime
@@ -30,6 +33,9 @@ type RuntimeMock struct {
 	// ExecFunc mocks the Exec method.
 	ExecFunc func(strings []string) error
 
+	// StringFunc mocks the String method.
+	StringFunc func() string
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// Exec holds details about calls to the Exec method.
@@ -37,8 +43,12 @@ type RuntimeMock struct {
 			// Strings is the strings argument value.
 			Strings []string
 		}
+		// String holds details about calls to the String method.
+		String []struct {
+		}
 	}
-	lockExec sync.RWMutex
+	lockExec   sync.RWMutex
+	lockString sync.RWMutex
 }
 
 // Exec calls ExecFunc.
@@ -73,5 +83,35 @@ func (mock *RuntimeMock) ExecCalls() []struct {
 	mock.lockExec.RLock()
 	calls = mock.calls.Exec
 	mock.lockExec.RUnlock()
+	return calls
+}
+
+// String calls StringFunc.
+func (mock *RuntimeMock) String() string {
+	callInfo := struct {
+	}{}
+	mock.lockString.Lock()
+	mock.calls.String = append(mock.calls.String, callInfo)
+	mock.lockString.Unlock()
+	if mock.StringFunc == nil {
+		var (
+			sOut string
+		)
+		return sOut
+	}
+	return mock.StringFunc()
+}
+
+// StringCalls gets all the calls that were made to String.
+// Check the length with:
+//
+//	len(mockedRuntime.StringCalls())
+func (mock *RuntimeMock) StringCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockString.RLock()
+	calls = mock.calls.String
+	mock.lockString.RUnlock()
 	return calls
 }

--- a/internal/oci/runtime_path.go
+++ b/internal/oci/runtime_path.go
@@ -63,3 +63,8 @@ func (s pathRuntime) Exec(args []string) error {
 
 	return s.execRuntime.Exec(runtimeArgs)
 }
+
+// String returns the path to the specified runtime as the string representation.
+func (s pathRuntime) String() string {
+	return s.path
+}

--- a/internal/oci/runtime_syscall_exec.go
+++ b/internal/oci/runtime_syscall_exec.go
@@ -37,3 +37,7 @@ func (r syscallExec) Exec(args []string) error {
 	// err is nil or not.
 	return fmt.Errorf("unexpected return from exec '%v'", args[0])
 }
+
+func (r syscallExec) String() string {
+	return "exec"
+}

--- a/internal/runtime/logger.go
+++ b/internal/runtime/logger.go
@@ -238,7 +238,7 @@ func parseArgs(args []string) loggerConfig {
 		var value string
 		switch {
 		case len(parts) == 2:
-			value = parts[2]
+			value = parts[1]
 		case i+1 < len(args):
 			value = args[i+1]
 			i++

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -17,7 +17,6 @@
 package runtime
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/info"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/root"
 )
 
@@ -66,23 +66,18 @@ func (r rt) Run(argv []string) (rerr error) {
 	if r.modeOverride != "" {
 		cfg.NVIDIAContainerRuntimeConfig.Mode = r.modeOverride
 	}
-	cfg.NVIDIACTKConfig.Path = config.ResolveNVIDIACTKPath(r.logger, cfg.NVIDIACTKConfig.Path)
-	cfg.NVIDIAContainerRuntimeHookConfig.Path = config.ResolveNVIDIAContainerRuntimeHookPath(r.logger, cfg.NVIDIAContainerRuntimeHookConfig.Path)
+	cfg.NVIDIACTKConfig.Path = config.ResolveNVIDIACTKPath(&logger.NullLogger{}, cfg.NVIDIACTKConfig.Path)
+	cfg.NVIDIAContainerRuntimeHookConfig.Path = config.ResolveNVIDIAContainerRuntimeHookPath(&logger.NullLogger{}, cfg.NVIDIAContainerRuntimeHookConfig.Path)
 
-	// Print the config to the output.
-	configJSON, err := json.MarshalIndent(cfg, "", "  ")
-	if err == nil {
-		r.logger.Infof("Running with config:\n%v", string(configJSON))
-	} else {
-		r.logger.Infof("Running with config:\n%+v", cfg)
-	}
+	// Log the config at Trace to allow for debugging if required.
+	r.logger.Tracef("Running with config: %+v", cfg)
 
 	driver := root.New(
 		root.WithLogger(r.logger),
 		root.WithDriverRoot(cfg.NVIDIAContainerCLIConfig.Root),
 	)
 
-	r.logger.Debugf("Command line arguments: %v", argv)
+	r.logger.Tracef("Command line arguments: %v", argv)
 	runtime, err := newNVIDIAContainerRuntime(r.logger, cfg, argv, driver)
 	if err != nil {
 		return fmt.Errorf("failed to create NVIDIA Container Runtime: %v", err)

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -35,8 +35,9 @@ func newNVIDIAContainerRuntime(logger logger.Interface, cfg *config.Config, argv
 		return nil, fmt.Errorf("error constructing low-level runtime: %v", err)
 	}
 
+	logger.Tracef("Using low-level runtime %v", lowLevelRuntime.String())
 	if !oci.HasCreateSubcommand(argv) {
-		logger.Debugf("Skipping modifier for non-create subcommand")
+		logger.Tracef("Skipping modifier for non-create subcommand")
 		return lowLevelRuntime, nil
 	}
 
@@ -50,7 +51,7 @@ func newNVIDIAContainerRuntime(logger logger.Interface, cfg *config.Config, argv
 		return nil, fmt.Errorf("failed to construct OCI spec modifier: %v", err)
 	}
 
-	// Create the wrapping runtime with the specified modifier
+	// Create the wrapping runtime with the specified modifier.
 	r := oci.NewModifyingRuntimeWrapper(
 		logger,
 		lowLevelRuntime,

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -19,7 +19,7 @@ package engine
 // Interface defines the API for a runtime config updater.
 type Interface interface {
 	DefaultRuntime() string
-	AddRuntime(string, string, bool) error
+	AddRuntime(string, string, bool, ...map[string]interface{}) error
 	Set(string, interface{})
 	RemoveRuntime(string) error
 	Save(string) (int64, error)

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -30,7 +30,7 @@ type ConfigV1 Config
 var _ engine.Interface = (*ConfigV1)(nil)
 
 // AddRuntime adds a runtime to the containerd config
-func (c *ConfigV1) AddRuntime(name string, path string, setAsDefault bool) error {
+func (c *ConfigV1) AddRuntime(name string, path string, setAsDefault bool, configOverrides ...map[string]interface{}) error {
 	if c == nil || c.Tree == nil {
 		return fmt.Errorf("config is nil")
 	}
@@ -75,6 +75,16 @@ func (c *ConfigV1) AddRuntime(name string, path string, setAsDefault bool) error
 		}
 		config.SetPath([]string{"plugins", "cri", "containerd", "default_runtime", "options", "BinaryName"}, path)
 		config.SetPath([]string{"plugins", "cri", "containerd", "default_runtime", "options", "Runtime"}, path)
+
+		defaultRuntimeSubtree := subtreeAtPath(config, "plugins", "cri", "containerd", "default_runtime")
+		if err := defaultRuntimeSubtree.applyOverrides(configOverrides...); err != nil {
+			return fmt.Errorf("failed to apply config overrides to default_runtime: %w", err)
+		}
+	}
+
+	runtimeSubtree := subtreeAtPath(config, "plugins", "cri", "containerd", "runtimes", name)
+	if err := runtimeSubtree.applyOverrides(configOverrides...); err != nil {
+		return fmt.Errorf("failed to apply config overrides: %w", err)
 	}
 
 	*c.Tree = config

--- a/pkg/config/engine/containerd/config_v1_test.go
+++ b/pkg/config/engine/containerd/config_v1_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddRuntime(t *testing.T) {
+func TestAddRuntimeV1(t *testing.T) {
 	logger, _ := testlog.NewNullLogger()
 	testCases := []struct {
 		description     string
@@ -37,18 +37,19 @@ func TestAddRuntime(t *testing.T) {
 		{
 			description: "empty config not default runtime",
 			expectedConfig: `
-			version = 2
+			version = 1
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+			[plugins.cri]
+				[plugins.cri.containerd]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.test]
 					privileged_without_host_devices = false
 					runtime_engine = ""
 					runtime_root = ""
 					runtime_type = ""
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+					[plugins.cri.containerd.runtimes.test.options]
 						BinaryName = "/usr/bin/test"
+						Runtime = "/usr/bin/test"
 			`,
 			expectedError: nil,
 		},
@@ -62,161 +63,162 @@ func TestAddRuntime(t *testing.T) {
 				},
 			},
 			expectedConfig: `
-			version = 2
+			version = 1
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+			[plugins.cri]
+				[plugins.cri.containerd]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.test]
 					privileged_without_host_devices = false
 					runtime_engine = ""
 					runtime_root = ""
 					runtime_type = ""
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+					[plugins.cri.containerd.runtimes.test.options]
 						BinaryName = "/usr/bin/test"
+						Runtime = "/usr/bin/test"
 						SystemdCgroup = true
 			`,
 		},
 		{
 			description: "options from runc are imported",
 			config: `
-			version = 2
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+			[plugins.cri]
+				[plugins.cri.containerd]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.runc]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+					[plugins.cri.containerd.runtimes.runc.options]
 						BinaryName = "/usr/bin/runc"
 						SystemdCgroup = true
 			`,
 			expectedConfig: `
-			version = 2
+			version = 1
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+			[plugins.cri]
+				[plugins.cri.containerd]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.runc]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+					[plugins.cri.containerd.runtimes.runc.options]
 						BinaryName = "/usr/bin/runc"
 						SystemdCgroup = true
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					[plugins.cri.containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+					[plugins.cri.containerd.runtimes.test.options]
 						BinaryName = "/usr/bin/test"
+						Runtime = "/usr/bin/test"
 						SystemdCgroup = true
 				`,
 		},
 		{
 			description: "options from default runtime are imported",
 			config: `
-			version = 2
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
+			[plugins.cri]
+				[plugins.cri.containerd]
 				default_runtime_name = "default"
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.default]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
+					[plugins.cri.containerd.runtimes.default.options]
 						BinaryName = "/usr/bin/default"
 						SystemdCgroup = true
 			`,
 			expectedConfig: `
-			version = 2
+			version = 1
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
+			[plugins.cri]
+				[plugins.cri.containerd]
 				default_runtime_name = "default"
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.default]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
+					[plugins.cri.containerd.runtimes.default.options]
 						BinaryName = "/usr/bin/default"
 						SystemdCgroup = true
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					[plugins.cri.containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+					[plugins.cri.containerd.runtimes.test.options]
 						BinaryName = "/usr/bin/test"
+						Runtime = "/usr/bin/test"
 						SystemdCgroup = true
 				`,
 		},
 		{
 			description: "options from runc take precedence over default runtime",
 			config: `
-			version = 2
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
+			[plugins.cri]
+				[plugins.cri.containerd]
 				default_runtime_name = "default"
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.runc]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+					[plugins.cri.containerd.runtimes.runc.options]
 						BinaryName = "/usr/bin/runc"
 						SystemdCgroup = true
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
+					[plugins.cri.containerd.runtimes.default]
 					privileged_without_host_devices = false
 					runtime_engine = "defaultengine"
 					runtime_root = "defaultroot"
 					runtime_type = "defaulttype"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
+					[plugins.cri.containerd.runtimes.default.options]
 						BinaryName = "/usr/bin/default"
 						SystemdCgroup = false
 			`,
 			expectedConfig: `
-			version = 2
+			version = 1
 			[plugins]
-			[plugins."io.containerd.grpc.v1.cri"]
-				[plugins."io.containerd.grpc.v1.cri".containerd]
+			[plugins.cri]
+				[plugins.cri.containerd]
 				default_runtime_name = "default"
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+				[plugins.cri.containerd.runtimes]
+					[plugins.cri.containerd.runtimes.runc]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+					[plugins.cri.containerd.runtimes.runc.options]
 						BinaryName = "/usr/bin/runc"
 						SystemdCgroup = true
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
+					[plugins.cri.containerd.runtimes.default]
 					privileged_without_host_devices = false
 					runtime_engine = "defaultengine"
 					runtime_root = "defaultroot"
 					runtime_type = "defaulttype"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
+					[plugins.cri.containerd.runtimes.default.options]
 						BinaryName = "/usr/bin/default"
 						SystemdCgroup = false
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					[plugins.cri.containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
 					runtime_root = "root"
 					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+					[plugins.cri.containerd.runtimes.test.options]
 						BinaryName = "/usr/bin/test"
+						Runtime = "/usr/bin/test"
 						SystemdCgroup = true
 				`,
 		},
@@ -229,7 +231,7 @@ func TestAddRuntime(t *testing.T) {
 			expectedConfig, err := toml.Load(tc.expectedConfig)
 			require.NoError(t, err)
 
-			c := &Config{
+			c := &ConfigV1{
 				Logger: logger,
 				Tree:   config,
 			}

--- a/pkg/config/engine/containerd/config_v2.go
+++ b/pkg/config/engine/containerd/config_v2.go
@@ -33,12 +33,22 @@ func (c *Config) AddRuntime(name string, path string, setAsDefault bool, configO
 
 	config.Set("version", int64(2))
 
-	if runc, ok := config.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc"}).(*toml.Tree); ok {
-		runc, _ = toml.Load(runc.String())
-		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name}, runc)
+	// By default we extract the runtime options from the runc settings; if this does not exist we get the options from the default runtime specified in the config.
+	runtimeNamesForConfig := []string{"runc"}
+	if name, ok := config.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "default_runtime_name"}).(string); ok && name != "" {
+		runtimeNamesForConfig = append(runtimeNamesForConfig, name)
+	}
+	for _, r := range runtimeNamesForConfig {
+		if options, ok := config.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", r}).(*toml.Tree); ok {
+			c.Logger.Debugf("using options from runtime %v: %v", r, options.String())
+			options, _ = toml.Load(options.String())
+			config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name}, options)
+			break
+		}
 	}
 
 	if config.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name}) == nil {
+		c.Logger.Warningf("could not infer options from runtimes %v; using defaults", runtimeNamesForConfig)
 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name, "runtime_type"}, c.RuntimeType)
 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name, "runtime_root"}, "")
 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name, "runtime_engine"}, "")

--- a/pkg/config/engine/containerd/config_v2.go
+++ b/pkg/config/engine/containerd/config_v2.go
@@ -25,7 +25,7 @@ import (
 )
 
 // AddRuntime adds a runtime to the containerd config
-func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
+func (c *Config) AddRuntime(name string, path string, setAsDefault bool, configOverrides ...map[string]interface{}) error {
 	if c == nil || c.Tree == nil {
 		return fmt.Errorf("config is nil")
 	}
@@ -58,6 +58,11 @@ func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
 
 	if setAsDefault {
 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "default_runtime_name"}, name)
+	}
+
+	runtimeSubtree := subtreeAtPath(config, "plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name)
+	if err := runtimeSubtree.applyOverrides(configOverrides...); err != nil {
+		return fmt.Errorf("failed to apply config overrides: %w", err)
 	}
 
 	*c.Tree = config

--- a/pkg/config/engine/containerd/config_v2_test.go
+++ b/pkg/config/engine/containerd/config_v2_test.go
@@ -1,0 +1,97 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package containerd
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddRuntime(t *testing.T) {
+	testCases := []struct {
+		description     string
+		config          string
+		setAsDefault    bool
+		configOverrides []map[string]interface{}
+		expectedConfig  string
+		expectedError   error
+	}{
+		{
+			description: "empty config not default runtime",
+			expectedConfig: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = ""
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+			`,
+			expectedError: nil,
+		},
+		{
+			description: "empty config not default runtime with overrides",
+			configOverrides: []map[string]interface{}{
+				{
+					"options": map[string]interface{}{
+						"SystemdCgroup": true,
+					},
+				},
+			},
+			expectedConfig: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = ""
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+						SystemdCgroup = true
+			`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			config, err := toml.Load(tc.config)
+			require.NoError(t, err)
+			expectedConfig, err := toml.Load(tc.expectedConfig)
+			require.NoError(t, err)
+
+			c := &Config{
+				Tree: config,
+			}
+
+			err = c.AddRuntime("test", "/usr/bin/test", tc.setAsDefault, tc.configOverrides...)
+			require.NoError(t, err)
+
+			require.EqualValues(t, expectedConfig.String(), config.String())
+		})
+	}
+}

--- a/pkg/config/engine/containerd/containerd.go
+++ b/pkg/config/engine/containerd/containerd.go
@@ -26,6 +26,7 @@ import (
 // Config represents the containerd config
 type Config struct {
 	*toml.Tree
+	Logger                logger.Interface
 	RuntimeType           string
 	UseDefaultRuntimeName bool
 	ContainerAnnotations  []string

--- a/pkg/config/engine/containerd/option.go
+++ b/pkg/config/engine/containerd/option.go
@@ -89,6 +89,7 @@ func (b *builder) build() (engine.Interface, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %v", err)
 	}
+	config.Logger = b.logger
 	config.RuntimeType = b.runtimeType
 	config.UseDefaultRuntimeName = !b.useLegacyConfig
 	config.ContainerAnnotations = b.containerAnnotations

--- a/pkg/config/engine/containerd/toml.go
+++ b/pkg/config/engine/containerd/toml.go
@@ -1,0 +1,56 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package containerd
+
+import (
+	"fmt"
+
+	"github.com/pelletier/go-toml"
+)
+
+// tomlTree is an alias for toml.Tree that allows for extensions.
+type tomlTree toml.Tree
+
+func subtreeAtPath(c toml.Tree, path ...string) *tomlTree {
+	tree := c.GetPath(path).(*toml.Tree)
+	return (*tomlTree)(tree)
+}
+
+func (t *tomlTree) insert(other map[string]interface{}) error {
+
+	for key, value := range other {
+		if insertsubtree, ok := value.(map[string]interface{}); ok {
+			subtree := (*toml.Tree)(t).Get(key).(*toml.Tree)
+			return (*tomlTree)(subtree).insert(insertsubtree)
+		}
+		(*toml.Tree)(t).Set(key, value)
+	}
+	return nil
+}
+
+func (t *tomlTree) applyOverrides(overrides ...map[string]interface{}) error {
+	for _, override := range overrides {
+		subconfig, err := toml.TreeFromMap(override)
+		if err != nil {
+			return fmt.Errorf("invalid toml config: %w", err)
+		}
+		if err := t.insert(subconfig.ToMap()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -40,7 +40,7 @@ func New(opts ...Option) (engine.Interface, error) {
 }
 
 // AddRuntime adds a new runtime to the crio config
-func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
+func (c *Config) AddRuntime(name string, path string, setAsDefault bool, _ ...map[string]interface{}) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}

--- a/pkg/config/engine/crio/crio_test.go
+++ b/pkg/config/engine/crio/crio_test.go
@@ -1,0 +1,146 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package crio
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml"
+	testlog "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddRuntime(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+	testCases := []struct {
+		description     string
+		config          string
+		setAsDefault    bool
+		configOverrides []map[string]interface{}
+		expectedConfig  string
+		expectedError   error
+	}{
+		{
+			description: "empty config not default runtime",
+			expectedConfig: `
+			[crio]
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			`,
+			expectedError: nil,
+		},
+		{
+			description: "options from runc are imported",
+			config: `
+			[crio]
+			[crio.runtime.runtimes.runc]
+			runtime_path = "/usr/bin/runc"
+			runtime_type = "runcoci"
+			runc_option = "option"
+			`,
+			expectedConfig: `
+			[crio]
+			[crio.runtime.runtimes.runc]
+			runtime_path = "/usr/bin/runc"
+			runtime_type = "runcoci"
+			runc_option = "option"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			runc_option = "option"
+			`,
+		},
+		{
+			description: "options from default runtime are imported",
+			config: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "default"
+			[crio.runtime.runtimes.default]
+			runtime_path = "/usr/bin/default"
+			runtime_type = "defaultoci"
+			default_option = "option"
+			`,
+			expectedConfig: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "default"
+			[crio.runtime.runtimes.default]
+			runtime_path = "/usr/bin/default"
+			runtime_type = "defaultoci"
+			default_option = "option"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			default_option = "option"
+			`,
+		},
+		{
+			description: "options from runc take precedence over default runtime",
+			config: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "default"
+			[crio.runtime.runtimes.default]
+			runtime_path = "/usr/bin/default"
+			runtime_type = "defaultoci"
+			default_option = "option"
+			[crio.runtime.runtimes.runc]
+			runtime_path = "/usr/bin/runc"
+			runtime_type = "runcoci"
+			runc_option = "option"
+			`,
+			expectedConfig: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "default"
+			[crio.runtime.runtimes.default]
+			runtime_path = "/usr/bin/default"
+			runtime_type = "defaultoci"
+			default_option = "option"
+			[crio.runtime.runtimes.runc]
+			runtime_path = "/usr/bin/runc"
+			runtime_type = "runcoci"
+			runc_option = "option"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			runc_option = "option"
+			`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			config, err := toml.Load(tc.config)
+			require.NoError(t, err)
+			expectedConfig, err := toml.Load(tc.expectedConfig)
+			require.NoError(t, err)
+
+			c := &Config{
+				Logger: logger,
+				Tree:   config,
+			}
+
+			err = c.AddRuntime("test", "/usr/bin/test", tc.setAsDefault, tc.configOverrides...)
+			require.NoError(t, err)
+
+			require.EqualValues(t, expectedConfig.String(), config.String())
+		})
+	}
+}

--- a/pkg/config/engine/crio/option.go
+++ b/pkg/config/engine/crio/option.go
@@ -48,12 +48,16 @@ func WithPath(path string) Option {
 }
 
 func (b *builder) build() (*Config, error) {
-	if b.path == "" {
-		empty := toml.Tree{}
-		return (*Config)(&empty), nil
-	}
 	if b.logger == nil {
 		b.logger = logger.New()
+	}
+	if b.path == "" {
+		empty := toml.Tree{}
+		c := Config{
+			Tree:   &empty,
+			Logger: b.logger,
+		}
+		return &c, nil
 	}
 
 	return b.loadConfig(b.path)
@@ -82,5 +86,9 @@ func (b *builder) loadConfig(config string) (*Config, error) {
 
 	b.logger.Infof("Successfully loaded config")
 
-	return (*Config)(cfg), nil
+	c := Config{
+		Tree:   cfg,
+		Logger: b.logger,
+	}
+	return &c, nil
 }

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -49,7 +49,7 @@ func New(opts ...Option) (engine.Interface, error) {
 }
 
 // AddRuntime adds a new runtime to the docker config
-func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
+func (c *Config) AddRuntime(name string, path string, setAsDefault bool, _ ...map[string]interface{}) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -81,14 +81,25 @@ func New(opts ...Option) (Interface, error) {
 		indexNamer, _ := NewDeviceNamer(DeviceNameStrategyIndex)
 		l.deviceNamers = []DeviceNamer{indexNamer}
 	}
+	if l.nvidiaCTKPath == "" {
+		l.nvidiaCTKPath = "/usr/bin/nvidia-ctk"
+	}
 	if l.driverRoot == "" {
 		l.driverRoot = "/"
 	}
 	if l.devRoot == "" {
 		l.devRoot = l.driverRoot
 	}
-	if l.nvidiaCTKPath == "" {
-		l.nvidiaCTKPath = "/usr/bin/nvidia-ctk"
+	l.driver = root.New(
+		root.WithLogger(l.logger),
+		root.WithDriverRoot(l.driverRoot),
+		root.WithLibrarySearchPaths(l.librarySearchPaths...),
+	)
+	if l.nvmllib == nil {
+		l.nvmllib = nvml.New()
+	}
+	if l.devicelib == nil {
+		l.devicelib = device.New(device.WithNvml(l.nvmllib))
 	}
 	if l.infolib == nil {
 		l.infolib = info.New(
@@ -98,12 +109,6 @@ func New(opts ...Option) (Interface, error) {
 			info.WithDeviceLib(l.devicelib),
 		)
 	}
-
-	l.driver = root.New(
-		root.WithLogger(l.logger),
-		root.WithDriverRoot(l.driverRoot),
-		root.WithLibrarySearchPaths(l.librarySearchPaths...),
-	)
 
 	var lib Interface
 	switch l.resolveMode() {
@@ -118,13 +123,6 @@ func New(opts ...Option) (Interface, error) {
 		}
 		lib = (*managementlib)(l)
 	case ModeNvml:
-		if l.nvmllib == nil {
-			l.nvmllib = nvml.New()
-		}
-		if l.devicelib == nil {
-			l.devicelib = device.New(device.WithNvml(l.nvmllib))
-		}
-
 		lib = (*nvmllib)(l)
 	case ModeWsl:
 		lib = (*wsllib)(l)

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -91,7 +91,12 @@ func New(opts ...Option) (Interface, error) {
 		l.nvidiaCTKPath = "/usr/bin/nvidia-ctk"
 	}
 	if l.infolib == nil {
-		l.infolib = info.New()
+		l.infolib = info.New(
+			info.WithRoot(l.driverRoot),
+			info.WithLogger(l.logger),
+			info.WithNvmlLib(l.nvmllib),
+			info.WithDeviceLib(l.devicelib),
+		)
 	}
 
 	l.driver = root.New(
@@ -184,26 +189,19 @@ func (l *nvcdilib) resolveMode() (rmode string) {
 		return l.mode
 	}
 	defer func() {
-		l.logger.Infof("Auto-detected mode as %q", rmode)
+		l.logger.Infof("Auto-detected mode as '%v'", rmode)
 	}()
 
-	isWSL, reason := l.infolib.HasDXCore()
-	l.logger.Debugf("Is WSL-based system? %v: %v", isWSL, reason)
-
-	if isWSL {
+	platform := l.infolib.ResolvePlatform()
+	switch platform {
+	case info.PlatformNVML:
+		return ModeNvml
+	case info.PlatformTegra:
+		return ModeCSV
+	case info.PlatformWSL:
 		return ModeWsl
 	}
-
-	isNvml, reason := l.infolib.HasNvml()
-	l.logger.Debugf("Is NVML-based system? %v: %v", isNvml, reason)
-
-	isTegra, reason := l.infolib.HasTegraFiles()
-	l.logger.Debugf("Is Tegra-based system? %v: %v", isTegra, reason)
-
-	if isTegra && !isNvml {
-		return ModeCSV
-	}
-
+	l.logger.Warningf("Unsupported platform detected: %v; assuming %v", platform, ModeNvml)
 	return ModeNvml
 }
 

--- a/pkg/nvcdi/spec/builder.go
+++ b/pkg/nvcdi/spec/builder.go
@@ -67,7 +67,7 @@ func newBuilder(opts ...Option) *builder {
 		s.format = FormatYAML
 	}
 	if s.permissions == 0 {
-		s.permissions = 0600
+		s.permissions = 0644
 	}
 	return s
 }

--- a/tools/container/container.go
+++ b/tools/container/container.go
@@ -67,8 +67,8 @@ func ParseArgs(c *cli.Context, o *Options) error {
 }
 
 // Configure applies the options to the specified config
-func (o Options) Configure(cfg engine.Interface) error {
-	err := o.UpdateConfig(cfg)
+func (o Options) Configure(cfg engine.Interface, configOverrides ...map[string]interface{}) error {
+	err := o.UpdateConfig(cfg, configOverrides...)
 	if err != nil {
 		return fmt.Errorf("unable to update config: %v", err)
 	}
@@ -98,14 +98,14 @@ func (o Options) flush(cfg engine.Interface) error {
 }
 
 // UpdateConfig updates the specified config to include the nvidia runtimes
-func (o Options) UpdateConfig(cfg engine.Interface) error {
+func (o Options) UpdateConfig(cfg engine.Interface, configOverrides ...map[string]interface{}) error {
 	runtimes := operator.GetRuntimes(
 		operator.WithNvidiaRuntimeName(o.RuntimeName),
 		operator.WithSetAsDefault(o.SetAsDefault),
 		operator.WithRoot(o.RuntimeDir),
 	)
 	for name, runtime := range runtimes {
-		err := cfg.AddRuntime(name, runtime.Path, runtime.SetAsDefault)
+		err := cfg.AddRuntime(name, runtime.Path, runtime.SetAsDefault, configOverrides...)
 		if err != nil {
 			return fmt.Errorf("failed to update runtime %q: %v", name, err)
 		}

--- a/tools/container/containerd/config_v1_test.go
+++ b/tools/container/containerd/config_v1_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pelletier/go-toml"
+	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine/containerd"
@@ -28,6 +29,7 @@ import (
 )
 
 func TestUpdateV1ConfigDefaultRuntime(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
 	const runtimeDir = "/test/runtime/dir"
 
 	testCases := []struct {
@@ -94,6 +96,7 @@ func TestUpdateV1ConfigDefaultRuntime(t *testing.T) {
 			require.NoError(t, err, "%d: %v", i, tc)
 
 			v1 := &containerd.ConfigV1{
+				Logger:                logger,
 				Tree:                  config,
 				UseDefaultRuntimeName: !tc.legacyConfig,
 				RuntimeType:           runtimeType,
@@ -125,6 +128,7 @@ func TestUpdateV1ConfigDefaultRuntime(t *testing.T) {
 }
 
 func TestUpdateV1Config(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
 	const runtimeDir = "/test/runtime/dir"
 
 	testCases := []struct {
@@ -240,6 +244,7 @@ func TestUpdateV1Config(t *testing.T) {
 			require.NoError(t, err)
 
 			v1 := &containerd.ConfigV1{
+				Logger:                logger,
 				Tree:                  config,
 				UseDefaultRuntimeName: true,
 				RuntimeType:           runtimeType,
@@ -258,6 +263,7 @@ func TestUpdateV1Config(t *testing.T) {
 }
 
 func TestUpdateV1ConfigWithRuncPresent(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
 	const runtimeDir = "/test/runtime/dir"
 
 	testCases := []struct {
@@ -399,6 +405,7 @@ func TestUpdateV1ConfigWithRuncPresent(t *testing.T) {
 			require.NoError(t, err)
 
 			v1 := &containerd.ConfigV1{
+				Logger:                logger,
 				Tree:                  config,
 				UseDefaultRuntimeName: true,
 				RuntimeType:           runtimeType,

--- a/tools/container/containerd/config_v2_test.go
+++ b/tools/container/containerd/config_v2_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pelletier/go-toml"
+	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine/containerd"
@@ -32,6 +33,7 @@ const (
 )
 
 func TestUpdateV2ConfigDefaultRuntime(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
 	const runtimeDir = "/test/runtime/dir"
 
 	testCases := []struct {
@@ -76,6 +78,7 @@ func TestUpdateV2ConfigDefaultRuntime(t *testing.T) {
 			require.NoError(t, err)
 
 			v2 := &containerd.Config{
+				Logger:      logger,
 				Tree:        config,
 				RuntimeType: runtimeType,
 			}
@@ -90,6 +93,7 @@ func TestUpdateV2ConfigDefaultRuntime(t *testing.T) {
 }
 
 func TestUpdateV2Config(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
 	const runtimeDir = "/test/runtime/dir"
 
 	testCases := []struct {
@@ -200,8 +204,9 @@ func TestUpdateV2Config(t *testing.T) {
 			require.NoError(t, err)
 
 			v2 := &containerd.Config{
+				Logger:               logger,
 				Tree:                 config,
-				RuntimeType:          runtimeType,
+				RuntimeType:          o.runtimeType,
 				ContainerAnnotations: []string{"cdi.k8s.io/*"},
 			}
 
@@ -218,6 +223,7 @@ func TestUpdateV2Config(t *testing.T) {
 }
 
 func TestUpdateV2ConfigWithRuncPresent(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
 	const runtimeDir = "/test/runtime/dir"
 
 	testCases := []struct {
@@ -353,6 +359,7 @@ func TestUpdateV2ConfigWithRuncPresent(t *testing.T) {
 			require.NoError(t, err)
 
 			v2 := &containerd.Config{
+				Logger:               logger,
 				Tree:                 config,
 				RuntimeType:          runtimeType,
 				ContainerAnnotations: []string{"cdi.k8s.io/*"},

--- a/tools/container/containerd/containerd_test.go
+++ b/tools/container/containerd/containerd_test.go
@@ -1,0 +1,72 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeOptions(t *testing.T) {
+	testCases := []struct {
+		description   string
+		options       options
+		expected      map[string]interface{}
+		expectedError error
+	}{
+		{
+			description: "empty is nil",
+		},
+		{
+			description: "empty json",
+			options: options{
+				runtimeConfigOverrideJSON: "{}",
+			},
+			expected:      map[string]interface{}{},
+			expectedError: nil,
+		},
+		{
+			description: "SystemdCgroup is true",
+			options: options{
+				runtimeConfigOverrideJSON: "{\"SystemdCgroup\": true}",
+			},
+			expected: map[string]interface{}{
+				"SystemdCgroup": true,
+			},
+			expectedError: nil,
+		},
+		{
+			description: "SystemdCgroup is false",
+			options: options{
+				runtimeConfigOverrideJSON: "{\"SystemdCgroup\": false}",
+			},
+			expected: map[string]interface{}{
+				"SystemdCgroup": false,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			runtimeOptions, err := tc.options.runtimeConfigOverride()
+			require.ErrorIs(t, tc.expectedError, err)
+			require.EqualValues(t, tc.expected, runtimeOptions)
+		})
+	}
+}

--- a/versions.mk
+++ b/versions.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 LIB_NAME := nvidia-container-toolkit
-LIB_VERSION := 1.15.0
+LIB_VERSION := 1.15.1
 LIB_TAG :=
 
 # The package version is the combination of the library version and tag.


### PR DESCRIPTION
The changes include:
* The version bump to v1.15.1

Backporting the following changes:
* https://github.com/NVIDIA/nvidia-container-toolkit/pull/484
* #497
* #515
* #528
* #542 
* #560 