### PR TITLE
add glibc/lib to library search paths

### DIFF
--- a/internal/lookup/library.go
+++ b/internal/lookup/library.go
@@ -56,6 +56,7 @@ func NewLibraryLocator(opts ...Option) Locator {
 			"/lib/aarch64-linux-gnu",
 			"/lib/x86_64-linux-gnu/nvidia/current",
 			"/lib/aarch64-linux-gnu/nvidia/current",
+			"/glibc/lib",
 		}...),
 	)
 	// We construct a symlink locator for expected library locations.


### PR DESCRIPTION
## Issue
When running Talos Linux, the Nvidia driver libraries are located under /usr/local/glibc/lib, and the binaries under /usr/local/bin. Using the default search paths, and a `driver-root` value of `/usr/local` the validator is able to locate the binaries, but not the libraries.

## Proposed solution
Add "glibc/lib" to the library search path. This has been tested to work on a Talos cluster running 1.8.1, production drivers (550.90.07) and H100 GPUs

This PR is part of a set of PRs to better support Talos Linux for the GPU Operator.