### PR TITLE
Add disableIMEXChannelCreation feature flag

### DIFF
--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -95,6 +95,9 @@ func doPrestart() {
 	if cli.LoadKmods {
 		args = append(args, "--load-kmods")
 	}
+	if hook.Features.DisableImexChannelCreation.IsEnabled() {
+		args = append(args, "--no-create-imex-channels")
+	}
 	if cli.NoPivot {
 		args = append(args, "--no-pivot")
 	}

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -18,6 +18,9 @@ package config
 
 // features specifies a set of named features.
 type features struct {
+	// DisableImexChannelCreation ensures that the implicit creation of
+	// requested IMEX channels is skipped when invoking the nvidia-container-cli.
+	DisableImexChannelCreation *feature `toml:"disable-imex-channel-creation,omitempty"`
 }
 
 //nolint:unused


### PR DESCRIPTION
This change adds a `disableIMEXChannelCreation` feature flag that allows the `--no-create-imex-channels` option added  in https://github.com/NVIDIA/libnvidia-container/pull/286 to be toggled.

This allows IMEX channels to be exposed in environment where they are expected to be created up front.

See also https://github.com/NVIDIA/k8s-device-plugin/pull/985