### PR TITLE
Add -z,lazy to LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 cmds: $(CMD_TARGETS)
 
 ifneq ($(shell uname),Darwin)
-EXTLDFLAGS = -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files
+EXTLDFLAGS = -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files -Wl,-z,lazy
 else
 EXTLDFLAGS = -Wl,-undefined,dynamic_lookup
 endif


### PR DESCRIPTION
This fixes undefined symbol errors on platforms where -z,lazy may not be the default.

This was inadvertently removed in #333 and replaced with `-Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files` which seems to be equivalent on some systems.