### PR TITLE
add go modules check for deployments/devel

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -49,7 +49,9 @@ jobs:
         args: -v --timeout 5m
         skip-cache: true
     - name: Check golang modules
-      run: make check-vendor
+      run: | 
+        make check-vendor
+        make -C deployments/devel check-modules
   test:
     name: Unit test
     runs-on: ubuntu-latest

--- a/deployments/devel/go.mod
+++ b/deployments/devel/go.mod
@@ -1,6 +1,7 @@
 module github.com/NVIDIA/k8s-device-plugin/deployments/devel
 
-go 1.22.1
+go 1.23
+
 toolchain go1.23.1
 
 require (


### PR DESCRIPTION
Adding the second go mod check to github Actions so we catch out-of-sync go mods before they are merged to main

This PR is a follow-up of https://github.com/NVIDIA/nvidia-container-toolkit/pull/702