### PR TITLE
Use just-in-time CDI spec generation by default in the NVIDIA Container Runtime

### DIFF
--- a/cmd/nvidia-container-runtime-hook/container_config_test.go
+++ b/cmd/nvidia-container-runtime-hook/container_config_test.go
@@ -487,7 +487,7 @@ func TestGetNvidiaConfig(t *testing.T) {
 				hookCfg := tc.hookConfig
 				if hookCfg == nil {
 					defaultConfig, _ := config.GetDefault()
-					hookCfg = &hookConfig{defaultConfig}
+					hookCfg = &hookConfig{Config: defaultConfig}
 				}
 				cfg = hookCfg.getNvidiaConfig(image, tc.privileged)
 			}

--- a/cmd/nvidia-container-runtime-hook/hook_config.go
+++ b/cmd/nvidia-container-runtime-hook/hook_config.go
@@ -140,6 +140,7 @@ func (c *hookConfig) assertModeIsLegacy() error {
 	mr := info.NewRuntimeModeResolver(
 		info.WithLogger(&logInterceptor{}),
 		info.WithImage(&c.containerConfig.Image),
+		info.WithDefaultMode(info.LegacyRuntimeMode),
 	)
 
 	mode := mr.ResolveRuntimeMode(c.NVIDIAContainerRuntimeConfig.Mode)

--- a/cmd/nvidia-container-runtime-hook/hook_config.go
+++ b/cmd/nvidia-container-runtime-hook/hook_config.go
@@ -7,9 +7,11 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config/image"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/info"
 )
 
 const (
@@ -20,7 +22,9 @@ const (
 // hookConfig wraps the toolkit config.
 // This allows for functions to be defined on the local type.
 type hookConfig struct {
+	sync.Mutex
 	*config.Config
+	containerConfig *containerConfig
 }
 
 // loadConfig loads the required paths for the hook config.
@@ -55,7 +59,7 @@ func getHookConfig() (*hookConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %v", err)
 	}
-	config := &hookConfig{cfg}
+	config := &hookConfig{Config: cfg}
 
 	allSupportedDriverCapabilities := image.SupportedDriverCapabilities
 	if config.SupportedDriverCapabilities == "all" {
@@ -73,8 +77,8 @@ func getHookConfig() (*hookConfig, error) {
 
 // getConfigOption returns the toml config option associated with the
 // specified struct field.
-func (c hookConfig) getConfigOption(fieldName string) string {
-	t := reflect.TypeOf(c)
+func (c *hookConfig) getConfigOption(fieldName string) string {
+	t := reflect.TypeOf(&c)
 	f, ok := t.FieldByName(fieldName)
 	if !ok {
 		return fieldName
@@ -126,4 +130,21 @@ func (c *hookConfig) nvidiaContainerCliCUDACompatModeFlags() []string {
 		return nil
 	}
 	return []string{flag}
+}
+
+func (c *hookConfig) assertModeIsLegacy() error {
+	if c.NVIDIAContainerRuntimeHookConfig.SkipModeDetection {
+		return nil
+	}
+
+	mr := info.NewRuntimeModeResolver(
+		info.WithLogger(&logInterceptor{}),
+		info.WithImage(&c.containerConfig.Image),
+	)
+
+	mode := mr.ResolveRuntimeMode(c.NVIDIAContainerRuntimeConfig.Mode)
+	if mode == "legacy" {
+		return nil
+	}
+	return fmt.Errorf("invoking the NVIDIA Container Runtime Hook directly (e.g. specifying the docker --gpus flag) is not supported. Please use the NVIDIA Container Runtime (e.g. specify the --runtime=nvidia flag) instead")
 }

--- a/cmd/nvidia-container-runtime-hook/hook_config_test.go
+++ b/cmd/nvidia-container-runtime-hook/hook_config_test.go
@@ -90,10 +90,10 @@ func TestGetHookConfig(t *testing.T) {
 				}
 			}
 
-			var cfg hookConfig
+			var cfg *hookConfig
 			getHookConfig := func() {
 				c, _ := getHookConfig()
-				cfg = *c
+				cfg = c
 			}
 
 			if tc.expectedPanic {

--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -55,7 +55,7 @@ func getCLIPath(config config.ContainerCLIConfig) string {
 }
 
 // getRootfsPath returns an absolute path. We don't need to resolve symlinks for now.
-func getRootfsPath(config containerConfig) string {
+func getRootfsPath(config *containerConfig) string {
 	rootfs, err := filepath.Abs(config.Rootfs)
 	if err != nil {
 		log.Panicln(err)
@@ -82,8 +82,8 @@ func doPrestart() {
 		return
 	}
 
-	if !hook.NVIDIAContainerRuntimeHookConfig.SkipModeDetection && info.ResolveAutoMode(&logInterceptor{}, hook.NVIDIAContainerRuntimeConfig.Mode, container.Image) != "legacy" {
-		log.Panicln("invoking the NVIDIA Container Runtime Hook directly (e.g. specifying the docker --gpus flag) is not supported. Please use the NVIDIA Container Runtime (e.g. specify the --runtime=nvidia flag) instead.")
+	if err := hook.assertModeIsLegacy(); err != nil {
+		log.Panicf("%v", err)
 	}
 
 	rootfs := getRootfsPath(container)

--- a/cmd/nvidia-container-runtime/main_test.go
+++ b/cmd/nvidia-container-runtime/main_test.go
@@ -122,11 +122,10 @@ func TestGoodInput(t *testing.T) {
 	err = cmdCreate.Run()
 	require.NoError(t, err, "runtime should not return an error")
 
-	// Check config.json for NVIDIA prestart hook
+	// Check config.json to ensure that the NVIDIA prestart was not inserted.
 	spec, err = cfg.getRuntimeSpec()
 	require.NoError(t, err, "should be no errors when reading and parsing spec from config.json")
-	require.NotEmpty(t, spec.Hooks, "there should be hooks in config.json")
-	require.Equal(t, 1, nvidiaHookCount(spec.Hooks), "exactly one nvidia prestart hook should be inserted correctly into config.json")
+	require.Empty(t, spec.Hooks, "there should be no hooks in config.json")
 }
 
 // NVIDIA prestart hook already present in config file
@@ -168,11 +167,10 @@ func TestDuplicateHook(t *testing.T) {
 	output, err := cmdCreate.CombinedOutput()
 	require.NoErrorf(t, err, "runtime should not return an error", "output=%v", string(output))
 
-	// Check config.json for NVIDIA prestart hook
+	// Check config.json to ensure that the NVIDIA prestart hook was removed.
 	spec, err = cfg.getRuntimeSpec()
 	require.NoError(t, err, "should be no errors when reading and parsing spec from config.json")
-	require.NotEmpty(t, spec.Hooks, "there should be hooks in config.json")
-	require.Equal(t, 1, nvidiaHookCount(spec.Hooks), "exactly one nvidia prestart hook should be inserted correctly into config.json")
+	require.Empty(t, spec.Hooks, "there should be no hooks in config.json")
 }
 
 // addNVIDIAHook is a basic wrapper for an addHookModifier that is used for
@@ -239,19 +237,4 @@ func (c testConfig) generateNewRuntimeSpec() error {
 		return err
 	}
 	return nil
-}
-
-// Return number of valid NVIDIA prestart hooks in runtime spec
-func nvidiaHookCount(hooks *specs.Hooks) int {
-	if hooks == nil {
-		return 0
-	}
-
-	count := 0
-	for _, hook := range hooks.Prestart {
-		if strings.Contains(hook.Path, nvidiaHook) {
-			count++
-		}
-	}
-	return count
 }

--- a/internal/info/auto.go
+++ b/internal/info/auto.go
@@ -41,6 +41,9 @@ const (
 	// to the container config required for the requested CDI devices in the
 	// same way that other CDI clients would.
 	CDIRuntimeMode = RuntimeMode("cdi")
+	// In JitCDIRuntimeMode the nvidia-container-runtime generates in-memory CDI
+	// specifications for requested NVIDIA devices.
+	JitCDIRuntimeMode = RuntimeMode("jit-cdi")
 )
 
 type RuntimeModeResolver interface {
@@ -116,9 +119,9 @@ func (m *modeResolver) ResolveRuntimeMode(mode string) (rmode RuntimeMode) {
 
 	switch nvinfo.ResolvePlatform() {
 	case info.PlatformNVML, info.PlatformWSL:
-		return LegacyRuntimeMode
+		return JitCDIRuntimeMode
 	case info.PlatformTegra:
 		return CSVRuntimeMode
 	}
-	return LegacyRuntimeMode
+	return JitCDIRuntimeMode
 }

--- a/internal/info/auto_test.go
+++ b/internal/info/auto_test.go
@@ -251,7 +251,12 @@ func TestResolveAutoMode(t *testing.T) {
 				image.WithAcceptDeviceListAsVolumeMounts(true),
 				image.WithAcceptEnvvarUnprivileged(true),
 			)
-			mode := resolveMode(logger, tc.mode, image, properties)
+			mr := NewRuntimeModeResolver(
+				WithLogger(logger),
+				WithImage(&image),
+				WithPropertyExtractor(properties),
+			)
+			mode := mr.ResolveRuntimeMode(tc.mode)
 			require.EqualValues(t, tc.expectedMode, mode)
 		})
 	}

--- a/internal/info/auto_test.go
+++ b/internal/info/auto_test.go
@@ -44,10 +44,15 @@ func TestResolveAutoMode(t *testing.T) {
 			expectedMode: "not-auto",
 		},
 		{
+			description:  "legacy resolves to legacy",
+			mode:         "legacy",
+			expectedMode: "legacy",
+		},
+		{
 			description:  "no info defaults to legacy",
 			mode:         "auto",
 			info:         map[string]bool{},
-			expectedMode: "legacy",
+			expectedMode: "jit-cdi",
 		},
 		{
 			description: "non-nvml, non-tegra, nvgpu resolves to csv",
@@ -80,14 +85,14 @@ func TestResolveAutoMode(t *testing.T) {
 			expectedMode: "csv",
 		},
 		{
-			description: "nvml, non-tegra, non-nvgpu resolves to legacy",
+			description: "nvml, non-tegra, non-nvgpu resolves to jit-cdi",
 			mode:        "auto",
 			info: map[string]bool{
 				"nvml":  true,
 				"tegra": false,
 				"nvgpu": false,
 			},
-			expectedMode: "legacy",
+			expectedMode: "jit-cdi",
 		},
 		{
 			description: "nvml, non-tegra, nvgpu resolves to csv",
@@ -100,14 +105,14 @@ func TestResolveAutoMode(t *testing.T) {
 			expectedMode: "csv",
 		},
 		{
-			description: "nvml, tegra, non-nvgpu resolves to legacy",
+			description: "nvml, tegra, non-nvgpu resolves to jit-cdi",
 			mode:        "auto",
 			info: map[string]bool{
 				"nvml":  true,
 				"tegra": true,
 				"nvgpu": false,
 			},
-			expectedMode: "legacy",
+			expectedMode: "jit-cdi",
 		},
 		{
 			description: "nvml, tegra, nvgpu resolves to csv",
@@ -136,7 +141,7 @@ func TestResolveAutoMode(t *testing.T) {
 			},
 		},
 		{
-			description: "at least one non-cdi device resolves to legacy",
+			description: "at least one non-cdi device resolves to jit-cdi",
 			mode:        "auto",
 			envmap: map[string]string{
 				"NVIDIA_VISIBLE_DEVICES": "nvidia.com/gpu=0,0",
@@ -146,7 +151,7 @@ func TestResolveAutoMode(t *testing.T) {
 				"tegra": false,
 				"nvgpu": false,
 			},
-			expectedMode: "legacy",
+			expectedMode: "jit-cdi",
 		},
 		{
 			description: "at least one non-cdi device resolves to csv",
@@ -170,7 +175,7 @@ func TestResolveAutoMode(t *testing.T) {
 			expectedMode: "cdi",
 		},
 		{
-			description: "cdi mount and non-CDI devices resolves to legacy",
+			description: "cdi mount and non-CDI devices resolves to jit-cdi",
 			mode:        "auto",
 			mounts: []string{
 				"/var/run/nvidia-container-devices/cdi/nvidia.com/gpu/0",
@@ -181,7 +186,7 @@ func TestResolveAutoMode(t *testing.T) {
 				"tegra": false,
 				"nvgpu": false,
 			},
-			expectedMode: "legacy",
+			expectedMode: "jit-cdi",
 		},
 		{
 			description: "cdi mount and non-CDI envvar resolves to cdi",
@@ -198,22 +203,6 @@ func TestResolveAutoMode(t *testing.T) {
 				"nvgpu": false,
 			},
 			expectedMode: "cdi",
-		},
-		{
-			description: "non-cdi mount and CDI envvar resolves to legacy",
-			mode:        "auto",
-			envmap: map[string]string{
-				"NVIDIA_VISIBLE_DEVICES": "nvidia.com/gpu=0",
-			},
-			mounts: []string{
-				"/var/run/nvidia-container-devices/0",
-			},
-			info: map[string]bool{
-				"nvml":  true,
-				"tegra": false,
-				"nvgpu": false,
-			},
-			expectedMode: "legacy",
 		},
 	}
 

--- a/internal/modifier/cdi_test.go
+++ b/internal/modifier/cdi_test.go
@@ -71,6 +71,18 @@ func TestDeviceRequests(t *testing.T) {
 			expectedDevices: []string{"nvidia.com/gpu=0", "example.com/class=device"},
 		},
 		{
+			description: "cdi devices from envvar with default kind",
+			input: cdiDeviceRequestor{
+				defaultKind: "runtime.nvidia.com/gpu",
+			},
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Env: []string{"NVIDIA_VISIBLE_DEVICES=all"},
+				},
+			},
+			expectedDevices: []string{"runtime.nvidia.com/gpu=all"},
+		},
+		{
 			description: "no matching annotations",
 			prefixes:    []string{"not-prefix/"},
 			spec: &specs.Spec{

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -107,8 +107,8 @@ func newModeModifier(logger logger.Interface, mode info.RuntimeMode, cfg *config
 		return modifier.NewStableRuntimeModifier(logger, cfg.NVIDIAContainerRuntimeHookConfig.Path), nil
 	case info.CSVRuntimeMode:
 		return modifier.NewCSVModifier(logger, cfg, image)
-	case info.CDIRuntimeMode:
-		return modifier.NewCDIModifier(logger, cfg, image)
+	case info.CDIRuntimeMode, info.JitCDIRuntimeMode:
+		return modifier.NewCDIModifier(logger, cfg, image, mode == info.JitCDIRuntimeMode)
 	}
 
 	return nil, fmt.Errorf("invalid runtime mode: %v", cfg.NVIDIAContainerRuntimeConfig.Mode)
@@ -160,7 +160,7 @@ func initRuntimeModeAndImage(logger logger.Interface, cfg *config.Config, ociSpe
 // supportedModifierTypes returns the modifiers supported for a specific runtime mode.
 func supportedModifierTypes(mode info.RuntimeMode) []string {
 	switch mode {
-	case info.CDIRuntimeMode:
+	case info.CDIRuntimeMode, info.JitCDIRuntimeMode:
 		// For CDI mode we make no additional modifications.
 		return []string{"nvidia-hook-remover", "mode"}
 	case info.CSVRuntimeMode:

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -136,7 +136,11 @@ func initRuntimeModeAndImage(logger logger.Interface, cfg *config.Config, ociSpe
 		return "", nil, err
 	}
 
-	mode := info.ResolveAutoMode(logger, cfg.NVIDIAContainerRuntimeConfig.Mode, image)
+	modeResolver := info.NewRuntimeModeResolver(
+		info.WithLogger(logger),
+		info.WithImage(&image),
+	)
+	mode := modeResolver.ResolveRuntimeMode(cfg.NVIDIAContainerRuntimeConfig.Mode)
 	// We update the mode here so that we can continue passing just the config to other functions.
 	cfg.NVIDIAContainerRuntimeConfig.Mode = mode
 


### PR DESCRIPTION
This PR changes the default behaviour of the NVIDIA Container Runtime to use an in-memory CDI specification to make changes to the incoming OCI runtime specification instead of invoking the `nvidia-container-runtime-hook` (i.e. "legacy" mode). This was previously available as an opt-in option when a user would request a CDI device using the predefined `runtime.nvidia.com/gpu` CDI device class as part of the CDI device name.

With this change, all device requests (annotations, volume mounts, environment variables) are mapped to `runtime.nvidia.com/gpu={{ .DeviceID }}` requests if they are not already CDI device requests. This means that CDI specifications for these defices are generated as the container is being created and these specifications are used to modify the incomming OCI runtime specification.

When the `nvidia` runtime is invoked in this mode, any existing `nvidia-container-runtime-hook` in the OCI runtime specification is removed so as to not use the legacy injection mechanism.

Note that when **only** the `nvidia-container-runtime-hook` is used (as is the case with the Docker `--gpus` flag or the default `crio` configuration), the default runtime mode is set to `legacy` to ensure that this mode of operation is not changed.

This means that:
```
$ docker run --rm -ti --runtime=runc --gpus=all ubuntu nvidia-smi -L
GPU 0: Tesla V100-SXM2-16GB-N (UUID: GPU-edfee158-11c1-52b8-0517-92f30e7fac88)
GPU 1: Tesla V100-SXM2-16GB-N (UUID: GPU-f22fb098-d1b3-3806-2655-ba25f02229c1)
GPU 2: Tesla V100-SXM2-16GB-N (UUID: GPU-f613f823-1032-b3ec-a876-50f2e35e6f9e)
GPU 3: Tesla V100-SXM2-16GB-N (UUID: GPU-3109fa37-4445-73c7-b695-1b5a4d13f58e)
GPU 4: Tesla V100-SXM2-16GB-N (UUID: GPU-e28a6529-288c-7ddf-8fea-68c4833cda70)
GPU 5: Tesla V100-SXM2-16GB-N (UUID: GPU-a27fb382-bad2-c02a-95ba-f6a1da38e76c)
GPU 6: Tesla V100-SXM2-16GB-N (UUID: GPU-f5bb8d07-ee19-1787-4d9a-a84c4ac6b086)
GPU 7: Tesla V100-SXM2-16GB-N (UUID: GPU-1ba0ca0e-6d1d-d9db-07d8-c1c5a8c32814)
```
works as expected

(without the change of the default this would return an error similar to):
```
$ docker run --rm -ti --runtime=runc --gpus="device=runtime.nvidia.com/gpu=0" ubuntu nvidia-smi -L
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: Auto-detected mode as 'cdi'
invoking the NVIDIA Container Runtime Hook directly (e.g. specifying the docker --gpus flag) is not supported. Please use the NVIDIA Container Runtime (e.g. specify the --runtime=nvidia flag) instead: unknown.
```