### PR TITLE
Exclude libnvidia-allocator from graphics mounts

### DIFF
--- a/internal/discover/graphics_test.go
+++ b/internal/discover/graphics_test.go
@@ -62,11 +62,7 @@ func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 					return mounts, nil
 				},
 			},
-			expectedMounts: []Mount{
-				{
-					Path: "/usr/lib64/libnvidia-allocator.so.123.45.67",
-				},
-			},
+			expectedMounts: nil,
 			expectedHooks: []Hook{
 				{
 					Lifecycle: "createContainer",
@@ -121,9 +117,6 @@ func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 				},
 			},
 			expectedMounts: []Mount{
-				{
-					Path: "/usr/lib64/libnvidia-allocator.so.123.45.67",
-				},
 				{
 					Path: "/usr/lib64/libnvidia-vulkan-producer.so.123.45.67",
 				},


### PR DESCRIPTION
This change ensures that the `libnvidia-allocator.so.RM_VERSION` mount is not injected BOTH by the `nvidia-container-runtime` through modifying the OCI spec AND libnvidia-container.

First injecting the mount through the OCI spec and then also following the mount logic implemented in `libnvidia-container` causes mounts to be leaked to the host when bind-propagation is enabled in a container.

To verify these changes set up the following folder:
```
$ mkdir -p /tmp/empty
```

Run the existing `nvidia` runtime:
```
$ nvidia-container-runtime --version
NVIDIA Container Runtime version 1.16.1
commit: a470818ba7d9166be282cd0039dd2fc9b0a34d73
spec: 1.2.0

runc version 1.1.12
commit: v1.1.12-0-g51d5e94
spec: 1.0.2-dev
go: go1.21.9
libseccomp: 2.5.1
```
```
$ docker run --runtime=nvidia --rm -ti -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all \
     --mount type=bind,source=/tmp/empty,target=/empty,bind-propagation=shared \
     ubuntu mount | grep allocator
/dev/md0 on /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.550.54.15 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro)
/dev/md0 on /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.550.54.15 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro)
```
Note that the mounts are leaked to the host:
```
$ mount | grep allocator
/dev/md0 on /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.550.54.15 type ext4 (rw,relatime,nodelalloc,errors=remount-ro)
```

Clean up the mount:
```
$ sudo umount /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.550.54.15
```

With these changes:
```
$ ./nvidia-container-runtime --version
NVIDIA Container Runtime version 1.16.1
commit: beb921fafebaf416cf03a3dcfc5d250a03d325b2
spec: 1.2.0

runc version 1.1.12
commit: v1.1.12-0-g51d5e94
spec: 1.0.2-dev
go: go1.21.9
libseccomp: 2.5.1
```

```
$ docker run --runtime=elezar --rm -ti -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all \
     --mount type=bind,source=/tmp/empty,target=/empty,bind-propagation=shared \
     ubuntu mount | grep allocator
/dev/md0 on /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.550.54.15 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro)
```

Note that no mounts are present on the host:
```
$ mount | grep allocator
```