### PR TITLE
Fetch current container runtime config

### DIFF
--- a/internal/config/toml.go
+++ b/internal/config/toml.go
@@ -170,9 +170,20 @@ func (t *Toml) Get(key string) interface{} {
 	return (*toml.Tree)(t).Get(key)
 }
 
+// GetDefault returns the value for the specified key and falls back to the default value if the Get call fails
+func (t *Toml) GetDefault(key string, def interface{}) interface{} {
+	return (*toml.Tree)(t).GetDefault(key, def)
+}
+
 // Set sets the specified key to the specified value in the TOML config.
 func (t *Toml) Set(key string, value interface{}) {
 	(*toml.Tree)(t).Set(key, value)
+}
+
+// WriteTo encode the Tree as Toml and writes it to the writer w.
+// Returns the number of bytes written in case of success, or an error if anything happened.
+func (t *Toml) WriteTo(w io.Writer) (int64, error) {
+	return (*toml.Tree)(t).WriteTo(w)
 }
 
 // commentDefaults applies the required comments for default values to the Toml.

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -23,4 +23,10 @@ type Interface interface {
 	Set(string, interface{})
 	RemoveRuntime(string) error
 	Save(string) (int64, error)
+	GetRuntimeConfig(string) (RuntimeConfig, error)
+}
+
+// RuntimeConfig defines the interface to query container runtime handler configuration
+type RuntimeConfig interface {
+	GetBinaryPath() string
 }

--- a/pkg/config/engine/containerd/config_v1_test.go
+++ b/pkg/config/engine/containerd/config_v1_test.go
@@ -138,7 +138,7 @@ func TestAddRuntimeV1(t *testing.T) {
 				`,
 		},
 		{
-			description: "options from runc take precedence over default runtime",
+			description: "options from the default runtime take precedence over runc",
 			config: `
 			[plugins]
 			[plugins.cri]
@@ -186,14 +186,14 @@ func TestAddRuntimeV1(t *testing.T) {
 						BinaryName = "/usr/bin/default"
 						SystemdCgroup = false
 					[plugins.cri.containerd.runtimes.test]
-					privileged_without_host_devices = true
-					runtime_engine = "engine"
-					runtime_root = "root"
-					runtime_type = "type"
+					privileged_without_host_devices = false
+					runtime_engine = "defaultengine"
+					runtime_root = "defaultroot"
+					runtime_type = "defaulttype"
 					[plugins.cri.containerd.runtimes.test.options]
 						BinaryName = "/usr/bin/test"
 						Runtime = "/usr/bin/test"
-						SystemdCgroup = true
+						SystemdCgroup = false
 				`,
 		},
 	}

--- a/pkg/config/engine/containerd/config_v2.go
+++ b/pkg/config/engine/containerd/config_v2.go
@@ -19,6 +19,7 @@ package containerd
 import (
 	"fmt"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/toml"
 )
 
@@ -31,11 +32,7 @@ func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
 
 	config.Set("version", int64(2))
 
-	// By default we extract the runtime options from the runc settings; if this does not exist we get the options from the default runtime specified in the config.
-	runtimeNamesForConfig := []string{"runc"}
-	if name, ok := config.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "default_runtime_name"}).(string); ok && name != "" {
-		runtimeNamesForConfig = append(runtimeNamesForConfig, name)
-	}
+	runtimeNamesForConfig := engine.GetLowLevelRuntimes(c)
 	for _, r := range runtimeNamesForConfig {
 		options := config.GetSubtreeByPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", r})
 		if options == nil {

--- a/pkg/config/engine/docker/docker_test.go
+++ b/pkg/config/engine/docker/docker_test.go
@@ -213,3 +213,37 @@ func TestUpdateConfigRuntimes(t *testing.T) {
 
 	}
 }
+
+func TestGetRuntimeConfig(t *testing.T) {
+	c := map[string]interface{}{
+		"runtimes": map[string]interface{}{
+			"nvidia": map[string]interface{}{
+				"path": "nvidia-container-runtime",
+				"args": []string{},
+			},
+		},
+	}
+	cfg := Config(c)
+
+	testCases := []struct {
+		description string
+		runtime     string
+		expected    string
+	}{
+		{
+			description: "existing runtime",
+			runtime:     "nvidia",
+			expected:    "nvidia-container-runtime",
+		},
+		{
+			description: "non-existent runtime",
+			runtime:     "some-other-runtime",
+			expected:    "",
+		},
+	}
+	for _, tc := range testCases {
+		rc, err := cfg.GetRuntimeConfig(tc.runtime)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, rc.GetBinaryPath())
+	}
+}

--- a/pkg/config/engine/engine.go
+++ b/pkg/config/engine/engine.go
@@ -1,0 +1,63 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package engine
+
+import "strings"
+
+// GetBinaryPathsForRuntimes returns the list of binary paths for common runtimes.
+// The following list of runtimes is considered:
+//
+//	the default runtime, "runc", and "crun"
+//
+// If an nvidia* runtime is set as the default runtime, this is ignored.
+func GetBinaryPathsForRuntimes(cfg Interface) []string {
+
+	var binaryPaths []string
+	seen := make(map[string]bool)
+	for _, runtime := range GetLowLevelRuntimes(cfg) {
+		runtimeConfig, err := cfg.GetRuntimeConfig(runtime)
+		if err != nil {
+			// TODO: It will be useful to log the error when GetRuntimeConfig fails for a runtime
+			continue
+		}
+		binaryPath := runtimeConfig.GetBinaryPath()
+		if binaryPath == "" || seen[binaryPath] {
+			continue
+		}
+		seen[binaryPath] = true
+		binaryPaths = append(binaryPaths, binaryPath)
+	}
+
+	return binaryPaths
+}
+
+// GetLowLevelRuntimes returns a predefined list low-level runtimes from the specified config.
+// nvidia* runtimes are ignored.
+func GetLowLevelRuntimes(cfg Interface) []string {
+	var runtimes []string
+	isValidDefault := func(s string) bool {
+		if s == "" {
+			return false
+		}
+		// ignore nvidia* runtimes.
+		return !strings.HasPrefix(s, "nvidia")
+	}
+	if defaultRuntime := cfg.DefaultRuntime(); isValidDefault(defaultRuntime) {
+		runtimes = append(runtimes, defaultRuntime)
+	}
+	return append(runtimes, "runc", "crun")
+}

--- a/pkg/config/toml/source-cli.go
+++ b/pkg/config/toml/source-cli.go
@@ -1,0 +1,45 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package toml
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+type tomlCliSource struct {
+	command string
+	args    []string
+}
+
+func (c tomlCliSource) Load() (*Tree, error) {
+	//nolint:gosec  // Subprocess launched with a potential tainted input or cmd arguments
+	cmd := exec.Command(c.command, c.args...)
+
+	var outb bytes.Buffer
+	var errb bytes.Buffer
+
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		// TODO: Log to stderr in case of failure
+		return nil, fmt.Errorf("failed to run command %v %v: %w", c.command, c.args, err)
+	}
+
+	return LoadBytes(outb.Bytes())
+}

--- a/pkg/config/toml/source.go
+++ b/pkg/config/toml/source.go
@@ -33,3 +33,15 @@ func FromFile(path string) Loader {
 	}
 	return tomlFile(path)
 }
+
+// FromCommandLine creates a TOML source from the output of a shell command and its corresponding args.
+// If the command is empty, an empty config is returned.
+func FromCommandLine(cmd string, args ...string) Loader {
+	if len(cmd) == 0 {
+		return Empty
+	}
+	return &tomlCliSource{
+		command: cmd,
+		args:    args,
+	}
+}

--- a/tools/container/runtime/crio/crio.go
+++ b/tools/container/runtime/crio/crio.go
@@ -25,6 +25,7 @@ import (
 	cli "github.com/urfave/cli/v2"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine/crio"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/ocihook"
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container"
@@ -117,6 +118,7 @@ func setupConfig(o *container.Options) error {
 
 	cfg, err := crio.New(
 		crio.WithPath(o.Config),
+		crio.WithConfigSource(crio.CommandLineSource(o.HostRootMount)),
 	)
 	if err != nil {
 		return fmt.Errorf("unable to load config: %v", err)
@@ -168,6 +170,7 @@ func cleanupConfig(o *container.Options) error {
 
 	cfg, err := crio.New(
 		crio.WithPath(o.Config),
+		crio.WithConfigSource(crio.CommandLineSource(o.HostRootMount)),
 	)
 	if err != nil {
 		return fmt.Errorf("unable to load config: %v", err)
@@ -189,4 +192,14 @@ func cleanupConfig(o *container.Options) error {
 // RestartCrio restarts crio depending on the value of restartModeFlag
 func RestartCrio(o *container.Options) error {
 	return o.Restart("crio", func(string) error { return fmt.Errorf("supporting crio via signal is unsupported") })
+}
+
+func GetLowlevelRuntimePaths(o *container.Options) ([]string, error) {
+	cfg, err := crio.New(
+		crio.WithConfigSource(crio.CommandLineSource(o.HostRootMount)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load crio config: %w", err)
+	}
+	return engine.GetBinaryPathsForRuntimes(cfg), nil
 }

--- a/tools/container/runtime/docker/docker.go
+++ b/tools/container/runtime/docker/docker.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine/docker"
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container"
 )
@@ -95,4 +96,14 @@ func Cleanup(c *cli.Context, o *container.Options) error {
 // RestartDocker restarts docker depending on the value of restartModeFlag
 func RestartDocker(o *container.Options) error {
 	return o.Restart("docker", SignalDocker)
+}
+
+func GetLowlevelRuntimePaths(o *container.Options) ([]string, error) {
+	cfg, err := docker.New(
+		docker.WithPath(o.Config),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load docker config: %w", err)
+	}
+	return engine.GetBinaryPathsForRuntimes(cfg), nil
 }

--- a/tools/container/runtime/runtime.go
+++ b/tools/container/runtime/runtime.go
@@ -166,3 +166,16 @@ func Cleanup(c *cli.Context, opts *Options, runtime string) error {
 		return fmt.Errorf("undefined runtime %v", runtime)
 	}
 }
+
+func GetLowlevelRuntimePaths(opts *Options, runtime string) ([]string, error) {
+	switch runtime {
+	case containerd.Name:
+		return containerd.GetLowlevelRuntimePaths(&opts.Options, &opts.containerdOptions)
+	case crio.Name:
+		return crio.GetLowlevelRuntimePaths(&opts.Options)
+	case docker.Name:
+		return docker.GetLowlevelRuntimePaths(&opts.Options)
+	default:
+		return nil, fmt.Errorf("undefined runtime %v", runtime)
+	}
+}


### PR DESCRIPTION
Summary of changes made in this PR:

1. In CRI-O and Containerd config engines, retrieve the container runtime config commands via the following commands:
    i. `crio status config`
    ii. `containerd config dump`

2. When configuring CRI-O runtime, we prioritise the runtime designated as the `default_runtime` in the config when setting up the `nvidia` runtime handler as opposed to favouring the `runc` runtime handler at all times. This is needed as vanilla cri-o packages have `crun` as the default low-level-runtime. Live-swapping the low-level runtime causes the running containers in a cluster to break

3. Add the full path of the low-level runtime to the `nvidia-container-runtime.runtimes` config value, so that `nvidia-container-runtime` binds to a low-level runtime binary that cannot be resolved in the `PATH`.