### PR TITLE
Remove ability to set per-container features in the config file

### DIFF
--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -16,70 +16,19 @@
 
 package config
 
-type featureName string
-
-const (
-	FeatureGDS      = featureName("gds")
-	FeatureMOFED    = featureName("mofed")
-	FeatureNVSWITCH = featureName("nvswitch")
-	FeatureGDRCopy  = featureName("gdrcopy")
-)
-
 // features specifies a set of named features.
 type features struct {
-	GDS      *feature `toml:"gds,omitempty"`
-	MOFED    *feature `toml:"mofed,omitempty"`
-	NVSWITCH *feature `toml:"nvswitch,omitempty"`
-	GDRCopy  *feature `toml:"gdrcopy,omitempty"`
 }
 
+//nolint:unused
 type feature bool
 
-// IsEnabled checks whether a specified named feature is enabled.
-// An optional list of environments to check for feature-specific environment
-// variables can also be supplied.
-func (fs features) IsEnabled(n featureName, in ...getenver) bool {
-	featureEnvvars := map[featureName]string{
-		FeatureGDS:      "NVIDIA_GDS",
-		FeatureMOFED:    "NVIDIA_MOFED",
-		FeatureNVSWITCH: "NVIDIA_NVSWITCH",
-		FeatureGDRCopy:  "NVIDIA_GDRCOPY",
-	}
-
-	envvar := featureEnvvars[n]
-	switch n {
-	case FeatureGDS:
-		return fs.GDS.isEnabled(envvar, in...)
-	case FeatureMOFED:
-		return fs.MOFED.isEnabled(envvar, in...)
-	case FeatureNVSWITCH:
-		return fs.NVSWITCH.isEnabled(envvar, in...)
-	case FeatureGDRCopy:
-		return fs.GDRCopy.isEnabled(envvar, in...)
-	default:
-		return false
-	}
-}
-
-// isEnabled checks whether a feature is enabled.
-// If the enabled value is explicitly set, this is returned, otherwise the
-// associated envvar is checked in the specified getenver for the string "enabled"
-// A CUDA container / image can be passed here.
-func (f *feature) isEnabled(envvar string, ins ...getenver) bool {
+// IsEnabled checks whether a feature is explicitly enabled.
+//
+//nolint:unused
+func (f *feature) IsEnabled() bool {
 	if f != nil {
 		return bool(*f)
 	}
-	if envvar == "" {
-		return false
-	}
-	for _, in := range ins {
-		if in.Getenv(envvar) == "enabled" {
-			return true
-		}
-	}
 	return false
-}
-
-type getenver interface {
-	Getenv(string) string
 }

--- a/internal/config/image/cuda_image.go
+++ b/internal/config/image/cuda_image.go
@@ -274,3 +274,7 @@ func (i CUDA) CDIDevicesFromMounts() []string {
 	}
 	return devices
 }
+
+func (i CUDA) IsEnabled(envvar string) bool {
+	return i.Getenv(envvar) == "enabled"
+}

--- a/internal/modifier/gated.go
+++ b/internal/modifier/gated.go
@@ -46,7 +46,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 	driverRoot := cfg.NVIDIAContainerCLIConfig.Root
 	devRoot := cfg.NVIDIAContainerCLIConfig.Root
 
-	if cfg.Features.IsEnabled(config.FeatureGDS, image) {
+	if image.Getenv("NVIDIA_GDS") == "enabled" {
 		d, err := discover.NewGDSDiscoverer(logger, driverRoot, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for GDS devices: %w", err)
@@ -54,7 +54,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 		discoverers = append(discoverers, d)
 	}
 
-	if cfg.Features.IsEnabled(config.FeatureMOFED, image) {
+	if image.Getenv("NVIDIA_MOFED") == "enabled" {
 		d, err := discover.NewMOFEDDiscoverer(logger, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for MOFED devices: %w", err)
@@ -62,7 +62,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 		discoverers = append(discoverers, d)
 	}
 
-	if cfg.Features.IsEnabled(config.FeatureNVSWITCH, image) {
+	if image.Getenv("NVIDIA_NVSWITCH") == "enabled" {
 		d, err := discover.NewNvSwitchDiscoverer(logger, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for NVSWITCH devices: %w", err)
@@ -70,7 +70,7 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 		discoverers = append(discoverers, d)
 	}
 
-	if cfg.Features.IsEnabled(config.FeatureGDRCopy, image) {
+	if image.Getenv("NVIDIA_GDRCOPY") == "enabled" {
 		d, err := discover.NewGDRCopyDiscoverer(logger, devRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct discoverer for GDRCopy devices: %w", err)


### PR DESCRIPTION
This change removes the ability to set the per-container opt-in features for GDS and MOFED, for example.

This functionality added in https://github.com/NVIDIA/nvidia-container-toolkit/pull/362 was not publicly documented.

