### PR TITLE
Generate CDI specification including additional GIDs

### DIFF
--- a/internal/edits/device.go
+++ b/internal/edits/device.go
@@ -17,6 +17,9 @@
 package edits
 
 import (
+	"os"
+
+	"golang.org/x/sys/unix"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 	"tags.cncf.io/container-device-interface/specs-go"
 
@@ -32,9 +35,15 @@ func (d device) toEdits() (*cdi.ContainerEdits, error) {
 		return nil, err
 	}
 
+	var additionalGIDs []uint32
+	if requiredGID, _ := d.getRequiredGID(); requiredGID != 0 {
+		additionalGIDs = append(additionalGIDs, requiredGID)
+	}
+
 	e := cdi.ContainerEdits{
 		ContainerEdits: &specs.ContainerEdits{
-			DeviceNodes: []*specs.DeviceNode{deviceNode},
+			DeviceNodes:    []*specs.DeviceNode{deviceNode},
+			AdditionalGIDs: additionalGIDs,
 		},
 	}
 	return &e, nil
@@ -52,10 +61,37 @@ func (d device) toSpec() (*specs.DeviceNode, error) {
 	if hostPath == d.Path {
 		hostPath = ""
 	}
+
 	s := specs.DeviceNode{
 		HostPath: hostPath,
 		Path:     d.Path,
 	}
 
 	return &s, nil
+}
+
+// getRequiredGID returns the group id of the device if the device is not world read/writable
+func (d device) getRequiredGID() (uint32, error) {
+	path := d.HostPath
+	if path == "" {
+		path = d.Path
+	}
+	if path == "" {
+		return 0, nil
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Lstat(path, &stat); err != nil {
+		return 0, err
+	}
+	// This is only supported for char devices
+	if stat.Mode&unix.S_IFMT != unix.S_IFCHR {
+		return 0, nil
+	}
+
+	permissions := os.FileMode(stat.Mode).Perm()
+	if permissions&06 == 0 {
+		return stat.Gid, nil
+	}
+	return 0, nil
 }

--- a/internal/edits/resource.go
+++ b/internal/edits/resource.go
@@ -1,0 +1,30 @@
+/**
+# Copyright 2023 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package edits
+
+import (
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+	"tags.cncf.io/container-device-interface/specs-go"
+)
+
+// NewResource creates a CDI resource (Device) with the specified name.
+func NewResource(name string, edits *cdi.ContainerEdits) specs.Device {
+	return specs.Device{
+		Name:           name,
+		ContainerEdits: *edits.ContainerEdits,
+	}
+}

--- a/pkg/nvcdi/full-gpu-nvml.go
+++ b/pkg/nvcdi/full-gpu-nvml.go
@@ -30,7 +30,7 @@ import (
 
 // GetGPUDeviceSpecs returns the CDI device specs for the full GPU represented by 'device'.
 func (l *nvmllib) GetGPUDeviceSpecs(i int, d device.Device) ([]specs.Device, error) {
-	edits, err := l.GetGPUDeviceEdits(d)
+	e, err := l.GetGPUDeviceEdits(d)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get edits for device: %v", err)
 	}
@@ -41,10 +41,7 @@ func (l *nvmllib) GetGPUDeviceSpecs(i int, d device.Device) ([]specs.Device, err
 		return nil, fmt.Errorf("failed to get device name: %v", err)
 	}
 	for _, name := range names {
-		spec := specs.Device{
-			Name:           name,
-			ContainerEdits: *edits.ContainerEdits,
-		}
+		spec := edits.NewResource(name, e)
 		deviceSpecs = append(deviceSpecs, spec)
 	}
 

--- a/pkg/nvcdi/gds.go
+++ b/pkg/nvcdi/gds.go
@@ -38,15 +38,12 @@ func (l *gdslib) GetAllDeviceSpecs() ([]specs.Device, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GPUDirect Storage discoverer: %v", err)
 	}
-	edits, err := edits.FromDiscoverer(discoverer)
+	e, err := edits.FromDiscoverer(discoverer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container edits for GPUDirect Storage: %v", err)
 	}
 
-	deviceSpec := specs.Device{
-		Name:           "all",
-		ContainerEdits: *edits.ContainerEdits,
-	}
+	deviceSpec := edits.NewResource("all", e)
 
 	return []specs.Device{deviceSpec}, nil
 }

--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -64,10 +64,7 @@ func (l *csvlib) GetAllDeviceSpecs() ([]specs.Device, error) {
 	}
 	var deviceSpecs []specs.Device
 	for _, name := range names {
-		deviceSpec := specs.Device{
-			Name:           name,
-			ContainerEdits: *e.ContainerEdits,
-		}
+		deviceSpec := edits.NewResource(name, e)
 		deviceSpecs = append(deviceSpecs, deviceSpec)
 	}
 

--- a/pkg/nvcdi/lib-wsl.go
+++ b/pkg/nvcdi/lib-wsl.go
@@ -39,15 +39,12 @@ func (l *wsllib) GetSpec() (spec.Interface, error) {
 // GetAllDeviceSpecs returns the device specs for all available devices.
 func (l *wsllib) GetAllDeviceSpecs() ([]specs.Device, error) {
 	device := newDXGDeviceDiscoverer(l.logger, l.devRoot)
-	deviceEdits, err := edits.FromDiscoverer(device)
+	e, err := edits.FromDiscoverer(device)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container edits for DXG device: %v", err)
 	}
 
-	deviceSpec := specs.Device{
-		Name:           "all",
-		ContainerEdits: *deviceEdits.ContainerEdits,
-	}
+	deviceSpec := edits.NewResource("all", e)
 
 	return []specs.Device{deviceSpec}, nil
 }

--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -43,19 +43,16 @@ func (m *managementlib) GetAllDeviceSpecs() ([]specs.Device, error) {
 		return nil, fmt.Errorf("failed to create device discoverer: %v", err)
 	}
 
-	edits, err := edits.FromDiscoverer(devices)
+	e, err := edits.FromDiscoverer(devices)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create edits from discoverer: %v", err)
 	}
 
-	if len(edits.DeviceNodes) == 0 {
+	if len(e.DeviceNodes) == 0 {
 		return nil, fmt.Errorf("no NVIDIA device nodes found")
 	}
 
-	device := specs.Device{
-		Name:           "all",
-		ContainerEdits: *edits.ContainerEdits,
-	}
+	device := edits.NewResource("all", e)
 	return []specs.Device{device}, nil
 }
 

--- a/pkg/nvcdi/mig-device-nvml.go
+++ b/pkg/nvcdi/mig-device-nvml.go
@@ -29,7 +29,7 @@ import (
 
 // GetMIGDeviceSpecs returns the CDI device specs for the full GPU represented by 'device'.
 func (l *nvmllib) GetMIGDeviceSpecs(i int, d device.Device, j int, mig device.MigDevice) ([]specs.Device, error) {
-	edits, err := l.GetMIGDeviceEdits(d, mig)
+	e, err := l.GetMIGDeviceEdits(d, mig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get edits for device: %v", err)
 	}
@@ -40,10 +40,7 @@ func (l *nvmllib) GetMIGDeviceSpecs(i int, d device.Device, j int, mig device.Mi
 	}
 	var deviceSpecs []specs.Device
 	for _, name := range names {
-		spec := specs.Device{
-			Name:           name,
-			ContainerEdits: *edits.ContainerEdits,
-		}
+		spec := edits.NewResource(name, e)
 		deviceSpecs = append(deviceSpecs, spec)
 	}
 	return deviceSpecs, nil

--- a/pkg/nvcdi/transform/merged-device.go
+++ b/pkg/nvcdi/transform/merged-device.go
@@ -109,7 +109,6 @@ func mergeDeviceSpecs(deviceSpecs []specs.Device, mergedDeviceName string) (*spe
 	}
 
 	mergedEdits := edits.NewContainerEdits()
-
 	for _, d := range deviceSpecs {
 		d := d
 		edit := cdi.ContainerEdits{
@@ -118,9 +117,6 @@ func mergeDeviceSpecs(deviceSpecs []specs.Device, mergedDeviceName string) (*spe
 		mergedEdits.Append(&edit)
 	}
 
-	merged := specs.Device{
-		Name:           mergedDeviceName,
-		ContainerEdits: *mergedEdits.ContainerEdits,
-	}
+	merged := edits.NewResource(mergedDeviceName, mergedEdits)
 	return &merged, nil
 }


### PR DESCRIPTION
This change adds logic to include the `AdditionalGIDs` required for a device node in a generated CDI specification.

When a device node requires specific group membership for access, a non-root user running in a container (e.g. using the `-u` Docker command line argument) may not have access to the device.

in the v0.7.0 CDI specification, support was added for specifying additional GIDs in the CDI specification and these changes extract the required information from the device nodes on the host if available.