### PR TITLE
Also search for driver libraries in vdpau

### DIFF
--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -200,7 +200,10 @@ func getVersionLibs(logger logger.Interface, driver *root.Driver, version string
 
 	libraries := lookup.NewFileLocator(
 		lookup.WithLogger(logger),
-		lookup.WithSearchPaths(libRoot),
+		lookup.WithSearchPaths(
+			libRoot,
+			filepath.Join(libRoot, "vdpau"),
+		),
 		lookup.WithOptional(true),
 	)
 


### PR DESCRIPTION
This change adds the vdpau subfolder to the paths searched for driver libraries. This allows the libvdpau_nvidia.so.RM_VERSION library to also be discovered.