### PR TITLE
[bugfix] Process error type instead of nvml.Return 

### DIFF
--- a/internal/platform-support/dgpu/nvml.go
+++ b/internal/platform-support/dgpu/nvml.go
@@ -145,9 +145,9 @@ type toRequiredMigInfo struct {
 }
 
 func (d *toRequiredMigInfo) getPlacementInfo() (int, int, int, error) {
-	gpu, ret := d.parent.GetMinorNumber()
-	if ret != nvml.SUCCESS {
-		return 0, 0, 0, fmt.Errorf("error getting GPU minor: %v", ret)
+	gpu, err := d.parent.GetMinorNumber()
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("error getting GPU minor: %w", err)
 	}
 
 	gi, ret := d.GetGpuInstanceId()


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/NVIDIA/nvidia-container-toolkit/commit/448a3853ad3b0c653209323a5cc520e664bced8a. This bug breaks CDI spec generation for MIG devices.