### PR TITLE
minor cleanup and improvements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 10m
+  timeout: 10m
 
 linters:
   enable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@
 ## v1.14.0-rc.2
 * Fix bug causing incorrect nvidia-smi symlink to be created on WSL2 systems with multiple driver roots.
 * Remove dependency on coreutils when installing package on RPM-based systems.
-* Create ouput folders if required when running `nvidia-ctk runtime configure`
+* Create output folders if required when running `nvidia-ctk runtime configure`
 * Generate default config as post-install step.
 * Added support for detecting GSP firmware at custom paths when generating CDI specifications.
 * Added logic to skip the extraction of image requirements if `NVIDIA_DISABLE_REQUIRES` is set to `true`.

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -54,7 +54,7 @@ type command struct {
 	logger logger.Interface
 }
 
-// NewCommand constructs an configure command with the specified logger
+// NewCommand constructs a configure command with the specified logger
 func NewCommand(logger logger.Interface) *cli.Command {
 	c := command{
 		logger: logger,
@@ -289,7 +289,7 @@ func (m command) configureConfigFile(c *cli.Context, config *config) error {
 		return fmt.Errorf("failed to enable CDI in %s: %w", config.runtime, err)
 	}
 
-	outputPath := config.getOuputConfigPath()
+	outputPath := config.getOutputConfigPath()
 	n, err := cfg.Save(outputPath)
 	if err != nil {
 		return fmt.Errorf("unable to flush config: %v", err)
@@ -346,8 +346,8 @@ func (c *config) getCommandConfigSource() toml.Loader {
 	return toml.Empty
 }
 
-// getOuputConfigPath returns the configured config path or "" if dry-run is enabled
-func (c *config) getOuputConfigPath() string {
+// getOutputConfigPath returns the configured config path or "" if dry-run is enabled
+func (c *config) getOutputConfigPath() string {
 	if c.dryRun {
 		return ""
 	}

--- a/internal/platform-support/tegra/csv.go
+++ b/internal/platform-support/tegra/csv.go
@@ -62,7 +62,7 @@ func (o tegraOptions) newDiscovererFromCSVFiles() (discover.Discover, error) {
 		o.nvidiaCDIHookPath,
 	)
 
-	// We process the expliclitlty requested symlinks.
+	// We process the explicitly requested symlinks.
 	symlinkTargets := o.ignorePatterns.Apply(targetsByType[csv.MountSpecSym]...)
 	o.logger.Debugf("Filtered symlink targets: %v", symlinkTargets)
 	symlinks := discover.NewMounts(

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -141,14 +141,14 @@ func (c *ConfigV1) RemoveRuntime(name string) error {
 	return nil
 }
 
-// SetOption sets the specified containerd option.
+// Set sets the specified containerd option.
 func (c *ConfigV1) Set(key string, value interface{}) {
 	config := *c.Tree
 	config.SetPath([]string{"plugins", "cri", "containerd", key}, value)
 	*c.Tree = config
 }
 
-// Save wrotes the config to a file
+// Save writes the config to a file
 func (c ConfigV1) Save(path string) (int64, error) {
 	return (Config)(c).Save(path)
 }

--- a/pkg/config/engine/containerd/containerd.go
+++ b/pkg/config/engine/containerd/containerd.go
@@ -41,7 +41,8 @@ type containerdCfgRuntime struct {
 
 var _ engine.RuntimeConfig = (*containerdCfgRuntime)(nil)
 
-// GetBinaryPath retrieves the path to the actual low-level runtime binary invoked by the runtime handler
+// GetBinaryPath retrieves the path to the low-level runtime binary for a runtime.
+// If no path is available, the empty string is returned.
 func (c *containerdCfgRuntime) GetBinaryPath() string {
 	if c == nil || c.tree == nil {
 		return ""

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -36,7 +36,8 @@ type crioRuntime struct {
 
 var _ engine.RuntimeConfig = (*crioRuntime)(nil)
 
-// GetBinaryPath retrieves the path to the actual low-level runtime binary invoked by the runtime handler
+// GetBinaryPath retrieves the path to the low-level runtime binary for a runtime.
+// If no path is available, the empty string is returned.
 func (c *crioRuntime) GetBinaryPath() string {
 	if c.tree != nil {
 		if binaryPath, ok := c.tree.GetPath([]string{"runtime_path"}).(string); ok {

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -39,7 +39,8 @@ type dockerRuntime map[string]interface{}
 
 var _ engine.RuntimeConfig = (*dockerRuntime)(nil)
 
-// GetBinaryPath retrieves the path to the actual low-level runtime binary invoked by the runtime handler
+// GetBinaryPath retrieves the path to the low-level runtime binary for a runtime.
+// If no path is available, the empty string is returned.
 func (d dockerRuntime) GetBinaryPath() string {
 	if d == nil {
 		return ""

--- a/tools/container/nvidia-toolkit/run.go
+++ b/tools/container/nvidia-toolkit/run.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
-	cli "github.com/urfave/cli/v2"
-	unix "golang.org/x/sys/unix"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sys/unix"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container/runtime"
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container/toolkit"
@@ -19,12 +19,10 @@ import (
 const (
 	toolkitPidFilename = "toolkit.pid"
 	defaultPidFile     = "/run/nvidia/toolkit/" + toolkitPidFilename
-	toolkitCommand     = "toolkit"
 	toolkitSubDir      = "toolkit"
 
-	defaultRuntime       = "docker"
-	defaultRuntimeArgs   = ""
-	defaultHostRootMount = "/host"
+	defaultRuntime     = "docker"
+	defaultRuntimeArgs = ""
 )
 
 var availableRuntimes = map[string]struct{}{"docker": {}, "crio": {}, "containerd": {}}
@@ -192,7 +190,7 @@ func Run(c *cli.Context, o *options) error {
 }
 
 // ParseArgs checks if a single positional argument was defined and extracts this the root.
-// If no positional arguments are defined, the it is assumed that the root is specified as a flag.
+// If no positional arguments are defined, it is assumed that the root is specified as a flag.
 func ParseArgs(args []string) ([]string, string, error) {
 	log.Infof("Parsing arguments")
 


### PR DESCRIPTION
i) Fix some typo errors
ii) Remove redundant import aliases
iii) Remove `deadline`, which is an invalid field in `golangci-lint.yml`, and replace it with `timeout`
