### PR TITLE
Add imex channels to management CDI spec

### DIFF
--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -131,6 +131,7 @@ func (m *managementlib) newManagementDeviceDiscoverer() (discover.Discover, erro
 			"/dev/nvidia-uvm-tools",
 			"/dev/nvidia-uvm",
 			"/dev/nvidiactl",
+			"/dev/nvidia-caps-imex-channels/channel*",
 		},
 	)
 


### PR DESCRIPTION
This changes adds IMEX channel devices to the management CDI spec.

Note that these devices nodes have to exist at the point of spec generation.

Part of https://github.com/NVIDIA/cloud-native-team/issues/113