### PR TITLE
Fix centos7 builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "third_party/libnvidia-container"]
 	path = third_party/libnvidia-container
 	url = https://github.com/NVIDIA/libnvidia-container.git
-	branch = main
+	branch = release-1.15

--- a/docker/Dockerfile.rpm-yum
+++ b/docker/Dockerfile.rpm-yum
@@ -20,11 +20,9 @@ FROM ${BASEIMAGE}
 # centos:stream8 is EOL.
 # We switch to the vault repositories for this base image.
 ARG BASEIMAGE
-RUN if [ "${BASEIMAGE}" = "quay.io/centos/centos:stream8" ]; then \
-        sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
-               -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
-                  /etc/yum.repos.d/CentOS-Stream-*; \
-    fi
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
+            -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
+                /etc/yum.repos.d/CentOS-*
 
 RUN yum install -y \
         ca-certificates \


### PR DESCRIPTION
With the EOL of centos:7 we cannot use the repo mirrors and we therefore switch to the vault repos.

Backports #574 