### PR TITLE
Ensure that nvsandboxutils is available for version

### DIFF
--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -263,6 +263,10 @@ func (l *nvcdilib) getCudaVersionNvml() (string, error) {
 }
 
 func (l *nvcdilib) getCudaVersionNvsandboxutils() (string, error) {
+	if l.nvsandboxutilslib == nil {
+		return "", fmt.Errorf("libnvsandboxutils is not available")
+	}
+
 	// Sandboxutils initialization should happen before this function is called
 	version, ret := l.nvsandboxutilslib.GetDriverVersion()
 	if ret != nvsandboxutils.SUCCESS {

--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -28,6 +28,7 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/edits"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/cuda"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvsandboxutils"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec"
 )
 
@@ -61,6 +62,19 @@ func (m *managementlib) GetAllDeviceSpecs() ([]specs.Device, error) {
 
 // GetCommonEdits returns the common edits for use in managementlib containers.
 func (m *managementlib) GetCommonEdits() (*cdi.ContainerEdits, error) {
+	if m.nvsandboxutilslib != nil {
+		if r := m.nvsandboxutilslib.Init(m.driverRoot); r != nvsandboxutils.SUCCESS {
+			m.logger.Warningf("Failed to init nvsandboxutils: %v; ignoring", r)
+			m.nvsandboxutilslib = nil
+		}
+		defer func() {
+			if m.nvsandboxutilslib == nil {
+				return
+			}
+			_ = m.nvsandboxutilslib.Shutdown()
+		}()
+	}
+
 	version, err := m.getCudaVersion()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CUDA version: %v", err)


### PR DESCRIPTION
This fix ensures that `nvsandboxutils` is available when generating management CDI specifications.

Without the fix:
```
./nvidia-ctk cdi generate --mode=management > /dev/null
INFO[0000] Using /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.515.105.01
WARN[0000] Ignoring error in locating libnvidia-sandboxutils.so.1: pattern libnvidia-sandboxutils.so.1 not found
64-bit library libnvidia-sandboxutils.so.1: not found
INFO[0000] Selecting /dev/nvidia-fs0 as /dev/nvidia-fs0
INFO[0000] Selecting /dev/nvidia-fs1 as /dev/nvidia-fs1
INFO[0000] Selecting /dev/nvidia-fs10 as /dev/nvidia-fs10
INFO[0000] Selecting /dev/nvidia-fs11 as /dev/nvidia-fs11
INFO[0000] Selecting /dev/nvidia-fs12 as /dev/nvidia-fs12
INFO[0000] Selecting /dev/nvidia-fs13 as /dev/nvidia-fs13
INFO[0000] Selecting /dev/nvidia-fs14 as /dev/nvidia-fs14
INFO[0000] Selecting /dev/nvidia-fs15 as /dev/nvidia-fs15
INFO[0000] Selecting /dev/nvidia-fs2 as /dev/nvidia-fs2
INFO[0000] Selecting /dev/nvidia-fs3 as /dev/nvidia-fs3
INFO[0000] Selecting /dev/nvidia-fs4 as /dev/nvidia-fs4
INFO[0000] Selecting /dev/nvidia-fs5 as /dev/nvidia-fs5
INFO[0000] Selecting /dev/nvidia-fs6 as /dev/nvidia-fs6
INFO[0000] Selecting /dev/nvidia-fs7 as /dev/nvidia-fs7
INFO[0000] Selecting /dev/nvidia-fs8 as /dev/nvidia-fs8
INFO[0000] Selecting /dev/nvidia-fs9 as /dev/nvidia-fs9
INFO[0000] Selecting /dev/nvidia-modeset as /dev/nvidia-modeset
INFO[0000] Selecting /dev/nvidia-nvswitchctl as /dev/nvidia-nvswitchctl
INFO[0000] Selecting /dev/nvidia-uvm as /dev/nvidia-uvm
INFO[0000] Selecting /dev/nvidia-uvm-tools as /dev/nvidia-uvm-tools
INFO[0000] Selecting /dev/nvidia0 as /dev/nvidia0
INFO[0000] Selecting /dev/nvidia1 as /dev/nvidia1
INFO[0000] Selecting /dev/nvidia2 as /dev/nvidia2
INFO[0000] Selecting /dev/nvidia3 as /dev/nvidia3
INFO[0000] Selecting /dev/nvidia4 as /dev/nvidia4
INFO[0000] Selecting /dev/nvidia5 as /dev/nvidia5
INFO[0000] Selecting /dev/nvidia6 as /dev/nvidia6
INFO[0000] Selecting /dev/nvidia7 as /dev/nvidia7
INFO[0000] Selecting /dev/nvidiactl as /dev/nvidiactl
INFO[0000] Selecting /dev/nvidia-caps/nvidia-cap1 as /dev/nvidia-caps/nvidia-cap1
INFO[0000] Selecting /dev/nvidia-caps/nvidia-cap2 as /dev/nvidia-caps/nvidia-cap2
./nvidia-ctk: symbol lookup error: ./nvidia-ctk: undefined symbol: nvSandboxUtilsGetDriverVersion
```

With the fix:
```
$ ./nvidia-ctk cdi generate --mode=management > /dev/null
$ echo $?
0
```