### PR TITLE
[no-relnotes] Add initial unit test for MIG CDI spec generation

### DIFF
--- a/internal/platform-support/dgpu/nvml.go
+++ b/internal/platform-support/dgpu/nvml.go
@@ -78,24 +78,23 @@ type requiredMigInfo interface {
 }
 
 func (o *options) newNvmlMigDiscoverer(d requiredMigInfo) (discover.Discover, error) {
+	if o.migCaps == nil || o.migCapsError != nil {
+		return nil, fmt.Errorf("error getting MIG capability device paths: %v", o.migCapsError)
+	}
+
 	gpu, gi, ci, err := d.getPlacementInfo()
 	if err != nil {
 		return nil, fmt.Errorf("error getting placement info: %w", err)
 	}
 
-	migCaps, err := nvcaps.NewMigCaps()
-	if err != nil {
-		return nil, fmt.Errorf("error getting MIG capability device paths: %v", err)
-	}
-
 	giCap := nvcaps.NewGPUInstanceCap(gpu, gi)
-	giCapDevicePath, err := migCaps.GetCapDevicePath(giCap)
+	giCapDevicePath, err := o.migCaps.GetCapDevicePath(giCap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get GI cap device path: %v", err)
 	}
 
 	ciCap := nvcaps.NewComputeInstanceCap(gpu, gi, ci)
-	ciCapDevicePath, err := migCaps.GetCapDevicePath(ciCap)
+	ciCapDevicePath, err := o.migCaps.GetCapDevicePath(ciCap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CI cap device path: %v", err)
 	}

--- a/internal/platform-support/dgpu/nvml_test.go
+++ b/internal/platform-support/dgpu/nvml_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvcaps"
 )
 
 // TODO: In order to properly test this, we need a mechanism to inject /
@@ -74,6 +75,89 @@ func TestNewNvmlDGPUDiscoverer(t *testing.T) {
 			require.NoError(t, err)
 
 			d, err := o.newNvmlDGPUDiscoverer(&toRequiredInfo{device})
+			require.ErrorIs(t, err, tc.expectedError)
+
+			devices, _ := d.Devices()
+			require.EqualValues(t, tc.expectedDevices, devices)
+			hooks, _ := d.Hooks()
+			require.EqualValues(t, tc.expectedHooks, hooks)
+			mounts, _ := d.Mounts()
+			require.EqualValues(t, tc.expectedMounts, mounts)
+		})
+	}
+}
+
+func TestNewNvmlMIGDiscoverer(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+
+	nvmllib := &mock.Interface{}
+	devicelib := device.New(
+		nvmllib,
+	)
+
+	testCases := []struct {
+		description     string
+		mig             *mock.Device
+		parent          nvml.Device
+		migCaps         nvcaps.MigCaps
+		expectedError   error
+		expectedDevices []discover.Device
+		expectedHooks   []discover.Hook
+		expectedMounts  []discover.Mount
+	}{
+		{
+			description: "",
+			mig: &mock.Device{
+				IsMigDeviceHandleFunc: func() (bool, nvml.Return) {
+					return true, nvml.SUCCESS
+				},
+				GetGpuInstanceIdFunc: func() (int, nvml.Return) {
+					return 1, nvml.SUCCESS
+				},
+				GetComputeInstanceIdFunc: func() (int, nvml.Return) {
+					return 2, nvml.SUCCESS
+				},
+			},
+			parent: &mock.Device{
+				GetMinorNumberFunc: func() (int, nvml.Return) {
+					return 3, nvml.SUCCESS
+				},
+				GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
+					var busID [32]int8
+					for i, b := range []byte("00000000:45:00:00") {
+						busID[i] = int8(b)
+					}
+					info := nvml.PciInfo{
+						BusId: busID,
+					}
+					return info, nvml.SUCCESS
+				},
+			},
+			migCaps: nvcaps.MigCaps{
+				"gpu3/gi1/access":     31,
+				"gpu3/gi1/ci2/access": 312,
+			},
+			expectedDevices: nil,
+			expectedMounts:  nil,
+			expectedHooks:   []discover.Hook{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+
+			tc.mig.GetDeviceHandleFromMigDeviceHandleFunc = func() (nvml.Device, nvml.Return) {
+				return tc.parent, nvml.SUCCESS
+			}
+			parent, err := devicelib.NewDevice(tc.parent)
+			require.NoError(t, err)
+
+			mig, err := devicelib.NewMigDevice(tc.mig)
+			require.NoError(t, err)
+
+			d, err := NewForMigDevice(parent, mig,
+				WithLogger(logger),
+				WithMIGCaps(tc.migCaps),
+			)
 			require.ErrorIs(t, err, tc.expectedError)
 
 			devices, _ := d.Devices()

--- a/internal/platform-support/dgpu/options.go
+++ b/internal/platform-support/dgpu/options.go
@@ -18,12 +18,18 @@ package dgpu
 
 import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvcaps"
 )
 
 type options struct {
 	logger            logger.Interface
 	devRoot           string
 	nvidiaCDIHookPath string
+
+	// migCaps stores the MIG capabilities for the system.
+	// If MIG is not available, this is nil.
+	migCaps      nvcaps.MigCaps
+	migCapsError error
 }
 
 type Option func(*options)
@@ -46,5 +52,12 @@ func WithLogger(logger logger.Interface) Option {
 func WithNVIDIACDIHookPath(path string) Option {
 	return func(l *options) {
 		l.nvidiaCDIHookPath = path
+	}
+}
+
+// WithMIGCaps sets the MIG capabilities.
+func WithMIGCaps(migCaps nvcaps.MigCaps) Option {
+	return func(l *options) {
+		l.migCaps = migCaps
 	}
 }


### PR DESCRIPTION
This adds a basic test that fails without the changes of #619

Against `v1.16.0`:
```
--- FAIL: TestNewNvmlMIGDiscoverer (0.00s)
    --- FAIL: TestNewNvmlMIGDiscoverer/#00 (0.00s)
        nvml_test.go:161:
                Error Trace:    /Users/elezar/src/container-toolkit/internal/platform-support/dgpu/nvml_test.go:161
                Error:          Target error should be in err chain:
                                expected: ""
                                in chain: "error getting placement info: error getting GPU minor: <nil>"
                                        "error getting GPU minor: <nil>"
                Test:           TestNewNvmlMIGDiscoverer/#00
FAIL
```

