### PR TITLE
Fix update-ldcache arguments

### DIFF
--- a/cmd/nvidia-cdi-hook/update-ldcache/update-ldcache.go
+++ b/cmd/nvidia-cdi-hook/update-ldcache/update-ldcache.go
@@ -109,14 +109,20 @@ func (m command) run(c *cli.Context, cfg *options) error {
 	}
 
 	containerRootDir, err := s.GetContainerRoot()
-	if err != nil {
+	if err != nil || containerRootDir == "" || containerRootDir == "/" {
 		return fmt.Errorf("failed to determined container root: %v", err)
 	}
 
 	ldconfigPath := m.resolveLDConfigPath(cfg.ldconfigPath)
-	args := []string{filepath.Base(ldconfigPath)}
-	if containerRootDir != "" {
-		args = append(args, "-r", containerRootDir)
+	args := []string{
+		filepath.Base(ldconfigPath),
+		// Run ldconfig in the container root directory on the host.
+		"-r", containerRootDir,
+		// Explicitly specify using /etc/ld.so.conf since the host's ldconfig may
+		// be configured to use a different config file by default.
+		// Note that since we apply the `-r {{ .containerRootDir }}` argument, /etc/ld.so.conf is
+		// in the container.
+		"-f", "/etc/ld.so.conf",
 	}
 
 	containerRoot := containerRoot(containerRootDir)
@@ -137,10 +143,6 @@ func (m command) run(c *cli.Context, cfg *options) error {
 	} else {
 		args = append(args, folders...)
 	}
-
-	// Explicitly specify using /etc/ld.so.conf since the host's ldconfig may
-	// be configured to use a different config file by default.
-	args = append(args, "-f", "/etc/ld.so.conf")
 
 	return m.SafeExec(ldconfigPath, args, nil)
 }


### PR DESCRIPTION
This change updates how the lconfig arguments are constructed. This makes the update-ldcache more robust and ensures that folders are specified last if at al.

Checks are also included for empty container roots at the start of the hook to simplify later checks.