### PR TITLE
fetch current container runtime config through the command line

### DIFF
--- a/internal/config/toml.go
+++ b/internal/config/toml.go
@@ -170,9 +170,24 @@ func (t *Toml) Get(key string) interface{} {
 	return (*toml.Tree)(t).Get(key)
 }
 
+// GetDefault returns the value for the specified key and falls back to the default value if the Get call fails
+func (t *Toml) GetDefault(key string, def interface{}) interface{} {
+	val := t.Get(key)
+	if val == nil {
+		return def
+	}
+	return val
+}
+
 // Set sets the specified key to the specified value in the TOML config.
 func (t *Toml) Set(key string, value interface{}) {
 	(*toml.Tree)(t).Set(key, value)
+}
+
+// WriteTo encode the Tree as Toml and writes it to the writer w.
+// Returns the number of bytes written in case of success, or an error if anything happened.
+func (t *Toml) WriteTo(w io.Writer) (int64, error) {
+	return (*toml.Tree)(t).WriteTo(w)
 }
 
 // commentDefaults applies the required comments for default values to the Toml.

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -23,4 +23,10 @@ type Interface interface {
 	Set(string, interface{})
 	RemoveRuntime(string) error
 	Save(string) (int64, error)
+	GetRuntimeConfig(string) (Runtime, error)
+}
+
+// Runtime defines the interface to query container runtime handler configuration
+type Runtime interface {
+	GetBinPath() string
 }

--- a/pkg/config/engine/containerd/config_v2.go
+++ b/pkg/config/engine/containerd/config_v2.go
@@ -22,6 +22,17 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/toml"
 )
 
+type ctrdCfgV2Runtime struct {
+	tree *toml.Tree
+}
+
+func (c *ctrdCfgV2Runtime) GetBinPath() string {
+	if binPath, ok := c.tree.GetPath([]string{"options", "BinaryName"}).(string); ok {
+		return binPath
+	}
+	return ""
+}
+
 // AddRuntime adds a runtime to the containerd config
 func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
 	if c == nil || c.Tree == nil {

--- a/pkg/config/engine/containerd/containerd.go
+++ b/pkg/config/engine/containerd/containerd.go
@@ -98,3 +98,14 @@ func (c *Config) parseVersion(useLegacyConfig bool) (int, error) {
 		return -1, fmt.Errorf("unsupported type for version field: %v", v)
 	}
 }
+
+func (c *Config) GetRuntimeConfig(name string) (engine.Runtime, error) {
+	if c == nil || c.Tree == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	config := *c.Tree
+	runtimeData := config.GetSubtreeByPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", name})
+	return &ctrdCfgV2Runtime{
+		tree: runtimeData,
+	}, nil
+}

--- a/pkg/config/engine/crio/crio_test.go
+++ b/pkg/config/engine/crio/crio_test.go
@@ -91,7 +91,7 @@ func TestAddRuntime(t *testing.T) {
 			`,
 		},
 		{
-			description: "options from runc take precedence over default runtime",
+			description: "options from runc do NOT take precedence over default runtime",
 			config: `
 			[crio]
 			[crio.runtime]
@@ -120,7 +120,7 @@ func TestAddRuntime(t *testing.T) {
 			[crio.runtime.runtimes.test]
 			runtime_path = "/usr/bin/test"
 			runtime_type = "oci"
-			runc_option = "option"
+			default_option = "option"
 			`,
 		},
 	}

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
@@ -131,4 +132,8 @@ func (c Config) Save(path string) (int64, error) {
 
 	n, err := config.Raw(path).Write(output)
 	return int64(n), err
+}
+
+func (c *Config) GetRuntimeConfig(name string) (engine.Runtime, error) {
+	return nil, errors.New("Not Implemented")
 }

--- a/pkg/config/toml/source-cli.go
+++ b/pkg/config/toml/source-cli.go
@@ -1,0 +1,44 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package toml
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+type tomlCliSource struct {
+	command string
+	args    []string
+}
+
+func (c tomlCliSource) Load() (*Tree, error) {
+	//nolint:gosec  // Subprocess launched with a potential tainted input or cmd arguments
+	cmd := exec.Command(c.command, c.args...)
+
+	var outb bytes.Buffer
+	var errb bytes.Buffer
+
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run command %v %v: %w", c.command, c.args, err)
+	}
+
+	return LoadBytes(outb.Bytes())
+}

--- a/pkg/config/toml/source.go
+++ b/pkg/config/toml/source.go
@@ -33,3 +33,16 @@ func FromFile(path string) Loader {
 	}
 	return tomlFile(path)
 }
+
+// FromCommandLine creates a TOML source from the output
+// of a shell command specified via string slice.
+// If an empty slice is passed an empty toml config is used.
+func FromCommandLine(params []string) Loader {
+	if len(params) == 0 {
+		return Empty
+	}
+	return &tomlCliSource{
+		command: params[0],
+		args:    params[1:],
+	}
+}


### PR DESCRIPTION
Summary of changes made in this PR:

In CRI-O and Containerd config engines, retrieve the container runtime config commands via the following commands:
i. crio status config
ii. containerd config dump

When configuring CRI-O runtime, we prioritise the runtime designated as the default_runtime in the config when setting up the nvidia runtime handler as opposed to favouring the runc runtime handler at all times. This is needed as vanilla cri-o packages have crun as the default low-level-runtime. Live-swapping the low-level runtime causes the running containers in a cluster to break

Add the full path of the low-level runtime to the nvidia-container-runtime.runtimes config value, so that nvidia-container-runtime binds to a low-level runtime binary that cannot be resolved in the PATH.

This is the latest iteration of the #686 PR that is most up-to-date and will supersede the same