### PR TITLE
[no-relnotes] Update moq to use rm and goimports

### DIFF
--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -38,7 +38,7 @@ type Hook struct {
 
 // Discover defines an interface for discovering the devices, mounts, and hooks available on a system
 //
-//go:generate moq -stub -out discover_mock.go . Discover
+//go:generate moq -rm -fmt=goimports -stub -out discover_mock.go . Discover
 type Discover interface {
 	Devices() ([]Device, error)
 	Mounts() ([]Mount, error)

--- a/internal/info/proc/devices/devices.go
+++ b/internal/info/proc/devices/devices.go
@@ -49,7 +49,7 @@ type Major int
 
 // Devices represents the set of devices under /proc/devices
 //
-//go:generate moq -stub -out devices_mock.go . Devices
+//go:generate moq -rm -fmt=goimports -stub -out devices_mock.go . Devices
 type Devices interface {
 	Exists(Name) bool
 	Get(Name) (Major, bool)

--- a/internal/ldcache/ldcache.go
+++ b/internal/ldcache/ldcache.go
@@ -79,7 +79,7 @@ type entry2 struct {
 
 // LDCache represents the interface for performing lookups into the LDCache
 //
-//go:generate moq -rm -out ldcache_mock.go . LDCache
+//go:generate moq -rm -fmt=goimports -out ldcache_mock.go . LDCache
 type LDCache interface {
 	List() ([]string, []string)
 }

--- a/internal/lookup/locator.go
+++ b/internal/lookup/locator.go
@@ -18,7 +18,7 @@ package lookup
 
 import "errors"
 
-//go:generate moq -stub -out locator_mock.go . Locator
+//go:generate moq -rm -fmt=goimports -stub -out locator_mock.go . Locator
 
 // Locator defines the interface for locating files on a system.
 type Locator interface {

--- a/internal/nvsandboxutils/gen/nvsandboxutils/generateapi.go
+++ b/internal/nvsandboxutils/gen/nvsandboxutils/generateapi.go
@@ -167,7 +167,7 @@ func generateInterfaceComment(input GeneratableInterfacePoperties) (string, erro
 	commentFmt := []string{
 		"// %s represents the interface for the %s type.",
 		"//",
-		"//go:generate moq -out mock/%s.go -pkg mock . %s:%s",
+		"//go:generate moq -rm -fmt=goimports -out mock/%s.go -pkg mock . %s:%s",
 	}
 
 	var signature strings.Builder

--- a/internal/nvsandboxutils/lib.go
+++ b/internal/nvsandboxutils/lib.go
@@ -35,7 +35,7 @@ var errLibraryAlreadyLoaded = errors.New("library already loaded")
 // dynamicLibrary is an interface for abstacting the underlying library.
 // This also allows for mocking and testing.
 
-//go:generate moq -rm -stub -out dynamicLibrary_mock.go . dynamicLibrary
+//go:generate moq -rm -fmt=goimports -stub -out dynamicLibrary_mock.go . dynamicLibrary
 type dynamicLibrary interface {
 	Lookup(string) error
 	Open() error

--- a/internal/nvsandboxutils/mock/interface.go
+++ b/internal/nvsandboxutils/mock/interface.go
@@ -4,8 +4,9 @@
 package mock
 
 import (
-	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvsandboxutils"
 	"sync"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvsandboxutils"
 )
 
 // Ensure, that Interface does implement nvsandboxutils.Interface.

--- a/internal/nvsandboxutils/zz_generated.api.go
+++ b/internal/nvsandboxutils/zz_generated.api.go
@@ -31,7 +31,7 @@ var (
 
 // Interface represents the interface for the library type.
 //
-//go:generate moq -out mock/interface.go -pkg mock . Interface:Interface
+//go:generate moq -rm -fmt=goimports -out mock/interface.go -pkg mock . Interface:Interface
 type Interface interface {
 	ErrorString(Ret) string
 	GetDriverVersion() (string, Ret)

--- a/internal/oci/runtime.go
+++ b/internal/oci/runtime.go
@@ -19,7 +19,7 @@ package oci
 // Runtime is an interface for a runtime shim. The Exec method accepts a list
 // of command line arguments, and returns an error / nil.
 //
-//go:generate moq -rm -stub -out runtime_mock.go . Runtime
+//go:generate moq -rm -fmt=goimports -stub -out runtime_mock.go . Runtime
 type Runtime interface {
 	Exec([]string) error
 	String() string

--- a/internal/oci/spec.go
+++ b/internal/oci/spec.go
@@ -33,7 +33,7 @@ type SpecModifier interface {
 
 // Spec defines the operations to be performed on an OCI specification
 //
-//go:generate moq -stub -out spec_mock.go . Spec
+//go:generate moq -rm -fmt=goimports -stub -out spec_mock.go . Spec
 type Spec interface {
 	Load() (*specs.Spec, error)
 	Flush() error

--- a/internal/requirements/constraints/constraints.go
+++ b/internal/requirements/constraints/constraints.go
@@ -18,7 +18,7 @@ package constraints
 
 // Constraint represents a constraint that is to be evaluated
 //
-//go:generate moq -stub -out constraint_mock.go . Constraint
+//go:generate moq -rm -fmt=goimports -stub -out constraint_mock.go . Constraint
 type Constraint interface {
 	String() string
 	Assert() error

--- a/internal/requirements/constraints/property.go
+++ b/internal/requirements/constraints/property.go
@@ -25,7 +25,7 @@ import (
 
 // Property represents a property that is used to check requirements
 //
-//go:generate moq -stub -out property_mock.go . Property
+//go:generate moq -rm -fmt=goimports -stub -out property_mock.go . Property
 type Property interface {
 	Name() string
 	Value() (string, error)

--- a/internal/system/nvdevices/mknod.go
+++ b/internal/system/nvdevices/mknod.go
@@ -25,7 +25,7 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 )
 
-//go:generate moq -stub -out mknod_mock.go . mknoder
+//go:generate moq -rm -fmt=goimports -stub -out mknod_mock.go . mknoder
 type mknoder interface {
 	Mknode(string, int, int) error
 }

--- a/internal/system/nvmodules/cmd.go
+++ b/internal/system/nvmodules/cmd.go
@@ -24,7 +24,7 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 )
 
-//go:generate moq -stub -out cmd_mock.go . cmder
+//go:generate moq -rm -fmt=goimports -stub -out cmd_mock.go . cmder
 type cmder interface {
 	// Run executes the command and returns the stdout, stderr, and an error if any
 	Run(string, ...string) error

--- a/pkg/nvcdi/namer.go
+++ b/pkg/nvcdi/namer.go
@@ -96,7 +96,7 @@ func (s deviceNameUUID) GetMigDeviceName(i int, _ UUIDer, j int, mig UUIDer) (st
 	return uuid, nil
 }
 
-//go:generate moq -stub -out namer_nvml_mock.go . nvmlUUIDer
+//go:generate moq -rm -fmt=goimports -stub -out namer_nvml_mock.go . nvmlUUIDer
 type nvmlUUIDer interface {
 	GetUUID() (string, nvml.Return)
 }


### PR DESCRIPTION
This change ensures that the go imports are properly formatted in generated mocks (using `goimports`).

The `-rm` flag is also added to ensure that previous mocks are removed before generation.