### PR TITLE
Force creation of symlinks in create-symlink hook

### DIFF
--- a/internal/lookup/symlinks/symlink.go
+++ b/internal/lookup/symlinks/symlink.go
@@ -33,3 +33,18 @@ func Resolve(filename string) (string, error) {
 
 	return os.Readlink(filename)
 }
+
+// ForceCreate creates a specified symlink.
+// If a file (or empty directory) exists at the path it is removed.
+func ForceCreate(target string, link string) error {
+	_, err := os.Lstat(link)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to get file info: %w", err)
+	}
+	if !os.IsNotExist(err) {
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("failed to remove existing file: %w", err)
+		}
+	}
+	return os.Symlink(target, link)
+}


### PR DESCRIPTION
This change updates the create-symlink hook to be equivalent to
```
ln -f -s target link
```
This ensures that links are updated even if they exist in the container being run.