### PR TITLE
Add feature to require kernel module

### DIFF
--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -21,6 +21,9 @@ type features struct {
 	// DisableImexChannelCreation ensures that the implicit creation of
 	// requested IMEX channels is skipped when invoking the nvidia-container-cli.
 	DisableImexChannelCreation *feature `toml:"disable-imex-channel-creation,omitempty"`
+	// RequireNvidiaKernelModules indicates that the NVIDIA kernel module must be
+	// loaded for the NVIDIA Container Runtime to perform any OCI spec modifications.
+	RequireNvidiaKernelModules *feature `toml:"require-nvidia-kernel-module,omitempty"`
 }
 
 //nolint:unused

--- a/tools/container/toolkit/executable.go
+++ b/tools/container/toolkit/executable.go
@@ -36,7 +36,6 @@ type executable struct {
 	source   string
 	target   executableTarget
 	env      map[string]string
-	preLines []string
 	argLines []string
 }
 
@@ -95,11 +94,6 @@ func (e executable) writeWrapperTo(wrapper io.Writer, destFolder string, dotfile
 
 	// Add the shebang
 	fmt.Fprintln(wrapper, "#! /bin/sh")
-
-	// Add the preceding lines if any
-	for _, line := range e.preLines {
-		fmt.Fprintf(wrapper, "%s\n", r.apply(line))
-	}
 
 	// Update the path to include the destination folder
 	var env map[string]string

--- a/tools/container/toolkit/executable_test.go
+++ b/tools/container/toolkit/executable_test.go
@@ -61,23 +61,6 @@ func TestWrapper(t *testing.T) {
 		},
 		{
 			e: executable{
-				preLines: []string{
-					"preline1",
-					"preline2",
-				},
-			},
-			expectedLines: []string{
-				shebang,
-				"preline1",
-				"preline2",
-				"PATH=/dest/folder:$PATH \\",
-				"source.real \\",
-				"\t\"$@\"",
-				"",
-			},
-		},
-		{
-			e: executable{
 				argLines: []string{
 					"argline1",
 					"argline2",

--- a/tools/container/toolkit/runtime.go
+++ b/tools/container/toolkit/runtime.go
@@ -57,16 +57,6 @@ func newNvidiaContainerRuntimeInstaller(source string) *executable {
 }
 
 func newRuntimeInstaller(source string, target executableTarget, env map[string]string) *executable {
-	preLines := []string{
-		"",
-		"cat /proc/modules | grep -e \"^nvidia \" >/dev/null 2>&1",
-		"if [ \"${?}\" != \"0\" ]; then",
-		"	echo \"nvidia driver modules are not yet loaded, invoking runc directly\"",
-		"	exec runc \"$@\"",
-		"fi",
-		"",
-	}
-
 	runtimeEnv := make(map[string]string)
 	runtimeEnv["XDG_CONFIG_HOME"] = filepath.Join(destDirPattern, ".config")
 	for k, v := range env {
@@ -74,10 +64,9 @@ func newRuntimeInstaller(source string, target executableTarget, env map[string]
 	}
 
 	r := executable{
-		source:   source,
-		target:   target,
-		env:      runtimeEnv,
-		preLines: preLines,
+		source: source,
+		target: target,
+		env:    runtimeEnv,
 	}
 
 	return &r

--- a/tools/container/toolkit/runtime_test.go
+++ b/tools/container/toolkit/runtime_test.go
@@ -38,13 +38,6 @@ func TestNvidiaContainerRuntimeInstallerWrapper(t *testing.T) {
 
 	expectedLines := []string{
 		shebang,
-		"",
-		"cat /proc/modules | grep -e \"^nvidia \" >/dev/null 2>&1",
-		"if [ \"${?}\" != \"0\" ]; then",
-		"	echo \"nvidia driver modules are not yet loaded, invoking runc directly\"",
-		"	exec runc \"$@\"",
-		"fi",
-		"",
 		"PATH=/dest/folder:$PATH \\",
 		"XDG_CONFIG_HOME=/dest/folder/.config \\",
 		"source.real \\",

--- a/tools/container/toolkit/toolkit.go
+++ b/tools/container/toolkit/toolkit.go
@@ -465,6 +465,8 @@ func installToolkitConfig(c *cli.Context, toolkitConfigPath string, nvidiaContai
 		configValues["nvidia-container-runtime.runtimes"] = toolkitRuntimeList
 	}
 
+	// We require the NVIDIA kernel modules to be loaded.
+	configValues["features.require-nvidia-kernel-modules"] = true
 	for _, optInFeature := range opts.optInFeatures.Value() {
 		configValues["features."+optInFeature] = true
 	}


### PR DESCRIPTION
This change adds a `require-nvidia-kernel-modules` feature flag that allows the logic for checking whether the `nvidia` kernel modules are loaded to be incorportated into the runtime itself.

This has the following advantages:
1. It allows support for platforms that don't have a shell (see #700)
2. It allows low-level runtimes other than `runc` to be used.