### PR TITLE
Add support for building ubuntu22.04 on amd64

### DIFF
--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Supported OSs by architecture
-AMD64_TARGETS := ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
+AMD64_TARGETS := ubuntu22.04 ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
 X86_64_TARGETS := centos7 centos8 rhel7 rhel8 amazonlinux2 opensuse-leap15.1
 PPC64LE_TARGETS := ubuntu18.04 ubuntu16.04 centos7 centos8 rhel7 rhel8
 ARM64_TARGETS := ubuntu20.04 ubuntu18.04

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -16,7 +16,7 @@
 AMD64_TARGETS := ubuntu22.04 ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
 X86_64_TARGETS := centos7 centos8 rhel7 rhel8 amazonlinux2 opensuse-leap15.1
 PPC64LE_TARGETS := ubuntu18.04 ubuntu16.04 centos7 centos8 rhel7 rhel8
-ARM64_TARGETS := ubuntu20.04 ubuntu18.04
+ARM64_TARGETS := ubuntu22.04 ubuntu20.04 ubuntu18.04
 AARCH64_TARGETS := centos7 centos8 rhel8 amazonlinux2
 
 # Define top-level build targets


### PR DESCRIPTION
Manual build for nvidia-contaier-toolkit is necessary! It can help open source community with debug and adding new features to this magnificent utility!

Manual build correct working was tested by me on ubuntu22.04 (run docker with gpus all on different models).