### PR TITLE
 Disable mounting of compat libs from container by default

### DIFF
--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -114,8 +114,9 @@ func doPrestart() {
 	}
 	args = append(args, "configure")
 
-	args = append(args, "--no-cntlibs")
-
+	if !hook.Features.AllowCUDACompatLibsFromContainer.IsEnabled() {
+		args = append(args, "--no-cntlibs")
+	}
 	if ldconfigPath := cli.NormalizeLDConfigPath(); ldconfigPath != "" {
 		args = append(args, fmt.Sprintf("--ldconfig=%s", ldconfigPath))
 	}

--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -114,6 +114,8 @@ func doPrestart() {
 	}
 	args = append(args, "configure")
 
+	args = append(args, "--no-cntlibs")
+
 	if ldconfigPath := cli.NormalizeLDConfigPath(); ldconfigPath != "" {
 		args = append(args, fmt.Sprintf("--ldconfig=%s", ldconfigPath))
 	}

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -18,6 +18,9 @@ package config
 
 // features specifies a set of named features.
 type features struct {
+	// AllowCUDACompatLibsFromContainer allows CUDA compat libs from a container
+	// to override certain driver library mounts from the host.
+	AllowCUDACompatLibsFromContainer *feature `toml:"allow-cuda-compat-libs-from-container,omitempty"`
 	// AllowLDConfigFromContainer allows non-host ldconfig paths to be used.
 	// If this feature flag is not set to 'true' only host-rooted config paths
 	// (i.e. paths starting with an '@' are considered valid)

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -18,13 +18,13 @@ package config
 
 // features specifies a set of named features.
 type features struct {
-	// DisableImexChannelCreation ensures that the implicit creation of
-	// requested IMEX channels is skipped when invoking the nvidia-container-cli.
-	DisableImexChannelCreation *feature `toml:"disable-imex-channel-creation,omitempty"`
 	// AllowLDConfigFromContainer allows non-host ldconfig paths to be used.
 	// If this feature flag is not set to 'true' only host-rooted config paths
 	// (i.e. paths starting with an '@' are considered valid)
 	AllowLDConfigFromContainer *feature `toml:"allow-ldconfig-from-container,omitempty"`
+	// DisableImexChannelCreation ensures that the implicit creation of
+	// requested IMEX channels is skipped when invoking the nvidia-container-cli.
+	DisableImexChannelCreation *feature `toml:"disable-imex-channel-creation,omitempty"`
 }
 
 type feature bool


### PR DESCRIPTION
This change passes the `--no-cntlibs` argument to the `nvidia-container-cli` from the nvidia-container-runtime-hook to disable overwriting host drivers with the compat libs from a container being started.

Note that this may be a breaking change for some applications. For that reason an `allow-cuda-compat-libs-from-container` feature flag is provided to opt-in to the previous behaviour.