### PR TITLE
[no-relnote] Don't check for submodule changes

### DIFF
--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -31,17 +31,8 @@ else
     targets=${all[@]}
 fi
 
-if [[ x"${SKIP_UPDATE_COMPONENTS}" != x"yes" ]]; then
-    echo "Updating components"
-    "${SCRIPTS_DIR}/update-components.sh"
-    if [[ -n $(git status -s third_party) && ${ALLOW_LOCAL_COMPONENT_CHANGES} != "true" ]]; then
-        echo "ERROR: Building with local component changes."
-        echo "Commit pending changes or rerun with ALLOW_LOCAL_COMPONENT_CHANGES='true'"
-        exit 1
-    fi
-else
-    echo "Skipping update of components"
-fi
+git submodule update --init
+git submodule status
 
 eval $(${SCRIPTS_DIR}/get-component-versions.sh)
 


### PR DESCRIPTION
With the move to dependabot to udpate the libnvidia-container submodule it is no longer required to have checks in place that ensure that this is up to date when building.

In addition when re-building old commits in CI, for example we explicitly do NOT want to have this check.