### PR TITLE
Add IMEX binaries to CDI discovery

### DIFF
--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -184,6 +184,8 @@ func NewDriverBinariesDiscoverer(logger logger.Interface, driverRoot string) dis
 			"nvidia-persistenced",     /* Persistence mode utility */
 			"nvidia-cuda-mps-control", /* Multi process service CLI */
 			"nvidia-cuda-mps-server",  /* Multi process service server */
+			"nvidia-imex",             /* NVIDIA IMEX Daemon */
+			"nvidia-imex-ctl",         /* NVIDIA IMEX control */
 		},
 	)
 }


### PR DESCRIPTION
This change adds the nvidia-imex and nivdia-imex-ctl binaries to the list of driver binaries that are searched when using CDI.