### PR TITLE
[no-relnote] Fix Dockerfile lint issues

### DIFF
--- a/deployments/container/Dockerfile.ubi8
+++ b/deployments/container/Dockerfile.ubi8
@@ -15,7 +15,7 @@
 ARG GOLANG_VERSION=x.x.x
 ARG VERSION="N/A"
 
-FROM nvidia/cuda:12.6.3-base-ubi8 as build
+FROM nvidia/cuda:12.6.3-base-ubi8 AS build
 
 RUN yum install -y \
     wget make git gcc \
@@ -36,8 +36,8 @@ RUN set -eux; \
     | tar -C /usr/local -xz
 
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /build
 COPY . .
@@ -62,7 +62,8 @@ WORKDIR /artifacts/packages
 
 ARG PACKAGE_VERSION
 ARG TARGETARCH
-ENV PACKAGE_ARCH ${TARGETARCH}
+ENV PACKAGE_ARCH=${TARGETARCH}
+
 RUN PACKAGE_ARCH=${PACKAGE_ARCH/amd64/x86_64} && PACKAGE_ARCH=${PACKAGE_ARCH/arm64/aarch64} && \
     yum localinstall -y \
     ${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container1-1.*.rpm \
@@ -75,6 +76,7 @@ COPY --from=build /artifacts/bin /work
 
 ENV PATH=/work:$PATH
 
+ARG VERSION
 LABEL io.k8s.display-name="NVIDIA Container Runtime Config"
 LABEL name="NVIDIA Container Runtime Config"
 LABEL vendor="NVIDIA"

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -15,7 +15,7 @@
 ARG GOLANG_VERSION=x.x.x
 ARG VERSION="N/A"
 
-FROM nvidia/cuda:12.6.3-base-ubuntu20.04 as build
+FROM nvidia/cuda:12.6.3-base-ubuntu20.04 AS build
 
 RUN apt-get update && \
     apt-get install -y wget make git gcc \
@@ -35,8 +35,8 @@ RUN set -eux; \
     wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /build
 COPY . .
@@ -71,7 +71,7 @@ WORKDIR /artifacts/packages
 
 ARG PACKAGE_VERSION
 ARG TARGETARCH
-ENV PACKAGE_ARCH ${TARGETARCH}
+ENV PACKAGE_ARCH=${TARGETARCH}
 
 RUN dpkg -i \
     ${PACKAGE_DIST}/${PACKAGE_ARCH}/libnvidia-container1_1.*.deb \
@@ -84,6 +84,7 @@ COPY --from=build /artifacts/bin /work/
 
 ENV PATH=/work:$PATH
 
+ARG VERSION
 LABEL io.k8s.display-name="NVIDIA Container Runtime Config"
 LABEL name="NVIDIA Container Runtime Config"
 LABEL vendor="NVIDIA"


### PR DESCRIPTION
This removes the following warnings when building the docker containers:

```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 65)
 - UndefinedVar: Usage of undefined variable '$VERSION' (line 81)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 18)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 39)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 40)
 ```