### PR TITLE
Allow container runtime executable path to be specified

### DIFF
--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -72,8 +72,6 @@ type config struct {
 	mode           string
 	hookFilePath   string
 
-	runtimeConfigOverrideJSON string
-
 	nvidiaRuntime struct {
 		name         string
 		path         string
@@ -206,11 +204,6 @@ func (m command) validateFlags(c *cli.Context, config *config) error {
 			m.logger.Warningf("Ignoring cdi.enabled flag for %v", config.runtime)
 		}
 		config.cdi.enabled = false
-	}
-
-	if config.runtimeConfigOverrideJSON != "" && config.runtime != "containerd" {
-		m.logger.Warningf("Ignoring runtime-config-override flag for %v", config.runtime)
-		config.runtimeConfigOverrideJSON = ""
 	}
 
 	switch config.configSource {

--- a/pkg/config/engine/containerd/containerd.go
+++ b/pkg/config/engine/containerd/containerd.go
@@ -162,8 +162,11 @@ func (c *Config) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 }
 
 // CommandLineSource returns the CLI-based containerd config loader
-func CommandLineSource(hostRoot string) toml.Loader {
-	return toml.FromCommandLine(chrootIfRequired(hostRoot, "containerd", "config", "dump")...)
+func CommandLineSource(hostRoot string, executablePath string) toml.Loader {
+	if executablePath == "" {
+		executablePath = "containerd"
+	}
+	return toml.FromCommandLine(chrootIfRequired(hostRoot, executablePath, "config", "dump")...)
 }
 
 func chrootIfRequired(hostRoot string, commandLine ...string) []string {

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -157,9 +157,12 @@ func (c *Config) GetRuntimeConfig(name string) (engine.RuntimeConfig, error) {
 func (c *Config) EnableCDI() {}
 
 // CommandLineSource returns the CLI-based crio config loader
-func CommandLineSource(hostRoot string) toml.Loader {
+func CommandLineSource(hostRoot string, executablePath string) toml.Loader {
+	if executablePath == "" {
+		executablePath = "crio"
+	}
 	return toml.LoadFirst(
-		toml.FromCommandLine(chrootIfRequired(hostRoot, "crio", "status", "config")...),
+		toml.FromCommandLine(chrootIfRequired(hostRoot, executablePath, "status", "config")...),
 		toml.FromCommandLine(chrootIfRequired(hostRoot, "crio-status", "config")...),
 	)
 }

--- a/tools/container/container.go
+++ b/tools/container/container.go
@@ -38,6 +38,11 @@ const (
 type Options struct {
 	Config string
 	Socket string
+	// ExecutablePath specifies the path to the container runtime executable.
+	// This is used to extract the current config, for example.
+	// If a HostRootMount is specified, this path is relative to the host root
+	// mount.
+	ExecutablePath string
 	// EnabledCDI indicates whether CDI should be enabled.
 	EnableCDI     bool
 	RuntimeName   string

--- a/tools/container/nvidia-toolkit/run.go
+++ b/tools/container/nvidia-toolkit/run.go
@@ -136,7 +136,7 @@ func validateFlags(c *cli.Context, o *options) error {
 	if err := toolkit.ValidateOptions(&o.toolkitOptions, o.toolkitRoot()); err != nil {
 		return err
 	}
-	if err := runtime.ValidateOptions(c, &o.runtimeOptions, o.runtime, o.toolkitRoot(), &o.toolkitOptions); err != nil {
+	if err := o.runtimeOptions.Validate(c, o.runtime, o.toolkitRoot(), &o.toolkitOptions); err != nil {
 		return err
 	}
 	return nil

--- a/tools/container/runtime/containerd/containerd.go
+++ b/tools/container/runtime/containerd/containerd.go
@@ -173,7 +173,7 @@ func getRuntimeConfig(o *container.Options, co *Options) (engine.Interface, erro
 		containerd.WithPath(o.Config),
 		containerd.WithConfigSource(
 			toml.LoadFirst(
-				containerd.CommandLineSource(o.HostRootMount),
+				containerd.CommandLineSource(o.HostRootMount, o.ExecutablePath),
 				toml.FromFile(o.Config),
 			),
 		),

--- a/tools/container/runtime/crio/crio.go
+++ b/tools/container/runtime/crio/crio.go
@@ -202,7 +202,7 @@ func getRuntimeConfig(o *container.Options) (engine.Interface, error) {
 		crio.WithPath(o.Config),
 		crio.WithConfigSource(
 			toml.LoadFirst(
-				crio.CommandLineSource(o.HostRootMount),
+				crio.CommandLineSource(o.HostRootMount, o.ExecutablePath),
 				toml.FromFile(o.Config),
 			),
 		),


### PR DESCRIPTION
This change adds support for specifying the container runtime executable path. This can be used if, for example, there are two containerd executables and a specific one must be used.

Deploying to a k0s system with:
```
helm install gpu-operator -n gpu-operator --create-namespace \
  nvidia/gpu-operator $HELM_OPTIONS \
    --version=v25.3.0 \
    --set toolkit.repository=ghcr.io/nvidia \
    --set toolkit.version=ae385428-ubuntu20.04 \
    --set toolkit.env[0].name=RUNTIME_CONFIG \
    --set toolkit.env[0].value=/etc/k0s/containerd.d/nvidia.toml \
    --set toolkit.env[1].name=RUNTIME_SOCKET \
    --set toolkit.env[1].value=/run/k0s/containerd.sock \
    --set toolkit.env[2].name=RUNTIME_EXECUTABLE_PATH \
    --set toolkit.env[2].value=/var/lib/k0s/bin/containerd \
    --set toolkit.env[3].name=NVIDIA_RUNTIME_NAME \
    --set toolkit.env[3].value=nvidia
```

Allows the config to be extracted correctly and unblocks the deployment.

Fixes #803

Backport of #1016