### PR TITLE
Properly pass configSearchPaths to a Driver constructor

### DIFF
--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -97,6 +97,7 @@ func New(opts ...Option) (Interface, error) {
 		root.WithLogger(l.logger),
 		root.WithDriverRoot(l.driverRoot),
 		root.WithLibrarySearchPaths(l.librarySearchPaths...),
+		root.WithConfigSearchPaths(l.configSearchPaths...),
 	)
 	if l.nvmllib == nil {
 		var nvmlOpts []nvml.LibraryOption


### PR DESCRIPTION
Without this fix it's not possible to use a custom config search path option with nvcdi interface.