### PR TITLE
Use empty string for default runtime-config-override

### DIFF
--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -160,7 +160,7 @@ func (m command) build() *cli.Command {
 			Name:        "runtime-config-override",
 			Destination: &config.runtimeConfigOverrideJSON,
 			Usage:       "specify additional runtime options as a JSON string. The paths are relative to the runtime config.",
-			Value:       "{}",
+			Value:       "",
 			EnvVars:     []string{"RUNTIME_CONFIG_OVERRIDE"},
 		},
 	}


### PR DESCRIPTION
This change ensures that we unnecessarily print warnings for runtimes where these configs are not applicable.

This removes the following warnings:
```
WARN[0000] Ignoring runtime-config-override flag for docker
```

See #631