### PR TITLE
Skip graphics modifier in CSV mode

### DIFF
--- a/internal/modifier/list.go
+++ b/internal/modifier/list.go
@@ -22,14 +22,12 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/oci"
 )
 
-type list struct {
-	modifiers []oci.SpecModifier
-}
+type List []oci.SpecModifier
 
 // Merge merges a set of OCI specification modifiers as a list.
 // This can be used to compose modifiers.
 func Merge(modifiers ...oci.SpecModifier) oci.SpecModifier {
-	var filteredModifiers []oci.SpecModifier
+	var filteredModifiers List
 	for _, m := range modifiers {
 		if m == nil {
 			continue
@@ -37,19 +35,19 @@ func Merge(modifiers ...oci.SpecModifier) oci.SpecModifier {
 		filteredModifiers = append(filteredModifiers, m)
 	}
 
-	return list{
-		modifiers: filteredModifiers,
-	}
+	return filteredModifiers
 }
 
 // Modify applies a list of modifiers in sequence and returns on any errors encountered.
-func (m list) Modify(spec *specs.Spec) error {
-	for _, mm := range m.modifiers {
+func (m List) Modify(spec *specs.Spec) error {
+	for _, mm := range m {
+		if mm == nil {
+			continue
+		}
 		err := mm.Modify(spec)
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -122,6 +122,9 @@ func supportedModifierTypes(mode string) []string {
 	case "cdi":
 		// For CDI mode we make no additional modifications.
 		return []string{"mode"}
+	case "csv":
+		// For CSV mode we support mode and feature-gated modification.
+		return []string{"mode", "feature-gated"}
 	default:
 		return []string{"mode", "graphics", "feature-gated"}
 	}

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -79,26 +79,27 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 	if err != nil {
 		return nil, err
 	}
-	// For CDI mode we make no additional modifications.
-	if mode == "cdi" {
-		return modeModifier, nil
+
+	var modifiers modifier.List
+	for _, modifierType := range supportedModifierTypes(mode) {
+		switch modifierType {
+		case "mode":
+			modifiers = append(modifiers, modeModifier)
+		case "graphics":
+			graphicsModifier, err := modifier.NewGraphicsModifier(logger, cfg, image, driver)
+			if err != nil {
+				return nil, err
+			}
+			modifiers = append(modifiers, graphicsModifier)
+		case "feature-gated":
+			featureGatedModifier, err := modifier.NewFeatureGatedModifier(logger, cfg, image)
+			if err != nil {
+				return nil, err
+			}
+			modifiers = append(modifiers, featureGatedModifier)
+		}
 	}
 
-	graphicsModifier, err := modifier.NewGraphicsModifier(logger, cfg, image, driver)
-	if err != nil {
-		return nil, err
-	}
-
-	featureModifier, err := modifier.NewFeatureGatedModifier(logger, cfg, image)
-	if err != nil {
-		return nil, err
-	}
-
-	modifiers := modifier.Merge(
-		modeModifier,
-		graphicsModifier,
-		featureModifier,
-	)
 	return modifiers, nil
 }
 
@@ -113,4 +114,15 @@ func newModeModifier(logger logger.Interface, mode string, cfg *config.Config, o
 	}
 
 	return nil, fmt.Errorf("invalid runtime mode: %v", cfg.NVIDIAContainerRuntimeConfig.Mode)
+}
+
+// supportedModifierTypes returns the modifiers supported for a specific runtime mode.
+func supportedModifierTypes(mode string) []string {
+	switch mode {
+	case "cdi":
+		// For CDI mode we make no additional modifications.
+		return []string{"mode"}
+	default:
+		return []string{"mode", "graphics", "feature-gated"}
+	}
 }


### PR DESCRIPTION
In CSV mode the CSV files at /etc/nvidia-container-runtime/host-files-for-container.d/ should be the source of truth for container modifications. This change skips graphics modifications to a container. This prevents conflicts when handling files such as vulkan icd files which are already defined in the CSV file.

Applying both modifications leads to errors such as:
```
time="2025-01-21T18:55:11Z" level=info msg="Symlinking /var/lib/docker/overlay2/8592b399d9308cdbef42010765f81af3f921ed86aa07c7e686b59f1e72fc3e2d/merged/etc/vulkan/icd.d/nvidia_icd.json to /usr/lib/aarch64-linux-gnu/nvidia/nvidia_icd.json"
time="2025-01-21T18:55:11Z" level=error msg="failed to create link [/usr/lib/aarch64-linux-gnu/nvidia/nvidia_icd.json /etc/vulkan/icd.d/nvidia_icd.json]: failed to create symlink: failed to remove existing file: remove /var/lib/docker/overlay2/8592b399d9308cdbef42010765f81af3f921ed86aa07c7e686b59f1e72fc3e2d/merged/etc/vulkan/icd.d/nvidia_icd.json: device or resource busy": unknown.
```