### PR TITLE
Use ref_name on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,12 +33,12 @@ jobs:
           REPO: ${{ github.event.repository.name }}
         run: |
           GH_EXTRA_ARGS=""
-          if [[ ${{ github.ref }} == *-rc.* ]]; then
+          if [[ ${{ github.ref_name }} == *-rc.* ]]; then
             GH_EXTRA_ARGS="--prerelease"
           fi
-          gh release create ${{ github.ref }} \
+          gh release create ${{ github.ref_name }} \
             --draft \
-            -t "${{ github.ref }}" \
+            -t "${{ github.ref_name }}" \
             -R $OWNER/$REPO \
             --verify-tag \
             $GH_EXTRA_ARGS
@@ -49,4 +49,4 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
         run: |
-          gh release upload ${{ github.ref }} CHANGELOG.md -R $OWNER/$REPO
+          gh release upload ${{ github.ref_name }} CHANGELOG.md -R $OWNER/$REPO


### PR DESCRIPTION
From https://docs.github.com/en/actions/learn-github-actions/contexts#github-context 

`ref_name` will provide only the tag name 