### PR TITLE
Use empty string for default runtime-config-override

### DIFF
--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -160,7 +160,7 @@ func (m command) build() *cli.Command {
 			Name:        "runtime-config-override",
 			Destination: &config.runtimeConfigOverrideJSON,
 			Usage:       "specify additional runtime options as a JSON string. The paths are relative to the runtime config.",
-			Value:       "{}",
+			Value:       "",
 			EnvVars:     []string{"RUNTIME_CONFIG_OVERRIDE"},
 		},
 	}

--- a/internal/discover/mounts_test.go
+++ b/internal/discover/mounts_test.go
@@ -100,7 +100,7 @@ func TestMounts(t *testing.T) {
 				lookup: &lookup.LocatorMock{
 					LocateFunc: func(s string) ([]string, error) {
 						if s == "error" {
-							return nil, fmt.Errorf(s)
+							return nil, fmt.Errorf("error")
 						}
 						return []string{s}, nil
 					},


### PR DESCRIPTION
Cherry picks #658

Fixes #631