### PR TITLE
Fix create-device-node test when devices exist

### DIFF
--- a/internal/system/nvdevices/devices.go
+++ b/internal/system/nvdevices/devices.go
@@ -19,7 +19,6 @@ package nvdevices
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -66,7 +65,7 @@ func New(opts ...Option) (*Interface, error) {
 	if i.dryRun {
 		i.mknoder = &mknodLogger{i.logger}
 	} else {
-		i.mknoder = &mknodUnix{}
+		i.mknoder = &mknodUnix{i.logger}
 	}
 	return i, nil
 }
@@ -107,13 +106,6 @@ func (m *Interface) CreateNVIDIADevice(node string) error {
 // If a devRoot is configured, this is prepended to the path.
 func (m *Interface) createDeviceNode(path string, major int, minor int) error {
 	path = filepath.Join(m.devRoot, path)
-	if _, err := os.Stat(path); err == nil {
-		m.logger.Infof("Skipping: %s already exists", path)
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to stat %s: %v", path, err)
-	}
-
 	return m.Mknode(path, major, minor)
 }
 

--- a/internal/system/nvdevices/mknod.go
+++ b/internal/system/nvdevices/mknod.go
@@ -17,6 +17,9 @@
 package nvdevices
 
 import (
+	"fmt"
+	"os"
+
 	"golang.org/x/sys/unix"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
@@ -36,9 +39,19 @@ func (m *mknodLogger) Mknode(path string, major, minor int) error {
 	return nil
 }
 
-type mknodUnix struct{}
+type mknodUnix struct {
+	logger logger.Interface
+}
 
 func (m *mknodUnix) Mknode(path string, major, minor int) error {
+	// TODO: Ensure that the existing device node has the correct properties.
+	if _, err := os.Stat(path); err == nil {
+		m.logger.Infof("Skipping: %s already exists", path)
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat %s: %v", path, err)
+	}
+
 	err := unix.Mknod(path, unix.S_IFCHR, int(unix.Mkdev(uint32(major), uint32(minor))))
 	if err != nil {
 		return err


### PR DESCRIPTION
This changes fixes the TestCreateControlDevices test on systems where device nodes exist.