### PR TITLE
sync go.mod with go mod tidy in deployments/devel

### DIFF
--- a/deployments/devel/Makefile
+++ b/deployments/devel/Makefile
@@ -34,3 +34,10 @@ DOCKERFILE_CONTEXT = deployments/devel
 		--tag $(BUILDIMAGE) \
 		-f $(DOCKERFILE_DEVEL) \
 		$(DOCKERFILE_CONTEXT)
+
+modules:
+	go mod tidy
+	go mod verify
+
+check-modules: modules
+	git diff --quiet HEAD -- go.mod go.sum

--- a/deployments/devel/go.mod
+++ b/deployments/devel/go.mod
@@ -1,6 +1,8 @@
 module github.com/NVIDIA/k8s-device-plugin/deployments/devel
 
-go 1.22
+go 1.22.1
+
+toolchain go1.23.1
 
 require (
 	github.com/golangci/golangci-lint v1.60.1


### PR DESCRIPTION
The `go.mod` file is currently out-of-sync as a `go mod tidy` results in a modification of the same. I've also added a make target to ensure no uncommitted changes remain after a `go mod tidy` run