### PR TITLE
Add option in toolkit container to enable CDI in runtime

### DIFF
--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -292,9 +292,8 @@ func (m command) configureConfigFile(c *cli.Context, config *config) error {
 		return fmt.Errorf("unable to update config: %v", err)
 	}
 
-	err = enableCDI(config, cfg)
-	if err != nil {
-		return fmt.Errorf("failed to enable CDI in %s: %w", config.runtime, err)
+	if config.cdi.enabled {
+		cfg.EnableCDI()
 	}
 
 	outputPath := config.getOutputConfigPath()
@@ -351,22 +350,6 @@ func (m *command) configureOCIHook(c *cli.Context, config *config) error {
 	err := ocihook.CreateHook(config.hookFilePath, config.nvidiaRuntime.hookPath)
 	if err != nil {
 		return fmt.Errorf("error creating OCI hook: %v", err)
-	}
-	return nil
-}
-
-// enableCDI enables the use of CDI in the corresponding container engine
-func enableCDI(config *config, cfg engine.Interface) error {
-	if !config.cdi.enabled {
-		return nil
-	}
-	switch config.runtime {
-	case "containerd":
-		cfg.Set("enable_cdi", true)
-	case "docker":
-		cfg.Set("features", map[string]bool{"cdi": true})
-	default:
-		return fmt.Errorf("enabling CDI in %s is not supported", config.runtime)
 	}
 	return nil
 }

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -163,7 +163,7 @@ func (m command) build() *cli.Command {
 		},
 		&cli.BoolFlag{
 			Name:        "cdi.enabled",
-			Aliases:     []string{"cdi.enable"},
+			Aliases:     []string{"cdi.enable", "enable-cdi"},
 			Usage:       "Enable CDI in the configured runtime",
 			Destination: &config.cdi.enabled,
 		},

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -24,7 +24,6 @@ type Interface interface {
 	GetRuntimeConfig(string) (RuntimeConfig, error)
 	RemoveRuntime(string) error
 	Save(string) (int64, error)
-	Set(string, interface{})
 	String() string
 }
 

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -20,6 +20,7 @@ package engine
 type Interface interface {
 	AddRuntime(string, string, bool) error
 	DefaultRuntime() string
+	EnableCDI()
 	GetRuntimeConfig(string) (RuntimeConfig, error)
 	RemoveRuntime(string) error
 	Save(string) (int64, error)

--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -111,6 +111,11 @@ func (c Config) DefaultRuntime() string {
 	return ""
 }
 
+// EnableCDI sets the enable_cdi field in the Containerd config to true.
+func (c *Config) EnableCDI() {
+	c.Set("enable_cdi", true)
+}
+
 // RemoveRuntime removes a runtime from the docker config
 func (c *Config) RemoveRuntime(name string) error {
 	if c == nil || c.Tree == nil {

--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -96,13 +96,6 @@ func (c *Config) getRuntimeAnnotations(path []string) ([]string, error) {
 	return annotations, nil
 }
 
-// Set sets the specified containerd option.
-func (c *Config) Set(key string, value interface{}) {
-	config := *c.Tree
-	config.SetPath([]string{"plugins", c.CRIRuntimePluginName, key}, value)
-	*c.Tree = config
-}
-
 // DefaultRuntime returns the default runtime for the cri-o config
 func (c Config) DefaultRuntime() string {
 	if runtime, ok := c.GetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "default_runtime_name"}).(string); ok {
@@ -113,7 +106,9 @@ func (c Config) DefaultRuntime() string {
 
 // EnableCDI sets the enable_cdi field in the Containerd config to true.
 func (c *Config) EnableCDI() {
-	c.Set("enable_cdi", true)
+	config := *c.Tree
+	config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "enable_cdi"}, true)
+	*c.Tree = config
 }
 
 // RemoveRuntime removes a runtime from the docker config

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -143,13 +143,6 @@ func (c *ConfigV1) RemoveRuntime(name string) error {
 	return nil
 }
 
-// Set sets the specified containerd option.
-func (c *ConfigV1) Set(key string, value interface{}) {
-	config := *c.Tree
-	config.SetPath([]string{"plugins", "cri", "containerd", key}, value)
-	*c.Tree = config
-}
-
 // Save writes the config to a file
 func (c ConfigV1) Save(path string) (int64, error) {
 	return (Config)(c).Save(path)
@@ -167,5 +160,7 @@ func (c *ConfigV1) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 }
 
 func (c *ConfigV1) EnableCDI() {
-	c.Set("enable_cdi", true)
+	config := *c.Tree
+	config.SetPath([]string{"plugins", "cri", "containerd", "enable_cdi"}, true)
+	*c.Tree = config
 }

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -165,3 +165,7 @@ func (c *ConfigV1) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 		tree: runtimeData,
 	}, nil
 }
+
+func (c *ConfigV1) EnableCDI() {
+	c.Set("enable_cdi", true)
+}

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -153,6 +153,9 @@ func (c *Config) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 	}, nil
 }
 
+// EnableCDI is a no-op for CRI-O since it always enabled where supported.
+func (c *Config) EnableCDI() {}
+
 // CommandLineSource returns the CLI-based crio config loader
 func CommandLineSource(hostRoot string) toml.Loader {
 	return toml.LoadFirst(

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -105,7 +105,20 @@ func (c Config) DefaultRuntime() string {
 
 // EnableCDI sets features.cdi to true in the docker config.
 func (c *Config) EnableCDI() {
-	(*c)["features"] = map[string]bool{"cdi": true}
+	if c == nil {
+		return
+	}
+	config := *c
+
+	features, ok := config["features"].(map[string]bool)
+	if !ok {
+		features = make(map[string]bool)
+	}
+	features["cdi"] = true
+
+	config["features"] = features
+
+	*c = config
 }
 
 // RemoveRuntime removes a runtime from the docker config

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -105,7 +105,7 @@ func (c Config) DefaultRuntime() string {
 
 // EnableCDI sets features.cdi to true in the docker config.
 func (c *Config) EnableCDI() {
-	c.Set("features", map[string]bool{"cdi": true})
+	(*c)["features"] = map[string]bool{"cdi": true}
 }
 
 // RemoveRuntime removes a runtime from the docker config
@@ -135,11 +135,6 @@ func (c *Config) RemoveRuntime(name string) error {
 	*c = config
 
 	return nil
-}
-
-// Set sets the specified docker option
-func (c *Config) Set(key string, value interface{}) {
-	(*c)[key] = value
 }
 
 // Save writes the config to the specified path

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -103,6 +103,11 @@ func (c Config) DefaultRuntime() string {
 	return r
 }
 
+// EnableCDI sets features.cdi to true in the docker config.
+func (c *Config) EnableCDI() {
+	c.Set("features", map[string]bool{"cdi": true})
+}
+
 // RemoveRuntime removes a runtime from the docker config
 func (c *Config) RemoveRuntime(name string) error {
 	if c == nil {

--- a/tools/container/container.go
+++ b/tools/container/container.go
@@ -36,8 +36,10 @@ const (
 
 // Options defines the shared options for the CLIs to configure containers runtimes.
 type Options struct {
-	Config        string
-	Socket        string
+	Config string
+	Socket string
+	// EnabledCDI indicates whether CDI should be enabled.
+	EnableCDI     bool
 	RuntimeName   string
 	RuntimeDir    string
 	SetAsDefault  bool
@@ -109,6 +111,10 @@ func (o Options) UpdateConfig(cfg engine.Interface) error {
 		if err != nil {
 			return fmt.Errorf("failed to update runtime %q: %v", name, err)
 		}
+	}
+
+	if o.EnableCDI {
+		cfg.EnableCDI()
 	}
 
 	return nil

--- a/tools/container/nvidia-toolkit/run.go
+++ b/tools/container/nvidia-toolkit/run.go
@@ -129,14 +129,14 @@ func main() {
 	log.Infof("Completed %v", c.Name)
 }
 
-func validateFlags(_ *cli.Context, o *options) error {
+func validateFlags(c *cli.Context, o *options) error {
 	if filepath.Base(o.pidFile) != toolkitPidFilename {
 		return fmt.Errorf("invalid toolkit.pid path %v", o.pidFile)
 	}
 	if err := toolkit.ValidateOptions(&o.toolkitOptions, o.toolkitRoot()); err != nil {
 		return err
 	}
-	if err := runtime.ValidateOptions(&o.runtimeOptions, o.runtime, o.toolkitRoot()); err != nil {
+	if err := runtime.ValidateOptions(c, &o.runtimeOptions, o.runtime, o.toolkitRoot(), &o.toolkitOptions); err != nil {
 		return err
 	}
 	return nil

--- a/tools/container/runtime/runtime.go
+++ b/tools/container/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container/runtime/containerd"
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container/runtime/crio"
 	"github.com/NVIDIA/nvidia-container-toolkit/tools/container/runtime/docker"
+	"github.com/NVIDIA/nvidia-container-toolkit/tools/container/toolkit"
 )
 
 const (
@@ -104,9 +105,13 @@ func Flags(opts *Options) []cli.Flag {
 }
 
 // ValidateOptions checks whether the specified options are valid
-func ValidateOptions(opts *Options, runtime string, toolkitRoot string) error {
+func ValidateOptions(c *cli.Context, opts *Options, runtime string, toolkitRoot string, to *toolkit.Options) error {
 	// We set this option here to ensure that it is available in future calls.
 	opts.RuntimeDir = toolkitRoot
+
+	if !c.IsSet("enable-cdi-in-runtime") {
+		opts.EnableCDI = to.CDI.Enabled
+	}
 
 	// Apply the runtime-specific config changes.
 	switch runtime {

--- a/tools/container/runtime/runtime.go
+++ b/tools/container/runtime/runtime.go
@@ -66,6 +66,12 @@ func Flags(opts *Options) []cli.Flag {
 			Destination: &opts.RestartMode,
 			EnvVars:     []string{"RUNTIME_RESTART_MODE"},
 		},
+		&cli.BoolFlag{
+			Name:        "enable-cdi-in-runtime",
+			Usage:       "Enable CDI in the configured runt	ime",
+			Destination: &opts.EnableCDI,
+			EnvVars:     []string{"RUNTIME_ENABLE_CDI"},
+		},
 		&cli.StringFlag{
 			Name:        "host-root",
 			Usage:       "Specify the path to the host root to be used when restarting the runtime using systemd",


### PR DESCRIPTION
These changes add an option to enable CDI in container engines (containerd, crio, docker) from the toolkit contaienr.

This can be triggered through the `--enable-cdi-in-runtime` command line option or `RUNTIME_ENABLE_CDI` environment variable.

Backports #838