### PR TITLE
Add ignore-imex-channel-requests feature flag

### DIFF
--- a/cmd/nvidia-container-runtime-hook/container_config.go
+++ b/cmd/nvidia-container-runtime-hook/container_config.go
@@ -198,6 +198,10 @@ func getMigDevices(image image.CUDA, envvar string) *string {
 }
 
 func (hookConfig *hookConfig) getImexChannels(image image.CUDA, privileged bool) []string {
+	if hookConfig.Features.IgnoreImexChannelRequests.IsEnabled() {
+		return nil
+	}
+
 	// If enabled, try and get the device list from volume mounts first
 	if hookConfig.AcceptDeviceListAsVolumeMounts {
 		devices := image.ImexChannelsFromMounts()

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -34,6 +34,17 @@ type features struct {
 	// DisableImexChannelCreation ensures that the implicit creation of
 	// requested IMEX channels is skipped when invoking the nvidia-container-cli.
 	DisableImexChannelCreation *feature `toml:"disable-imex-channel-creation,omitempty"`
+	// IgnoreImexChannelRequests configures the NVIDIA Container Toolkit to
+	// ignore IMEX channel requests through the NVIDIA_IMEX_CHANNELS envvar or
+	// volume mounts.
+	// This ensures that the NVIDIA Container Toolkit cannot be used to provide
+	// access to an IMEX channel by simply specifying an environment variable,
+	// possibly bypassing other checks by an orchestration system such as
+	// kubernetes.
+	// Note that this is not enabled by default to maintain backward compatibility
+	// with the existing behaviour when the NVIDIA Container Toolkit is used in
+	// non-kubernetes environments.
+	IgnoreImexChannelRequests *feature `toml:"ignore-imex-channel-requests,omitempty"`
 }
 
 type feature bool


### PR DESCRIPTION
This allows the NVIDIA Container Toolkit to ignore IMEX channel requests through the NVIDIA_IMEX_CHANNELS envvar or volume mounts and ensures that the NVIDIA Container Toolkit cannot be used to provide out-of-band access to an IMEX channel by simply specifying an environment variable, possibly bypassing other checks by an orchestration system such as kubernetes.

To enable this feature add the following to the `config.toml`:
```
[features]
ignore-imex-channel-requests = true
```
This can also be done by running:
```
sudo nvidia-ctk config --set features.ignore-imex-channel-requests
```

In the case of the toolkit container ensure that the `NVIDIA_CONTAINER_TOOLKIT_OPT_IN_FEATURES` includes `ignore-imex-channel-requests`.

Backport of #943 