### PR TITLE
[no-relnote] switch to the newer qemu artifacts image

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -57,6 +57,8 @@ jobs:
         name: Check out code
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: build ${{ matrix.target }} packages
@@ -114,6 +116,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Get built packages


### PR DESCRIPTION
This PR fixes the recent segfault errors that have been showing up in the CI's multi-arch docker builds lately.  This [comment](https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2613004741) summarises the root cause well.

Since our linux runners have picked up the newer kernels, the old qemu versions from the default `tonistiigi/binfmt:latest` are no longer compatible. Moreover, the `latest` tag hasn't been updated in over two years. So we switch to the `master` tag instead which is regularly maintained and is based on qemu 9.2.0 instead

P.S: If you're wondering why the `setup-qemu-action` doesn't pick up the `master` tag instead, the maintainers have already responded to that question.  See [here](https://github.com/tonistiigi/binfmt/issues/165#issuecomment-1996882334)

So far, this fix has been applied in the gpu-operator and mig-parted repos. They have been working fine with no issue since this fix

https://github.com/NVIDIA/gpu-operator/pull/1248
https://github.com/NVIDIA/mig-parted/pull/167

