### PR TITLE
Allow nvidia-ctk config --set to accept comma-separated lists

### DIFF
--- a/cmd/nvidia-ctk/config/config.go
+++ b/cmd/nvidia-ctk/config/config.go
@@ -194,7 +194,14 @@ func setFlagToKeyValue(setFlag string, setListSeparator string) (string, interfa
 	case reflect.String:
 		return key, value, nil
 	case reflect.Slice:
-		valueParts := strings.Split(value, setListSeparator)
+		valueParts := []string{value}
+		for _, sep := range []string{setListSeparator, ","} {
+			if !strings.Contains(value, sep) {
+				continue
+			}
+			valueParts = strings.Split(value, sep)
+			break
+		}
 		switch field.Elem().Kind() {
 		case reflect.String:
 			return key, valueParts, nil

--- a/cmd/nvidia-ctk/main.go
+++ b/cmd/nvidia-ctk/main.go
@@ -49,6 +49,7 @@ func main() {
 
 	// Create the top-level CLI
 	c := cli.NewApp()
+	c.DisableSliceFlagSeparator = true
 	c.Name = "NVIDIA Container Toolkit CLI"
 	c.UseShortOptionHandling = true
 	c.EnableBashCompletion = true


### PR DESCRIPTION
The urfave update to v2.27.6 fixes the behaviour when disabling a separator for repeated StringSliceFlags. This change updates the nvidia-ctk config command to allow list options to be specified as comma-separated values.

For example:
```
➜  container-toolkit git:(allow-comma-separated-config-values) ✗ ./nvidia-ctk config --set nvidia-container-runtime.runtimes=foo,bar,baz | grep runtimes
runtimes = ["foo", "bar", "baz"]
➜  container-toolkit git:(allow-comma-separated-config-values) ✗ ./nvidia-ctk config --set nvidia-container-runtime.runtimes=foo:bar:baz | grep runtimes
runtimes = ["foo", "bar", "baz"]
```