### PR TITLE
Skip injection of nvidia-persistenced socket by default

### DIFF
--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -89,6 +89,12 @@ func doPrestart() {
 	rootfs := getRootfsPath(container)
 
 	args := []string{getCLIPath(cli)}
+
+	// Only include the nvidia-persistenced socket if it is explicitly enabled.
+	if !hook.Features.IncludePersistencedSocket.IsEnabled() {
+		args = append(args, "--no-persistenced")
+	}
+
 	if cli.Root != "" {
 		args = append(args, fmt.Sprintf("--root=%s", cli.Root))
 	}

--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -60,6 +60,8 @@ type options struct {
 		files          cli.StringSlice
 		ignorePatterns cli.StringSlice
 	}
+
+	includePersistencedSocket bool
 }
 
 // NewCommand constructs a generate-cdi command with the specified logger
@@ -169,6 +171,11 @@ func (m command) build() *cli.Command {
 			Usage:       "Specify a pattern the CSV mount specifications.",
 			Destination: &opts.csv.ignorePatterns,
 		},
+		&cli.BoolFlag{
+			Name:        "include-persistenced-socket",
+			Usage:       "Include the nvidia-persistenced socket in the generated CDI specification.",
+			Destination: &opts.includePersistencedSocket,
+		},
 	}
 
 	return &c
@@ -273,6 +280,7 @@ func (m command) generateSpec(opts *options) (spec.Interface, error) {
 		nvcdi.WithLibrarySearchPaths(opts.librarySearchPaths.Value()),
 		nvcdi.WithCSVFiles(opts.csv.files.Value()),
 		nvcdi.WithCSVIgnorePatterns(opts.csv.ignorePatterns.Value()),
+		nvcdi.WithOptInFeature("include-persistenced-socket", opts.includePersistencedSocket),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CDI library: %v", err)

--- a/internal/discover/ipc.go
+++ b/internal/discover/ipc.go
@@ -24,7 +24,13 @@ import (
 type ipcMounts mounts
 
 // NewIPCDiscoverer creats a discoverer for NVIDIA IPC sockets.
-func NewIPCDiscoverer(logger logger.Interface, driverRoot string) (Discover, error) {
+func NewIPCDiscoverer(logger logger.Interface, driverRoot string, includePersistencedSocket bool) (Discover, error) {
+	var requiredSockets []string
+	if includePersistencedSocket {
+		requiredSockets = append(requiredSockets, "/nvidia-persistenced/socket")
+	}
+	requiredSockets = append(requiredSockets, "/nvidia-fabricmanager/socket")
+
 	sockets := newMounts(
 		logger,
 		lookup.NewFileLocator(
@@ -34,10 +40,7 @@ func NewIPCDiscoverer(logger logger.Interface, driverRoot string) (Discover, err
 			lookup.WithCount(1),
 		),
 		driverRoot,
-		[]string{
-			"/nvidia-persistenced/socket",
-			"/nvidia-fabricmanager/socket",
-		},
+		requiredSockets,
 	)
 
 	mps := newMounts(

--- a/internal/modifier/cdi.go
+++ b/internal/modifier/cdi.go
@@ -189,6 +189,7 @@ func generateAutomaticCDISpec(logger logger.Interface, cfg *config.Config, devic
 		nvcdi.WithDriverRoot(cfg.NVIDIAContainerCLIConfig.Root),
 		nvcdi.WithVendor("runtime.nvidia.com"),
 		nvcdi.WithClass("gpu"),
+		nvcdi.WithOptInFeature("include-persistenced-socket", cfg.Features.IncludePersistencedSocket.IsEnabled()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct CDI library: %w", err)

--- a/internal/modifier/gated.go
+++ b/internal/modifier/gated.go
@@ -46,7 +46,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 	driverRoot := cfg.NVIDIAContainerCLIConfig.Root
 	devRoot := cfg.NVIDIAContainerCLIConfig.Root
 
-	if cfg.Features.IsEnabled(config.FeatureGDS, image) {
+	if cfg.Features.IsEnabledInEnvironment(config.FeatureGDS, image) {
 		d, err := discover.NewGDSDiscoverer(logger, driverRoot, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for GDS devices: %w", err)
@@ -54,7 +54,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 		discoverers = append(discoverers, d)
 	}
 
-	if cfg.Features.IsEnabled(config.FeatureMOFED, image) {
+	if cfg.Features.IsEnabledInEnvironment(config.FeatureMOFED, image) {
 		d, err := discover.NewMOFEDDiscoverer(logger, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for MOFED devices: %w", err)
@@ -62,7 +62,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 		discoverers = append(discoverers, d)
 	}
 
-	if cfg.Features.IsEnabled(config.FeatureNVSWITCH, image) {
+	if cfg.Features.IsEnabledInEnvironment(config.FeatureNVSWITCH, image) {
 		d, err := discover.NewNvSwitchDiscoverer(logger, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for NVSWITCH devices: %w", err)
@@ -70,7 +70,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 		discoverers = append(discoverers, d)
 	}
 
-	if cfg.Features.IsEnabled(config.FeatureGDRCopy, image) {
+	if cfg.Features.IsEnabledInEnvironment(config.FeatureGDRCopy, image) {
 		d, err := discover.NewGDRCopyDiscoverer(logger, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for GDRCopy devices: %w", err)

--- a/pkg/nvcdi/common-nvml.go
+++ b/pkg/nvcdi/common-nvml.go
@@ -41,7 +41,7 @@ func (l *nvmllib) newCommonNVMLDiscoverer() (discover.Discover, error) {
 		l.logger.Warningf("failed to create discoverer for graphics mounts: %v", err)
 	}
 
-	driverFiles, err := NewDriverDiscoverer(l.logger, l.driver, l.nvidiaCDIHookPath, l.ldconfigPath, l.nvmllib)
+	driverFiles, err := l.NewDriverDiscoverer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for driver files: %v", err)
 	}

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -132,6 +132,9 @@ func New(opts ...Option) (Interface, error) {
 		if l.vendor == "" {
 			l.vendor = "management.nvidia.com"
 		}
+		// For management specifications we always allow the fabricmanager and
+		// persistenced sockets.
+		WithOptInFeature("include-persistenced-socket", true)(l)
 		lib = (*managementlib)(l)
 	case ModeNvml:
 		lib = (*nvmllib)(l)

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -63,6 +63,8 @@ type nvcdilib struct {
 	infolib info.Interface
 
 	mergedDeviceOptions []transform.MergedDeviceOption
+
+	optInFeatures map[string]bool
 }
 
 // New creates a new nvcdi library

--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -66,7 +66,7 @@ func (m *managementlib) GetCommonEdits() (*cdi.ContainerEdits, error) {
 		return nil, fmt.Errorf("failed to get CUDA version: %v", err)
 	}
 
-	driver, err := newDriverVersionDiscoverer(m.logger, m.driver, m.nvidiaCDIHookPath, m.ldconfigPath, version)
+	driver, err := (*nvcdilib)(m).newDriverVersionDiscoverer(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver library discoverer: %v", err)
 	}

--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -155,3 +155,14 @@ func WithLibrarySearchPaths(paths []string) Option {
 		o.librarySearchPaths = paths
 	}
 }
+
+// WithOptInFeature sets a specific opt-in feature.
+// Note that previous opt-in-features are not removed.
+func WithOptInFeature(feature string, enabled bool) Option {
+	return func(n *nvcdilib) {
+		if n.optInFeatures == nil {
+			n.optInFeatures = make(map[string]bool)
+		}
+		n.optInFeatures[feature] = enabled
+	}
+}

--- a/tools/container/toolkit/toolkit.go
+++ b/tools/container/toolkit/toolkit.go
@@ -81,6 +81,8 @@ type options struct {
 	acceptNVIDIAVisibleDevicesAsVolumeMounts   bool
 
 	ignoreErrors bool
+
+	optInFeatures cli.StringSlice
 }
 
 func main() {
@@ -249,6 +251,12 @@ func main() {
 			Value:       cli.NewStringSlice("control"),
 			Destination: &opts.createDeviceNodes,
 			EnvVars:     []string{"CREATE_DEVICE_NODES"},
+		},
+		&cli.StringSliceFlag{
+			Name:        "opt-in-feature",
+			Hidden:      true,
+			Destination: &opts.optInFeatures,
+			EnvVars:     []string{"NVIDIA_CONTAINER_TOOLKIT_OPT_IN_FEATURES"},
 		},
 	}
 
@@ -518,6 +526,10 @@ func installToolkitConfig(c *cli.Context, toolkitConfigPath string, nvidiaContai
 		"nvidia-container-runtime.runtimes":                      opts.ContainerRuntimeRuntimes,
 		"nvidia-container-cli.debug":                             opts.ContainerCLIDebug,
 	}
+	for _, feature := range opts.optInFeatures.Value() {
+		optionalConfigValues["features."+feature] = true
+	}
+
 	for key, value := range optionalConfigValues {
 		if !c.IsSet(key) {
 			log.Infof("Skipping unset option: %v", key)


### PR DESCRIPTION
This changes skips the injection of the nvidia-persistenced socket by default.

An include-persistenced-socket feature flag is added to allow the
injection of this socket to be explicitly requested.

See https://github.com/NVIDIA/libnvidia-container/pull/283
