### PR TITLE
Reduce logging verbosity in NVIDIA Container Runtime

### DIFF
--- a/internal/logger/api.go
+++ b/internal/logger/api.go
@@ -24,4 +24,5 @@ type Interface interface {
 	Infof(string, ...interface{})
 	Warning(...interface{})
 	Warningf(string, ...interface{})
+	Tracef(string, ...interface{})
 }

--- a/internal/logger/lib.go
+++ b/internal/logger/lib.go
@@ -45,3 +45,6 @@ func (l *NullLogger) Warning(...interface{}) {}
 
 // Warningf is a no-op for the null logger
 func (l *NullLogger) Warningf(string, ...interface{}) {}
+
+// Tracef is a no-op for the null logger
+func (l *NullLogger) Tracef(string, ...interface{}) {}

--- a/internal/oci/runtime.go
+++ b/internal/oci/runtime.go
@@ -16,10 +16,11 @@
 
 package oci
 
-//go:generate moq -stub -out runtime_mock.go . Runtime
-
 // Runtime is an interface for a runtime shim. The Exec method accepts a list
 // of command line arguments, and returns an error / nil.
+//
+//go:generate moq -rm -stub -out runtime_mock.go . Runtime
 type Runtime interface {
 	Exec([]string) error
+	String() string
 }

--- a/internal/oci/runtime_low_level.go
+++ b/internal/oci/runtime_low_level.go
@@ -31,8 +31,6 @@ func NewLowLevelRuntime(logger logger.Interface, candidates []string) (Runtime, 
 	if err != nil {
 		return nil, fmt.Errorf("error locating runtime: %v", err)
 	}
-
-	logger.Infof("Using low-level runtime %v", runtimePath)
 	return NewRuntimeForPath(logger, runtimePath)
 }
 
@@ -45,13 +43,12 @@ func findRuntime(logger logger.Interface, candidates []string) (string, error) {
 
 	locator := lookup.NewExecutableLocator(logger, "/")
 	for _, candidate := range candidates {
-		logger.Debugf("Looking for runtime binary '%v'", candidate)
+		logger.Tracef("Looking for runtime binary '%v'", candidate)
 		targets, err := locator.Locate(candidate)
 		if err == nil && len(targets) > 0 {
-			logger.Debugf("Found runtime binary '%v'", targets)
+			logger.Tracef("Found runtime binary '%v'", targets)
 			return targets[0], nil
 		}
-		logger.Debugf("Runtime binary '%v' not found: %v (targets=%v)", candidate, err, targets)
 	}
 
 	return "", fmt.Errorf("no runtime binary found from candidate list: %v", candidates)

--- a/internal/oci/runtime_mock.go
+++ b/internal/oci/runtime_mock.go
@@ -20,6 +20,9 @@ var _ Runtime = &RuntimeMock{}
 //			ExecFunc: func(strings []string) error {
 //				panic("mock out the Exec method")
 //			},
+//			StringFunc: func() string {
+//				panic("mock out the String method")
+//			},
 //		}
 //
 //		// use mockedRuntime in code that requires Runtime
@@ -30,6 +33,9 @@ type RuntimeMock struct {
 	// ExecFunc mocks the Exec method.
 	ExecFunc func(strings []string) error
 
+	// StringFunc mocks the String method.
+	StringFunc func() string
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// Exec holds details about calls to the Exec method.
@@ -37,8 +43,12 @@ type RuntimeMock struct {
 			// Strings is the strings argument value.
 			Strings []string
 		}
+		// String holds details about calls to the String method.
+		String []struct {
+		}
 	}
-	lockExec sync.RWMutex
+	lockExec   sync.RWMutex
+	lockString sync.RWMutex
 }
 
 // Exec calls ExecFunc.
@@ -73,5 +83,35 @@ func (mock *RuntimeMock) ExecCalls() []struct {
 	mock.lockExec.RLock()
 	calls = mock.calls.Exec
 	mock.lockExec.RUnlock()
+	return calls
+}
+
+// String calls StringFunc.
+func (mock *RuntimeMock) String() string {
+	callInfo := struct {
+	}{}
+	mock.lockString.Lock()
+	mock.calls.String = append(mock.calls.String, callInfo)
+	mock.lockString.Unlock()
+	if mock.StringFunc == nil {
+		var (
+			sOut string
+		)
+		return sOut
+	}
+	return mock.StringFunc()
+}
+
+// StringCalls gets all the calls that were made to String.
+// Check the length with:
+//
+//	len(mockedRuntime.StringCalls())
+func (mock *RuntimeMock) StringCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockString.RLock()
+	calls = mock.calls.String
+	mock.lockString.RUnlock()
 	return calls
 }

--- a/internal/oci/runtime_modifier.go
+++ b/internal/oci/runtime_modifier.go
@@ -35,7 +35,7 @@ var _ Runtime = (*modifyingRuntimeWrapper)(nil)
 // before invoking the wrapped runtime. If the modifier is nil, the input runtime is returned.
 func NewModifyingRuntimeWrapper(logger logger.Interface, runtime Runtime, spec Spec, modifier SpecModifier) Runtime {
 	if modifier == nil {
-		logger.Infof("Using low-level runtime with no modification")
+		logger.Tracef("Using low-level runtime with no modification")
 		return runtime
 	}
 
@@ -52,16 +52,15 @@ func NewModifyingRuntimeWrapper(logger logger.Interface, runtime Runtime, spec S
 // into the wrapped runtime.
 func (r *modifyingRuntimeWrapper) Exec(args []string) error {
 	if HasCreateSubcommand(args) {
+		r.logger.Debugf("Create command detected; applying OCI specification modifications")
 		err := r.modify()
 		if err != nil {
-			return fmt.Errorf("could not apply required modification to OCI specification: %v", err)
+			return fmt.Errorf("could not apply required modification to OCI specification: %w", err)
 		}
-		r.logger.Infof("Applied required modification to OCI specification")
-	} else {
-		r.logger.Infof("No modification of OCI specification required")
+		r.logger.Debugf("Applied required modification to OCI specification")
 	}
 
-	r.logger.Infof("Forwarding command to runtime")
+	r.logger.Debugf("Forwarding command to runtime %v", r.runtime.String())
 	return r.runtime.Exec(args)
 }
 

--- a/internal/oci/runtime_modifier.go
+++ b/internal/oci/runtime_modifier.go
@@ -83,3 +83,8 @@ func (r *modifyingRuntimeWrapper) modify() error {
 	}
 	return nil
 }
+
+// String returns a string representation of the runtime.
+func (r *modifyingRuntimeWrapper) String() string {
+	return fmt.Sprintf("modify on-create and forward to %s", r.runtime.String())
+}

--- a/internal/oci/runtime_path.go
+++ b/internal/oci/runtime_path.go
@@ -63,3 +63,8 @@ func (s pathRuntime) Exec(args []string) error {
 
 	return s.execRuntime.Exec(runtimeArgs)
 }
+
+// String returns the path to the specified runtime as the string representation.
+func (s pathRuntime) String() string {
+	return s.path
+}

--- a/internal/oci/runtime_syscall_exec.go
+++ b/internal/oci/runtime_syscall_exec.go
@@ -37,3 +37,7 @@ func (r syscallExec) Exec(args []string) error {
 	// err is nil or not.
 	return fmt.Errorf("unexpected return from exec '%v'", args[0])
 }
+
+func (r syscallExec) String() string {
+	return "exec"
+}

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -35,8 +35,9 @@ func newNVIDIAContainerRuntime(logger logger.Interface, cfg *config.Config, argv
 		return nil, fmt.Errorf("error constructing low-level runtime: %v", err)
 	}
 
+	logger.Tracef("Using low-level runtime %v", lowLevelRuntime.String())
 	if !oci.HasCreateSubcommand(argv) {
-		logger.Debugf("Skipping modifier for non-create subcommand")
+		logger.Tracef("Skipping modifier for non-create subcommand")
 		return lowLevelRuntime, nil
 	}
 
@@ -50,7 +51,7 @@ func newNVIDIAContainerRuntime(logger logger.Interface, cfg *config.Config, argv
 		return nil, fmt.Errorf("failed to construct OCI spec modifier: %v", err)
 	}
 
-	// Create the wrapping runtime with the specified modifier
+	// Create the wrapping runtime with the specified modifier.
 	r := oci.NewModifyingRuntimeWrapper(
 		logger,
 		lowLevelRuntime,


### PR DESCRIPTION
These changes reduce the verbosity of the logging of the NVIDIA Container Runtime -- especially for the case where no modifications are required.

See:
* https://github.com/containerd/containerd/issues/8972#issuecomment-2067595892
* https://github.com/NVIDIA/nvidia-container-toolkit/issues/511

## Testing
1. Build the executable:
  ``` 
  make cmd-nvidia-container-runtime
  ```
2. Create a dummy config file:
  ```
  mkdir -p .config/nvidia-container-runtime
  cat <<EOF > .config/nvidia-container-runtime/config.toml 
  [nvidia-container-runtime]
  log-level = "info"
  runtimes = ["undefined", "missing", "runtime"]
  EOF
  ```
3. Create a dummy runtime:
  ```
  cat <<EOF > runtime
  #!/bin/bash
  echo "runtime args \$@"
  EOF
  chmod +x runtime
  ```
4. Run the NVIDIA runtime with the create command:
  ```
  PATH=$(pwd):${PATH} XDG_CONFIG_HOME=$(pwd)/.config \
  ./nvidia-container-runtime --log=$(pwd)/runtime.log create foo
  ```
5. Check the generated log:
  ```
  cat runtime.log
  ```

We can change the following:
* the log-level in the config file. Note that adding `--debug` flag to the command line (e.g. `./nvidia-container-runtime --debug`) will configure debug logging.
* The runc command to check the behaviour for non-`create` commands.
 