### PR TITLE
Set default CDI spec permissions to 644

### DIFF
--- a/pkg/nvcdi/spec/builder.go
+++ b/pkg/nvcdi/spec/builder.go
@@ -77,7 +77,7 @@ func newBuilder(opts ...Option) *builder {
 		s.format = FormatYAML
 	}
 	if s.permissions == 0 {
-		s.permissions = 0600
+		s.permissions = 0644
 	}
 	return s
 }


### PR DESCRIPTION
Although the nvidia-ctk cdi generate command generates specs with 644 permissions, the nvidia-ctk cdi transform commands do not. This change sets the default permissions to 600 instead of 644.