### PR TITLE
Disable nvsandboxutils in nvcdi API

### DIFF
--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -99,19 +99,24 @@ func New(opts ...Option) (Interface, error) {
 		}
 		l.nvmllib = nvml.New(nvmlOpts...)
 	}
-	if l.nvsandboxutilslib == nil {
-		var nvsandboxutilsOpts []nvsandboxutils.LibraryOption
-		// Set the library path for libnvidia-sandboxutils
-		candidates, err := l.driver.Libraries().Locate("libnvidia-sandboxutils.so.1")
-		if err != nil {
-			l.logger.Warningf("Ignoring error in locating libnvidia-sandboxutils.so.1: %v", err)
-		} else {
-			libNvidiaSandboxutilsPath := candidates[0]
-			l.logger.Infof("Using %v", libNvidiaSandboxutilsPath)
-			nvsandboxutilsOpts = append(nvsandboxutilsOpts, nvsandboxutils.WithLibraryPath(libNvidiaSandboxutilsPath))
-		}
-		l.nvsandboxutilslib = nvsandboxutils.New(nvsandboxutilsOpts...)
-	}
+	// TODO: Repeated calls to nvsandboxutils.Init and Shutdown are causing
+	// segmentation violations. Here we disabled nvsandbox utils unless explicitly
+	// specified.
+	// This will be reenabled as soon as we have more visibility into why this is
+	// happening and a mechanism to detect and disable this if required.
+	// if l.nvsandboxutilslib == nil {
+	// 	var nvsandboxutilsOpts []nvsandboxutils.LibraryOption
+	// 	// Set the library path for libnvidia-sandboxutils
+	// 	candidates, err := l.driver.Libraries().Locate("libnvidia-sandboxutils.so.1")
+	// 	if err != nil {
+	// 		l.logger.Warningf("Ignoring error in locating libnvidia-sandboxutils.so.1: %v", err)
+	// 	} else {
+	// 		libNvidiaSandboxutilsPath := candidates[0]
+	// 		l.logger.Infof("Using %v", libNvidiaSandboxutilsPath)
+	// 		nvsandboxutilsOpts = append(nvsandboxutilsOpts, nvsandboxutils.WithLibraryPath(libNvidiaSandboxutilsPath))
+	// 	}
+	// 	l.nvsandboxutilslib = nvsandboxutils.New(nvsandboxutilsOpts...)
+	// }
 	if l.devicelib == nil {
 		l.devicelib = device.New(l.nvmllib)
 	}


### PR DESCRIPTION
Repeated calls to nvsandboxutils.Init and Shutdown are causing segmentation violations. Here we disabled nvsandbox utils unless explicitly specified.

We will reenable the interaction with this library once the required checks and tests are in place to ensure that we don't introduce breakages.

This was tested by updating `nvidia-ctk cdi generate` to allow for multiple modes and validating that removing this initialisation fixes the failure.