### PR TITLE
Remove provenance information from image manifests

### DIFF
--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -92,6 +92,7 @@ ARTIFACTS_ROOT ?= $(shell realpath --relative-to=$(CURDIR) $(DIST_DIR))
 $(BUILD_TARGETS): build-%: $(ARTIFACTS_ROOT)
 	DOCKER_BUILDKIT=1 \
 		$(DOCKER) $(BUILDX) build --pull \
+		--provenance=false --sbom=false \
 		$(DOCKER_BUILD_OPTIONS) \
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \


### PR DESCRIPTION
Tools such as oc mirror do not support the provenence metadata added to the image manifests with newer docker buildx versions.

This change disables the addition of provenance information.