### PR TITLE
Fallback to file for runtime config

### DIFF
--- a/tools/container/runtime/docker/docker.go
+++ b/tools/container/runtime/docker/docker.go
@@ -45,9 +45,7 @@ func Flags(opts *Options) []cli.Flag {
 func Setup(c *cli.Context, o *container.Options) error {
 	log.Infof("Starting 'setup' for %v", c.App.Name)
 
-	cfg, err := docker.New(
-		docker.WithPath(o.Config),
-	)
+	cfg, err := getRuntimeConfig(o)
 	if err != nil {
 		return fmt.Errorf("unable to load config: %v", err)
 	}
@@ -71,9 +69,7 @@ func Setup(c *cli.Context, o *container.Options) error {
 func Cleanup(c *cli.Context, o *container.Options) error {
 	log.Infof("Starting 'cleanup' for %v", c.App.Name)
 
-	cfg, err := docker.New(
-		docker.WithPath(o.Config),
-	)
+	cfg, err := getRuntimeConfig(o)
 	if err != nil {
 		return fmt.Errorf("unable to load config: %v", err)
 	}
@@ -106,4 +102,10 @@ func GetLowlevelRuntimePaths(o *container.Options) ([]string, error) {
 		return nil, fmt.Errorf("unable to load docker config: %w", err)
 	}
 	return engine.GetBinaryPathsForRuntimes(cfg), nil
+}
+
+func getRuntimeConfig(o *container.Options) (engine.Interface, error) {
+	return docker.New(
+		docker.WithPath(o.Config),
+	)
 }


### PR DESCRIPTION
This change ensures that we fall back to the previous behaviour of reading the existing config from the specified config file if extracting the current config from the command line fails. This fixes use cases where the containerd / crio executables are not available.

This backports the changes from #777 