### PR TITLE
Load NVIDIA Kernel Modules for JIT-CDI mode

### DIFF
--- a/cmd/nvidia-ctk-installer/main_test.go
+++ b/cmd/nvidia-ctk-installer/main_test.go
@@ -141,6 +141,9 @@ swarm-resource = ""
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+    [nvidia-container-runtime.modes.jit-cdi]
+      load-kernel-modules = ["nvidia", "nvidia-uvm", "nvidia-modeset"]
+
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
   skip-mode-detection = true
@@ -201,6 +204,9 @@ swarm-resource = ""
 
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+    [nvidia-container-runtime.modes.jit-cdi]
+      load-kernel-modules = ["nvidia", "nvidia-uvm", "nvidia-modeset"]
 
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
@@ -266,6 +272,9 @@ swarm-resource = ""
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+    [nvidia-container-runtime.modes.jit-cdi]
+      load-kernel-modules = ["nvidia", "nvidia-uvm", "nvidia-modeset"]
+
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
   skip-mode-detection = true
@@ -326,6 +335,9 @@ swarm-resource = ""
 
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+    [nvidia-container-runtime.modes.jit-cdi]
+      load-kernel-modules = ["nvidia", "nvidia-uvm", "nvidia-modeset"]
 
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
@@ -409,6 +421,9 @@ swarm-resource = ""
 
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+    [nvidia-container-runtime.modes.jit-cdi]
+      load-kernel-modules = ["nvidia", "nvidia-uvm", "nvidia-modeset"]
 
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,9 @@ func GetDefault() (*Config, error) {
 					AnnotationPrefixes: []string{cdi.AnnotationPrefix},
 					SpecDirs:           cdi.DefaultSpecDirs,
 				},
+				JitCDI: jitCDIModeConfig{
+					LoadKernelModules: []string{"nvidia", "nvidia-uvm", "nvidia-modeset"},
+				},
 			},
 		},
 		NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,9 @@ func TestGetConfig(t *testing.T) {
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
 						},
+						JitCDI: jitCDIModeConfig{
+							LoadKernelModules: []string{"nvidia", "nvidia-uvm", "nvidia-modeset"},
+						},
 					},
 				},
 				NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{
@@ -102,6 +105,7 @@ func TestGetConfig(t *testing.T) {
 				"nvidia-container-runtime.modes.cdi.annotation-prefixes = [\"cdi.k8s.io/\", \"example.vendor.com/\",]",
 				"nvidia-container-runtime.modes.cdi.spec-dirs = [\"/except/etc/cdi\", \"/not/var/run/cdi\",]",
 				"nvidia-container-runtime.modes.csv.mount-spec-path = \"/not/etc/nvidia-container-runtime/host-files-for-container.d\"",
+				"nvidia-container-runtime.modes.jit-cdi.load-kernel-modules = [\"foo\"]",
 				"nvidia-container-runtime-hook.path = \"/foo/bar/nvidia-container-runtime-hook\"",
 				"nvidia-ctk.path = \"/foo/bar/nvidia-ctk\"",
 			},
@@ -133,6 +137,9 @@ func TestGetConfig(t *testing.T) {
 								"/except/etc/cdi",
 								"/not/var/run/cdi",
 							},
+						},
+						JitCDI: jitCDIModeConfig{
+							LoadKernelModules: []string{"foo"},
 						},
 					},
 				},
@@ -178,6 +185,9 @@ func TestGetConfig(t *testing.T) {
 								"/var/run/cdi",
 							},
 						},
+						JitCDI: jitCDIModeConfig{
+							LoadKernelModules: []string{"nvidia", "nvidia-uvm", "nvidia-modeset"},
+						},
 					},
 				},
 				NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{
@@ -213,6 +223,8 @@ func TestGetConfig(t *testing.T) {
 				"spec-dirs = [\"/except/etc/cdi\", \"/not/var/run/cdi\",]",
 				"[nvidia-container-runtime.modes.csv]",
 				"mount-spec-path = \"/not/etc/nvidia-container-runtime/host-files-for-container.d\"",
+				"[nvidia-container-runtime.modes.jit-cdi]",
+				"load-kernel-modules = [\"foo\"]",
 				"[nvidia-container-runtime-hook]",
 				"path = \"/foo/bar/nvidia-container-runtime-hook\"",
 				"[nvidia-ctk]",
@@ -246,6 +258,9 @@ func TestGetConfig(t *testing.T) {
 								"/except/etc/cdi",
 								"/not/var/run/cdi",
 							},
+						},
+						JitCDI: jitCDIModeConfig{
+							LoadKernelModules: []string{"foo"},
 						},
 					},
 				},
@@ -282,6 +297,9 @@ func TestGetConfig(t *testing.T) {
 							DefaultKind:        "nvidia.com/gpu",
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
+						},
+						JitCDI: jitCDIModeConfig{
+							LoadKernelModules: []string{"nvidia", "nvidia-uvm", "nvidia-modeset"},
 						},
 					},
 				},
@@ -321,6 +339,9 @@ func TestGetConfig(t *testing.T) {
 							DefaultKind:        "nvidia.com/gpu",
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
+						},
+						JitCDI: jitCDIModeConfig{
+							LoadKernelModules: []string{"nvidia", "nvidia-uvm", "nvidia-modeset"},
 						},
 					},
 				},

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -29,8 +29,9 @@ type RuntimeConfig struct {
 
 // modesConfig defines (optional) per-mode configs
 type modesConfig struct {
-	CSV csvModeConfig `toml:"csv"`
-	CDI cdiModeConfig `toml:"cdi"`
+	CSV    csvModeConfig    `toml:"csv"`
+	CDI    cdiModeConfig    `toml:"cdi"`
+	JitCDI jitCDIModeConfig `toml:"jit-cdi"`
 }
 
 type cdiModeConfig struct {
@@ -44,4 +45,12 @@ type cdiModeConfig struct {
 
 type csvModeConfig struct {
 	MountSpecPath string `toml:"mount-spec-path"`
+}
+
+type jitCDIModeConfig struct {
+	// LoadKernelModules defines the names of the kernel modules that should be
+	// loaded before generating a just-in-time CDI specification.
+	// The module names must start with `nvidia` and if no modules are specified
+	// no kernel modules are loaded.
+	LoadKernelModules []string `toml:"load-kernel-modules"`
 }

--- a/internal/config/toml_test.go
+++ b/internal/config/toml_test.go
@@ -74,6 +74,9 @@ spec-dirs = ["/etc/cdi", "/var/run/cdi"]
 [nvidia-container-runtime.modes.csv]
 mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+[nvidia-container-runtime.modes.jit-cdi]
+load-kernel-modules = ["nvidia", "nvidia-uvm", "nvidia-modeset"]
+
 [nvidia-container-runtime-hook]
 path = "nvidia-container-runtime-hook"
 skip-mode-detection = false

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -77,7 +77,7 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 	mode := info.ResolveAutoMode(logger, cfg.NVIDIAContainerRuntimeConfig.Mode, image)
 	// We update the mode here so that we can continue passing just the config to other functions.
 	cfg.NVIDIAContainerRuntimeConfig.Mode = mode
-	modeModifier, err := newModeModifier(logger, mode, cfg, ociSpec, image)
+	modeModifier, err := newModeModifier(logger, mode, cfg, driver, ociSpec, image)
 	if err != nil {
 		return nil, err
 	}
@@ -107,14 +107,14 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 	return modifiers, nil
 }
 
-func newModeModifier(logger logger.Interface, mode string, cfg *config.Config, ociSpec oci.Spec, image image.CUDA) (oci.SpecModifier, error) {
+func newModeModifier(logger logger.Interface, mode string, cfg *config.Config, driver *root.Driver, ociSpec oci.Spec, image image.CUDA) (oci.SpecModifier, error) {
 	switch mode {
 	case "legacy":
 		return modifier.NewStableRuntimeModifier(logger, cfg.NVIDIAContainerRuntimeHookConfig.Path), nil
 	case "csv":
 		return modifier.NewCSVModifier(logger, cfg, image)
 	case "cdi":
-		return modifier.NewCDIModifier(logger, cfg, ociSpec)
+		return modifier.NewCDIModifier(logger, cfg, driver, ociSpec)
 	}
 
 	return nil, fmt.Errorf("invalid runtime mode: %v", cfg.NVIDIAContainerRuntimeConfig.Mode)


### PR DESCRIPTION
This change attempts to load the nvidia, nvidia-uvm, and nvidia-modeset kernel modules (NVIDIA kernel-mode GPU drivers) before generating the automatic (jit) CDI specification. This aligns the behaviour of the JIT-CDI mode with that of the [`nvidia-container-cli`](https://github.com/NVIDIA/libnvidia-container/blob/95d3e86522976061e856724867ebcaf75c4e9b60/src/nvc.c#L232).

The kernel modules can be controlled by the

`nvidia-container-runtime.modes.jit-cdi.load-kernel-modules`

config option. If this is set to the empty list, then no kernel modules are loaded.

Errors in loading the kernel modules are logged, but ignored.