### PR TITLE
Add option in toolkit container to enable CDI in runtime

### DIFF
--- a/cmd/nvidia-ctk-installer/container/container.go
+++ b/cmd/nvidia-ctk-installer/container/container.go
@@ -36,8 +36,10 @@ const (
 
 // Options defines the shared options for the CLIs to configure containers runtimes.
 type Options struct {
-	Config        string
-	Socket        string
+	Config string
+	Socket string
+	// EnabledCDI indicates whether CDI should be enabled.
+	EnableCDI     bool
 	RuntimeName   string
 	RuntimeDir    string
 	SetAsDefault  bool
@@ -109,6 +111,10 @@ func (o Options) UpdateConfig(cfg engine.Interface) error {
 		if err != nil {
 			return fmt.Errorf("failed to update runtime %q: %v", name, err)
 		}
+	}
+
+	if o.EnableCDI {
+		cfg.EnableCDI()
 	}
 
 	return nil

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk-installer/container/runtime/containerd"
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk-installer/container/runtime/crio"
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk-installer/container/runtime/docker"
+	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk-installer/container/toolkit"
 )
 
 const (
@@ -104,9 +105,13 @@ func Flags(opts *Options) []cli.Flag {
 }
 
 // ValidateOptions checks whether the specified options are valid
-func ValidateOptions(opts *Options, runtime string, toolkitRoot string) error {
+func ValidateOptions(c *cli.Context, opts *Options, runtime string, toolkitRoot string, to *toolkit.Options) error {
 	// We set this option here to ensure that it is available in future calls.
 	opts.RuntimeDir = toolkitRoot
+
+	if !c.IsSet("enable-cdi-in-runtime") {
+		opts.EnableCDI = to.CDI.Enabled
+	}
 
 	// Apply the runtime-specific config changes.
 	switch runtime {

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -66,6 +66,12 @@ func Flags(opts *Options) []cli.Flag {
 			Destination: &opts.RestartMode,
 			EnvVars:     []string{"RUNTIME_RESTART_MODE"},
 		},
+		&cli.BoolFlag{
+			Name:        "enable-cdi-in-runtime",
+			Usage:       "Enable CDI in the configured runt	ime",
+			Destination: &opts.EnableCDI,
+			EnvVars:     []string{"RUNTIME_ENABLE_CDI"},
+		},
 		&cli.StringFlag{
 			Name:        "host-root",
 			Usage:       "Specify the path to the host root to be used when restarting the runtime using systemd",

--- a/cmd/nvidia-ctk-installer/container/toolkit/toolkit_test.go
+++ b/cmd/nvidia-ctk-installer/container/toolkit/toolkit_test.go
@@ -124,9 +124,11 @@ kind: example.com/class
 			options := Options{
 				DriverRoot:        "/host/driver/root",
 				DriverRootCtrPath: filepath.Join(moduleRoot, "testdata", "lookup", tc.hostRoot),
-				cdiEnabled:        tc.cdiEnabled,
-				cdiOutputDir:      cdiOutputDir,
-				cdiKind:           "example.com/class",
+				CDI: cdiOptions{
+					Enabled:   tc.cdiEnabled,
+					outputDir: cdiOutputDir,
+					kind:      "example.com/class",
+				},
 			}
 
 			ti := NewInstaller(

--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -164,7 +164,7 @@ func (a *app) Before(c *cli.Context, o *options) error {
 	return a.validateFlags(c, o)
 }
 
-func (a *app) validateFlags(_ *cli.Context, o *options) error {
+func (a *app) validateFlags(c *cli.Context, o *options) error {
 	if o.root == "" {
 		return fmt.Errorf("the install root must be specified")
 	}
@@ -178,7 +178,7 @@ func (a *app) validateFlags(_ *cli.Context, o *options) error {
 	if err := a.toolkit.ValidateOptions(&o.toolkitOptions); err != nil {
 		return err
 	}
-	if err := runtime.ValidateOptions(&o.runtimeOptions, o.runtime, o.toolkitRoot()); err != nil {
+	if err := runtime.ValidateOptions(c, &o.runtimeOptions, o.runtime, o.toolkitRoot(), &o.toolkitOptions); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -38,6 +38,7 @@ type options struct {
 	runtimeArgs string
 	root        string
 	pidFile     string
+	sourceRoot  string
 
 	toolkitOptions toolkit.Options
 	runtimeOptions runtime.Options
@@ -142,6 +143,13 @@ func (a app) build() *cli.App {
 			EnvVars:     []string{"ROOT"},
 		},
 		&cli.StringFlag{
+			Name:        "source-root",
+			Value:       "/",
+			Usage:       "The folder where the required toolkit artifacts can be found",
+			Destination: &options.sourceRoot,
+			EnvVars:     []string{"SOURCE_ROOT"},
+		},
+		&cli.StringFlag{
 			Name:        "pid-file",
 			Value:       defaultPidFile,
 			Usage:       "the path to a toolkit.pid file to ensure that only a single configuration instance is running",
@@ -159,6 +167,7 @@ func (a app) build() *cli.App {
 func (a *app) Before(c *cli.Context, o *options) error {
 	a.toolkit = toolkit.NewInstaller(
 		toolkit.WithLogger(a.logger),
+		toolkit.WithSourceRoot(o.sourceRoot),
 		toolkit.WithToolkitRoot(o.toolkitRoot()),
 	)
 	return a.validateFlags(c, o)

--- a/cmd/nvidia-ctk-installer/main_test.go
+++ b/cmd/nvidia-ctk-installer/main_test.go
@@ -18,10 +18,15 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
 )
 
 func TestParseArgs(t *testing.T) {
@@ -83,4 +88,119 @@ func TestParseArgs(t *testing.T) {
 			require.Equal(t, tc.expectedRoot, root)
 		})
 	}
+}
+
+func TestApp(t *testing.T) {
+	t.Setenv("__NVCT_TESTING_DEVICES_ARE_FILES", "true")
+	logger, _ := testlog.NewNullLogger()
+
+	moduleRoot, err := test.GetModuleRoot()
+	require.NoError(t, err)
+
+	artifactRoot := filepath.Join(moduleRoot, "testdata", "installer", "artifacts")
+
+	testCases := []struct {
+		description           string
+		args                  []string
+		expectedToolkitConfig string
+		expectedRuntimeConfig string
+	}{
+		{
+			description: "no args",
+			expectedToolkitConfig: `accept-nvidia-visible-devices-as-volume-mounts = false
+accept-nvidia-visible-devices-envvar-when-unprivileged = true
+disable-require = false
+supported-driver-capabilities = "compat32,compute,display,graphics,ngx,utility,video"
+swarm-resource = ""
+
+[nvidia-container-cli]
+  debug = ""
+  environment = []
+  ldcache = ""
+  ldconfig = "@/run/nvidia/driver/sbin/ldconfig"
+  load-kmods = true
+  no-cgroups = false
+  path = "{{ .toolkitRoot }}/toolkit/nvidia-container-cli"
+  root = "/run/nvidia/driver"
+  user = ""
+
+[nvidia-container-runtime]
+  debug = "/dev/null"
+  log-level = "info"
+  mode = "auto"
+  runtimes = ["docker-runc", "runc", "crun"]
+
+  [nvidia-container-runtime.modes]
+
+    [nvidia-container-runtime.modes.cdi]
+      annotation-prefixes = ["cdi.k8s.io/"]
+      default-kind = "nvidia.com/gpu"
+      spec-dirs = ["/etc/cdi", "/var/run/cdi"]
+
+    [nvidia-container-runtime.modes.csv]
+      mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+[nvidia-container-runtime-hook]
+  path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
+  skip-mode-detection = true
+
+[nvidia-ctk]
+  path = "{{ .toolkitRoot }}/toolkit/nvidia-ctk"
+`,
+			expectedRuntimeConfig: `{
+    "default-runtime": "nvidia",
+    "runtimes": {
+        "nvidia": {
+            "args": [],
+            "path": "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime"
+        },
+        "nvidia-cdi": {
+            "args": [],
+            "path": "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime.cdi"
+        },
+        "nvidia-legacy": {
+            "args": [],
+            "path": "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime.legacy"
+        }
+    }
+}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			testRoot := t.TempDir()
+
+			runtimeConfigFile := filepath.Join(testRoot, "config.file")
+
+			toolkitRoot := filepath.Join(testRoot, "toolkit-test")
+			toolkitConfigFile := filepath.Join(toolkitRoot, "toolkit/.config/nvidia-container-runtime/config.toml")
+
+			app := NewApp(logger, toolkitRoot)
+
+			testArgs := []string{
+				"nvidia-ctk-installer",
+				"--no-daemon",
+				"--pid-file=" + filepath.Join(testRoot, "toolkit.pid"),
+				"--source-root=" + filepath.Join(artifactRoot, "deb"),
+				"--config=" + runtimeConfigFile,
+				"--restart-mode=none",
+			}
+
+			err := app.Run(append(testArgs, tc.args...))
+
+			require.NoError(t, err)
+
+			require.FileExists(t, toolkitConfigFile)
+			toolkitConfigFileContents, err := os.ReadFile(toolkitConfigFile)
+			require.NoError(t, err)
+			require.EqualValues(t, strings.ReplaceAll(tc.expectedToolkitConfig, "{{ .toolkitRoot }}", toolkitRoot), string(toolkitConfigFileContents))
+
+			require.FileExists(t, runtimeConfigFile)
+			runtimeConfigFileContents, err := os.ReadFile(runtimeConfigFile)
+			require.NoError(t, err)
+			require.EqualValues(t, strings.ReplaceAll(tc.expectedRuntimeConfig, "{{ .toolkitRoot }}", toolkitRoot), string(runtimeConfigFileContents))
+		})
+	}
+
 }

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -292,9 +292,8 @@ func (m command) configureConfigFile(c *cli.Context, config *config) error {
 		return fmt.Errorf("unable to update config: %v", err)
 	}
 
-	err = enableCDI(config, cfg)
-	if err != nil {
-		return fmt.Errorf("failed to enable CDI in %s: %w", config.runtime, err)
+	if config.cdi.enabled {
+		cfg.EnableCDI()
 	}
 
 	outputPath := config.getOutputConfigPath()
@@ -351,22 +350,6 @@ func (m *command) configureOCIHook(c *cli.Context, config *config) error {
 	err := ocihook.CreateHook(config.hookFilePath, config.nvidiaRuntime.hookPath)
 	if err != nil {
 		return fmt.Errorf("error creating OCI hook: %v", err)
-	}
-	return nil
-}
-
-// enableCDI enables the use of CDI in the corresponding container engine
-func enableCDI(config *config, cfg engine.Interface) error {
-	if !config.cdi.enabled {
-		return nil
-	}
-	switch config.runtime {
-	case "containerd":
-		cfg.Set("enable_cdi", true)
-	case "docker":
-		cfg.Set("features", map[string]bool{"cdi": true})
-	default:
-		return fmt.Errorf("enabling CDI in %s is not supported", config.runtime)
 	}
 	return nil
 }

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -163,7 +163,7 @@ func (m command) build() *cli.Command {
 		},
 		&cli.BoolFlag{
 			Name:        "cdi.enabled",
-			Aliases:     []string{"cdi.enable"},
+			Aliases:     []string{"cdi.enable", "enable-cdi"},
 			Usage:       "Enable CDI in the configured runtime",
 			Destination: &config.cdi.enabled,
 		},

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -24,7 +24,6 @@ type Interface interface {
 	GetRuntimeConfig(string) (RuntimeConfig, error)
 	RemoveRuntime(string) error
 	Save(string) (int64, error)
-	Set(string, interface{})
 	String() string
 }
 

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -20,6 +20,7 @@ package engine
 type Interface interface {
 	AddRuntime(string, string, bool) error
 	DefaultRuntime() string
+	EnableCDI()
 	GetRuntimeConfig(string) (RuntimeConfig, error)
 	RemoveRuntime(string) error
 	Save(string) (int64, error)

--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -111,6 +111,11 @@ func (c Config) DefaultRuntime() string {
 	return ""
 }
 
+// EnableCDI sets the enable_cdi field in the Containerd config to true.
+func (c *Config) EnableCDI() {
+	c.Set("enable_cdi", true)
+}
+
 // RemoveRuntime removes a runtime from the docker config
 func (c *Config) RemoveRuntime(name string) error {
 	if c == nil || c.Tree == nil {

--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -96,13 +96,6 @@ func (c *Config) getRuntimeAnnotations(path []string) ([]string, error) {
 	return annotations, nil
 }
 
-// Set sets the specified containerd option.
-func (c *Config) Set(key string, value interface{}) {
-	config := *c.Tree
-	config.SetPath([]string{"plugins", c.CRIRuntimePluginName, key}, value)
-	*c.Tree = config
-}
-
 // DefaultRuntime returns the default runtime for the cri-o config
 func (c Config) DefaultRuntime() string {
 	if runtime, ok := c.GetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "default_runtime_name"}).(string); ok {
@@ -113,7 +106,9 @@ func (c Config) DefaultRuntime() string {
 
 // EnableCDI sets the enable_cdi field in the Containerd config to true.
 func (c *Config) EnableCDI() {
-	c.Set("enable_cdi", true)
+	config := *c.Tree
+	config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "enable_cdi"}, true)
+	*c.Tree = config
 }
 
 // RemoveRuntime removes a runtime from the docker config

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -143,13 +143,6 @@ func (c *ConfigV1) RemoveRuntime(name string) error {
 	return nil
 }
 
-// Set sets the specified containerd option.
-func (c *ConfigV1) Set(key string, value interface{}) {
-	config := *c.Tree
-	config.SetPath([]string{"plugins", "cri", "containerd", key}, value)
-	*c.Tree = config
-}
-
 // Save writes the config to a file
 func (c ConfigV1) Save(path string) (int64, error) {
 	return (Config)(c).Save(path)
@@ -167,5 +160,7 @@ func (c *ConfigV1) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 }
 
 func (c *ConfigV1) EnableCDI() {
-	c.Set("enable_cdi", true)
+	config := *c.Tree
+	config.SetPath([]string{"plugins", "cri", "containerd", "enable_cdi"}, true)
+	*c.Tree = config
 }

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -165,3 +165,7 @@ func (c *ConfigV1) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 		tree: runtimeData,
 	}, nil
 }
+
+func (c *ConfigV1) EnableCDI() {
+	c.Set("enable_cdi", true)
+}

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -153,6 +153,9 @@ func (c *Config) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 	}, nil
 }
 
+// EnableCDI is a no-op for CRI-O since it always enabled where supported.
+func (c *Config) EnableCDI() {}
+
 // CommandLineSource returns the CLI-based crio config loader
 func CommandLineSource(hostRoot string) toml.Loader {
 	return toml.LoadFirst(

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -105,7 +105,20 @@ func (c Config) DefaultRuntime() string {
 
 // EnableCDI sets features.cdi to true in the docker config.
 func (c *Config) EnableCDI() {
-	(*c)["features"] = map[string]bool{"cdi": true}
+	if c == nil {
+		return
+	}
+	config := *c
+
+	features, ok := config["features"].(map[string]bool)
+	if !ok {
+		features = make(map[string]bool)
+	}
+	features["cdi"] = true
+
+	config["features"] = features
+
+	*c = config
 }
 
 // RemoveRuntime removes a runtime from the docker config

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -105,7 +105,7 @@ func (c Config) DefaultRuntime() string {
 
 // EnableCDI sets features.cdi to true in the docker config.
 func (c *Config) EnableCDI() {
-	c.Set("features", map[string]bool{"cdi": true})
+	(*c)["features"] = map[string]bool{"cdi": true}
 }
 
 // RemoveRuntime removes a runtime from the docker config
@@ -135,11 +135,6 @@ func (c *Config) RemoveRuntime(name string) error {
 	*c = config
 
 	return nil
-}
-
-// Set sets the specified docker option
-func (c *Config) Set(key string, value interface{}) {
-	(*c)[key] = value
 }
 
 // Save writes the config to the specified path

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -103,6 +103,11 @@ func (c Config) DefaultRuntime() string {
 	return r
 }
 
+// EnableCDI sets features.cdi to true in the docker config.
+func (c *Config) EnableCDI() {
+	c.Set("features", map[string]bool{"cdi": true})
+}
+
 // RemoveRuntime removes a runtime from the docker config
 func (c *Config) RemoveRuntime(name string) error {
 	if c == nil {


### PR DESCRIPTION
These changes add an option to enable CDI in container engines (containerd, crio, docker) from the toolkit contaienr.

This can be triggered through the `--enable-cdi-in-runtime` command line option or `RUNTIME_ENABLE_CDI` environment variable.