### PR TITLE
[no-relnote] Move --no-persistenced flag to after configure

### DIFF
--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -90,11 +90,6 @@ func doPrestart() {
 
 	args := []string{getCLIPath(cli)}
 
-	// Only include the nvidia-persistenced socket if it is explicitly enabled.
-	if !hook.Features.IncludePersistencedSocket.IsEnabled() {
-		args = append(args, "--no-persistenced")
-	}
-
 	if cli.Root != "" {
 		args = append(args, fmt.Sprintf("--root=%s", cli.Root))
 	}
@@ -116,6 +111,11 @@ func doPrestart() {
 		args = append(args, fmt.Sprintf("--user=%s", cli.User))
 	}
 	args = append(args, "configure")
+
+	// Only include the nvidia-persistenced socket if it is explicitly enabled.
+	if !hook.Features.IncludePersistencedSocket.IsEnabled() {
+		args = append(args, "--no-persistenced")
+	}
 
 	if ldconfigPath := cli.NormalizeLDConfigPath(); ldconfigPath != "" {
 		args = append(args, fmt.Sprintf("--ldconfig=%s", ldconfigPath))


### PR DESCRIPTION
The `--no-persistenced` flag needs to be specified *after* the `configure` subcommand.

See #694 