### PR TITLE
Issue warning on unsupported CDI hook

### DIFF
--- a/cmd/nvidia-cdi-hook/commands/commands.go
+++ b/cmd/nvidia-cdi-hook/commands/commands.go
@@ -36,3 +36,16 @@ func New(logger logger.Interface) []*cli.Command {
 		cudacompat.NewCommand(logger),
 	}
 }
+
+// IssueUnsupportedHookWarning logs a warning that no hook or an unsupported
+// hook has been specified.
+// This happens if a subcommand is provided that does not match one of the
+// subcommands that has been explicitly specified.
+func IssueUnsupportedHookWarning(logger logger.Interface, c *cli.Context) {
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		logger.Warningf("No CDI hook specified")
+	} else {
+		logger.Warningf("Unsupported CDI hook: %v", args[0])
+	}
+}

--- a/cmd/nvidia-cdi-hook/main.go
+++ b/cmd/nvidia-cdi-hook/main.go
@@ -51,6 +51,18 @@ func main() {
 	c.Usage = "Command to structure files for usage inside a container, called as hooks from a container runtime, defined in a CDI yaml file"
 	c.Version = info.GetVersionString()
 
+	// We set the default action for the `nvidia-cdi-hook` command to issue a
+	// warning and exit with no error.
+	// This means that if an unsupported hook is run, a container will not fail
+	// to launch. An unsupported hook could be the result of a CDI specification
+	// referring to a new hook that is not yet supported by an older NVIDIA
+	// Container Toolkit version or a hook that has been removed in newer
+	// version.
+	c.Action = func(ctx *cli.Context) error {
+		commands.IssueUnsupportedHookWarning(logger, ctx)
+		return nil
+	}
+
 	// Setup the flags for this command
 	c.Flags = []cli.Flag{
 		&cli.BoolFlag{

--- a/cmd/nvidia-ctk/hook/hook.go
+++ b/cmd/nvidia-ctk/hook/hook.go
@@ -27,7 +27,7 @@ type hookCommand struct {
 	logger logger.Interface
 }
 
-// NewCommand constructs a hook command with the specified logger
+// NewCommand constructs CLI subcommand for handling CDI hooks.
 func NewCommand(logger logger.Interface) *cli.Command {
 	c := hookCommand{
 		logger: logger,
@@ -37,10 +37,21 @@ func NewCommand(logger logger.Interface) *cli.Command {
 
 // build
 func (m hookCommand) build() *cli.Command {
-	// Create the 'hook' command
+	// Create the 'hook' subcommand
 	hook := cli.Command{
 		Name:  "hook",
 		Usage: "A collection of hooks that may be injected into an OCI spec",
+		// We set the default action for the `hook` subcommand to issue a
+		// warning and exit with no error.
+		// This means that if an unsupported hook is run, a container will not fail
+		// to launch. An unsupported hook could be the result of a CDI specification
+		// referring to a new hook that is not yet supported by an older NVIDIA
+		// Container Toolkit version or a hook that has been removed in newer
+		// version.
+		Action: func(ctx *cli.Context) error {
+			commands.IssueUnsupportedHookWarning(m.logger, ctx)
+			return nil
+		},
 	}
 
 	hook.Subcommands = commands.New(m.logger)


### PR DESCRIPTION
To allow for CDI hooks to be added gradually we provide a generic no-op hook for unrecognised subcommands. This will log a warning (to STDERR) instead of erroring out.

For example:
```
$ ./nvidia-cdi-hook foo
WARN[0000] Unsupported CDI hook: foo
$ echo $?
0
$ ./nvidia-cdi-hook
WARN[0000] No CDI hook specified
$ echo $?
0
```

```
./nvidia-ctk hook foo
WARN[0000] Unsupported CDI hook: foo
$ echo $?
0
./nvidia-ctk hook
WARN[0000] No CDI hook specified
$ echo $?
0
```