### PR TITLE
Fix fsnotify.Remove logic function.

### DIFF
--- a/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
+++ b/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
@@ -187,11 +187,11 @@ create:
 			if !strings.HasPrefix(deviceNode, "nvidia") {
 				continue
 			}
-			if event.Op&fsnotify.Create == fsnotify.Create {
+			if event.Has(fsnotify.Create) {
 				m.logger.Infof("%s created, restarting.", event.Name)
 				goto create
 			}
-			if event.Op&fsnotify.Create == fsnotify.Remove {
+			if event.Has(fsnotify.Remove) {
 				m.logger.Infof("%s removed. Ignoring", event.Name)
 
 			}


### PR DESCRIPTION
1 Use simple grammar in fsnotify package.
```
This makes checking events a lot easier; for example:

  if event.Op&Write == Write && !(event.Op&Remove == Remove) {
  }
Becomes:

  if event.Has(Write) && !event.Has(Remove) {
  }
``` 

 According [fsnotify notes](https://github.com/fsnotify/fsnotify/releases/tag/v1.6.0)

2.
Fix Remove event.