### PR TITLE
Manage golang version with dependabot

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Get Golang version
       id: vars
       run: |
-        GOLANG_VERSION=$( grep "GOLANG_VERSION :=" versions.mk )
+        GOLANG_VERSION=$(./hack/golang-version.sh)
         echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION := }" >> $GITHUB_ENV
     - name: Install Go
       uses: actions/setup-go@v5
@@ -59,7 +59,7 @@ jobs:
         - name: Get Golang version
           id: vars
           run: |
-            GOLANG_VERSION=$( grep "GOLANG_VERSION :=" versions.mk )
+            GOLANG_VERSION=$(./hack/golang-version.sh)
             echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION := }" >> $GITHUB_ENV
         - name: Install Go
           uses: actions/setup-go@v5

--- a/deployments/container/Dockerfile.golang
+++ b/deployments/container/Dockerfile.golang
@@ -1,0 +1,19 @@
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile is used to define the golang version used in this
+# project.
+# This allows dependabot to manage this version in addition to other
+# images.
+FROM golang:1.22.1

--- a/hack/golang-version.sh
+++ b/hack/golang-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../scripts && pwd )"
+
+DOCKERFILE_ROOT=${SCRIPTS_DIR}/../deployments/container
+
+GOLANG_VERSION=$(grep -E "^FROM golang:.*$" ${DOCKERFILE_ROOT}/Dockerfile.golang | grep -oE "[0-9\.]+")
+
+echo $GOLANG_VERSION

--- a/versions.mk
+++ b/versions.mk
@@ -21,7 +21,7 @@ LIB_TAG := rc.2
 PACKAGE_VERSION := $(LIB_VERSION)$(if $(LIB_TAG),~$(LIB_TAG))
 PACKAGE_REVISION := 1
 
-GOLANG_VERSION := 1.22.1
+GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
 BUILDIMAGE ?=  ghcr.io/nvidia/k8s-test-infra:$(BUILDIMAGE_TAG)


### PR DESCRIPTION
This change adds logic to extract the golang version from a Dockefile.
This allows us to trigger golang updates using dependabot.