### PR TITLE
Add nvidia-container-cli.compat-mode config option

### DIFF
--- a/cmd/nvidia-container-runtime-hook/hook_config.go
+++ b/cmd/nvidia-container-runtime-hook/hook_config.go
@@ -104,3 +104,26 @@ func (c *hookConfig) getSwarmResourceEnvvars() []string {
 
 	return envvars
 }
+
+// nvidiaContainerCliCUDACompatModeFlags returns required --cuda-compat-mode
+// flag(s) depending on the hook and runtime configurations.
+func (c *hookConfig) nvidiaContainerCliCUDACompatModeFlags() []string {
+	var flag string
+	switch c.NVIDIAContainerRuntimeConfig.Modes.Legacy.CUDACompatMode {
+	case config.CUDACompatModeLdconfig:
+		flag = "--cuda-compat-mode=ldconfig"
+	case config.CUDACompatModeMount:
+		flag = "--cuda-compat-mode=mount"
+	case config.CUDACompatModeDisabled, config.CUDACompatModeHook:
+		flag = "--cuda-compat-mode=disabled"
+	default:
+		if !c.Features.AllowCUDACompatLibsFromContainer.IsEnabled() {
+			flag = "--cuda-compat-mode=disabled"
+		}
+	}
+
+	if flag == "" {
+		return nil
+	}
+	return []string{flag}
+}

--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -114,9 +114,8 @@ func doPrestart() {
 	}
 	args = append(args, "configure")
 
-	if !hook.Features.AllowCUDACompatLibsFromContainer.IsEnabled() {
-		args = append(args, "--no-cntlibs")
-	}
+	args = append(args, hook.nvidiaContainerCliCUDACompatModeFlags()...)
+
 	if ldconfigPath := cli.NormalizeLDConfigPath(); ldconfigPath != "" {
 		args = append(args, fmt.Sprintf("--ldconfig=%s", ldconfigPath))
 	}

--- a/cmd/nvidia-ctk-installer/main_test.go
+++ b/cmd/nvidia-ctk-installer/main_test.go
@@ -79,6 +79,9 @@ swarm-resource = ""
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+    [nvidia-container-runtime.modes.legacy]
+      cuda-compat-mode = "ldconfig"
+
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
   skip-mode-detection = true
@@ -139,6 +142,9 @@ swarm-resource = ""
 
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+    [nvidia-container-runtime.modes.legacy]
+      cuda-compat-mode = "ldconfig"
 
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
@@ -204,6 +210,9 @@ swarm-resource = ""
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+    [nvidia-container-runtime.modes.legacy]
+      cuda-compat-mode = "ldconfig"
+
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
   skip-mode-detection = true
@@ -264,6 +273,9 @@ swarm-resource = ""
 
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+    [nvidia-container-runtime.modes.legacy]
+      cuda-compat-mode = "ldconfig"
 
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"
@@ -347,6 +359,9 @@ swarm-resource = ""
 
     [nvidia-container-runtime.modes.csv]
       mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+    [nvidia-container-runtime.modes.legacy]
+      cuda-compat-mode = "ldconfig"
 
 [nvidia-container-runtime-hook]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-container-runtime-hook"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,9 @@ func GetDefault() (*Config, error) {
 					AnnotationPrefixes: []string{cdi.AnnotationPrefix},
 					SpecDirs:           cdi.DefaultSpecDirs,
 				},
+				Legacy: legacyModeConfig{
+					CUDACompatMode: defaultCUDACompatMode,
+				},
 			},
 		},
 		NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,9 @@ func TestGetConfig(t *testing.T) {
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
 						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
+						},
 					},
 				},
 				NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{
@@ -93,6 +96,7 @@ func TestGetConfig(t *testing.T) {
 				"nvidia-container-cli.load-kmods = false",
 				"nvidia-container-cli.ldconfig = \"@/foo/bar/ldconfig\"",
 				"nvidia-container-cli.user = \"foo:bar\"",
+				"nvidia-container-cli.cuda-compat-mode = \"mount\"",
 				"nvidia-container-runtime.debug = \"/foo/bar\"",
 				"nvidia-container-runtime.discover-mode = \"not-legacy\"",
 				"nvidia-container-runtime.log-level = \"debug\"",
@@ -102,6 +106,7 @@ func TestGetConfig(t *testing.T) {
 				"nvidia-container-runtime.modes.cdi.annotation-prefixes = [\"cdi.k8s.io/\", \"example.vendor.com/\",]",
 				"nvidia-container-runtime.modes.cdi.spec-dirs = [\"/except/etc/cdi\", \"/not/var/run/cdi\",]",
 				"nvidia-container-runtime.modes.csv.mount-spec-path = \"/not/etc/nvidia-container-runtime/host-files-for-container.d\"",
+				"nvidia-container-runtime.modes.legacy.cuda-compat-mode = \"mount\"",
 				"nvidia-container-runtime-hook.path = \"/foo/bar/nvidia-container-runtime-hook\"",
 				"nvidia-ctk.path = \"/foo/bar/nvidia-ctk\"",
 			},
@@ -133,6 +138,9 @@ func TestGetConfig(t *testing.T) {
 								"/except/etc/cdi",
 								"/not/var/run/cdi",
 							},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "mount",
 						},
 					},
 				},
@@ -178,6 +186,9 @@ func TestGetConfig(t *testing.T) {
 								"/var/run/cdi",
 							},
 						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
+						},
 					},
 				},
 				NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{
@@ -200,6 +211,7 @@ func TestGetConfig(t *testing.T) {
 				"root = \"/bar/baz\"",
 				"load-kmods = false",
 				"ldconfig = \"@/foo/bar/ldconfig\"",
+				"cuda-compat-mode = \"mount\"",
 				"user = \"foo:bar\"",
 				"[nvidia-container-runtime]",
 				"debug = \"/foo/bar\"",
@@ -213,6 +225,8 @@ func TestGetConfig(t *testing.T) {
 				"spec-dirs = [\"/except/etc/cdi\", \"/not/var/run/cdi\",]",
 				"[nvidia-container-runtime.modes.csv]",
 				"mount-spec-path = \"/not/etc/nvidia-container-runtime/host-files-for-container.d\"",
+				"[nvidia-container-runtime.modes.legacy]",
+				"cuda-compat-mode = \"mount\"",
 				"[nvidia-container-runtime-hook]",
 				"path = \"/foo/bar/nvidia-container-runtime-hook\"",
 				"[nvidia-ctk]",
@@ -246,6 +260,9 @@ func TestGetConfig(t *testing.T) {
 								"/except/etc/cdi",
 								"/not/var/run/cdi",
 							},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "mount",
 						},
 					},
 				},
@@ -282,6 +299,9 @@ func TestGetConfig(t *testing.T) {
 							DefaultKind:        "nvidia.com/gpu",
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
 						},
 					},
 				},
@@ -321,6 +341,9 @@ func TestGetConfig(t *testing.T) {
 							DefaultKind:        "nvidia.com/gpu",
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
 						},
 					},
 				},

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -29,8 +29,9 @@ type RuntimeConfig struct {
 
 // modesConfig defines (optional) per-mode configs
 type modesConfig struct {
-	CSV csvModeConfig `toml:"csv"`
-	CDI cdiModeConfig `toml:"cdi"`
+	CSV    csvModeConfig    `toml:"csv"`
+	CDI    cdiModeConfig    `toml:"cdi"`
+	Legacy legacyModeConfig `toml:"legacy"`
 }
 
 type cdiModeConfig struct {
@@ -45,3 +46,31 @@ type cdiModeConfig struct {
 type csvModeConfig struct {
 	MountSpecPath string `toml:"mount-spec-path"`
 }
+
+type legacyModeConfig struct {
+	// CUDACompatMode sets the mode to be used to make CUDA Forward Compat
+	// libraries discoverable in the container.
+	CUDACompatMode cudaCompatMode `toml:"cuda-compat-mode,omitempty"`
+}
+
+type cudaCompatMode string
+
+const (
+	defaultCUDACompatMode = CUDACompatModeLdconfig
+	// CUDACompatModeDisabled explicitly disables the handling of CUDA Forward
+	// Compatibility in the NVIDIA Container Runtime and NVIDIA Container
+	// Runtime Hook.
+	CUDACompatModeDisabled = cudaCompatMode("disabled")
+	// CUDACompatModeHook uses a container lifecycle hook to implement CUDA
+	// Forward Compatibility support. This requires the use of the NVIDIA
+	// Container Runtime and is not compatible with use cases where only the
+	// NVIDIA Container Runtime Hook is used (e.g. the Docker --gpus flag).
+	CUDACompatModeHook = cudaCompatMode("hook")
+	// CUDACompatModeLdconfig adds the folders containing CUDA Forward Compat
+	// libraries to the ldconfig command invoked from the NVIDIA Container
+	// Runtime Hook.
+	CUDACompatModeLdconfig = cudaCompatMode("ldconfig")
+	// CUDACompatModeMount mounts CUDA Forward Compat folders from the container
+	// to the container when using the NVIDIA Container Runtime Hook.
+	CUDACompatModeMount = cudaCompatMode("mount")
+)

--- a/internal/config/toml_test.go
+++ b/internal/config/toml_test.go
@@ -74,6 +74,9 @@ spec-dirs = ["/etc/cdi", "/var/run/cdi"]
 [nvidia-container-runtime.modes.csv]
 mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+[nvidia-container-runtime.modes.legacy]
+cuda-compat-mode = "ldconfig"
+
 [nvidia-container-runtime-hook]
 path = "nvidia-container-runtime-hook"
 skip-mode-detection = false


### PR DESCRIPTION
This change adds a config option to trigger the `--cuda-compat-mode=ldconfig` option added to the `nvidia-container-cli` in https://github.com/NVIDIA/libnvidia-container/pull/307.

The `nvidia-container-runtime.modes.legacy.cuda-compat-mode` option controls the behaviour of both the `nvidia-container-runtime-hook` and the `nvidia-container-runtime`. The main motivation being that the hook-based CUDA Forward Compat support that was added as part of the v1.17.5 release requires the `nvidia-container-runtime` and as such does not work when only the Docker `--gpus` flag is specified.

# Testing:
```
$ cat check-compat.sh
#!/bin/bash
set -x
ldconfig -p | grep libcuda
ls -al  /usr/lib/x86_64-linux-gnu/libcuda.so*
mount | grep libcuda
```

## cuda-compat-mode unset (upgrades)

### `--gpus` flag
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=runc -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
        libcuda.so (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:15 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:15 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

### `nvidia` runtime
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=nvidia -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
        libcuda.so (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:15 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:15 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

## cuda-compat-mode=ldconfig
```
$ nvidia-ctk config | grep cuda-compat-mode
cuda-compat-mode = "ldconfig"
```

### `--gpus` flag
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=runc -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
        libcuda.so (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:16 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:16 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

### `nvidia` runtime
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=nvidia -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
        libcuda.so (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:16 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:16 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

## cuda-compat-mode=mount
```
$ nvidia-ctk config | grep cuda-compat-mode
cuda-compat-mode = "mount"
```

### `--gpus` flag
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=runc -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 /usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06
lrwxrwxrwx 1 root root       12 May 13 13:11 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:11 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.570.124.06
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
-rw-r--r-- 1 root root 71373816 Feb 26 02:04 /usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
overlay on /usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06 type overlay (ro,nosuid,nodev,relatime,lowerdir=/var/lib/docker/overlay2/l/YNAMYYCHXHBXE5PZBTHKRLESOU:/var/lib/docker/overlay2/l/2KDSGP7VKFMJR4C3GFANVX4QBN:/var/lib/docker/overlay2/l/RQGLGB33HTKTBTSRXW53V7PNXQ:/var/lib/docker/overlay2/l/PPCDKWEUS6OY7NNDRHKSWKFUHY:/var/lib/docker/overlay2/l/SF4RIIOHIGRUCTKUXZB6FDSZD7:/var/lib/docker/overlay2/l/VORH6BSJPVXUCIXSQPI4V7YOZ5,upperdir=/var/lib/docker/overlay2/9bd3f6b8aaa8519b0af1256454858dddb38d14e2682aa50a57b0253f9e00cd61/diff,workdir=/var/lib/docker/overlay2/9bd3f6b8aaa8519b0af1256454858dddb38d14e2682aa50a57b0253f9e00cd61/work,xino=off)
overlay on /usr/lib/x86_64-linux-gnu/libcudadebugger.so.570.124.06 type overlay (ro,nosuid,nodev,relatime,lowerdir=/var/lib/docker/overlay2/l/YNAMYYCHXHBXE5PZBTHKRLESOU:/var/lib/docker/overlay2/l/2KDSGP7VKFMJR4C3GFANVX4QBN:/var/lib/docker/overlay2/l/RQGLGB33HTKTBTSRXW53V7PNXQ:/var/lib/docker/overlay2/l/PPCDKWEUS6OY7NNDRHKSWKFUHY:/var/lib/docker/overlay2/l/SF4RIIOHIGRUCTKUXZB6FDSZD7:/var/lib/docker/overlay2/l/VORH6BSJPVXUCIXSQPI4V7YOZ5,upperdir=/var/lib/docker/overlay2/9bd3f6b8aaa8519b0af1256454858dddb38d14e2682aa50a57b0253f9e00cd61/diff,workdir=/var/lib/docker/overlay2/9bd3f6b8aaa8519b0af1256454858dddb38d14e2682aa50a57b0253f9e00cd61/work,xino=off)
```

### `nvidia` runtime
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=nvidia -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 /usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06
lrwxrwxrwx 1 root root       12 May 13 13:12 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:12 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.570.124.06
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
-rw-r--r-- 1 root root 71373816 Feb 26 02:04 /usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
overlay on /usr/lib/x86_64-linux-gnu/libcuda.so.570.124.06 type overlay (ro,nosuid,nodev,relatime,lowerdir=/var/lib/docker/overlay2/l/S76G4EOPKJMKO7EANJT54FYT35:/var/lib/docker/overlay2/l/2KDSGP7VKFMJR4C3GFANVX4QBN:/var/lib/docker/overlay2/l/RQGLGB33HTKTBTSRXW53V7PNXQ:/var/lib/docker/overlay2/l/PPCDKWEUS6OY7NNDRHKSWKFUHY:/var/lib/docker/overlay2/l/SF4RIIOHIGRUCTKUXZB6FDSZD7:/var/lib/docker/overlay2/l/VORH6BSJPVXUCIXSQPI4V7YOZ5,upperdir=/var/lib/docker/overlay2/67e07f9319d2c2df1ead5fd2b837a9e67402237d32e6f77f9a3168852af6c3e6/diff,workdir=/var/lib/docker/overlay2/67e07f9319d2c2df1ead5fd2b837a9e67402237d32e6f77f9a3168852af6c3e6/work,xino=off)
overlay on /usr/lib/x86_64-linux-gnu/libcudadebugger.so.570.124.06 type overlay (ro,nosuid,nodev,relatime,lowerdir=/var/lib/docker/overlay2/l/S76G4EOPKJMKO7EANJT54FYT35:/var/lib/docker/overlay2/l/2KDSGP7VKFMJR4C3GFANVX4QBN:/var/lib/docker/overlay2/l/RQGLGB33HTKTBTSRXW53V7PNXQ:/var/lib/docker/overlay2/l/PPCDKWEUS6OY7NNDRHKSWKFUHY:/var/lib/docker/overlay2/l/SF4RIIOHIGRUCTKUXZB6FDSZD7:/var/lib/docker/overlay2/l/VORH6BSJPVXUCIXSQPI4V7YOZ5,upperdir=/var/lib/docker/overlay2/67e07f9319d2c2df1ead5fd2b837a9e67402237d32e6f77f9a3168852af6c3e6/diff,workdir=/var/lib/docker/overlay2/67e07f9319d2c2df1ead5fd2b837a9e67402237d32e6f77f9a3168852af6c3e6/work,xino=off)
```

## cuda-compat-mode=disabled
```
$ nvidia-ctk config | grep cuda-compat-mode
cuda-compat-mode = "disabled"
```

### `--gpus` flag

```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=runc -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:17 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:17 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

## `nvidia` runtime
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=nvidia -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:18 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:18 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

## cuda-compat-mode=hook

### `--gpus` flag
Note that this has CUDA Forward Compat disabled
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=runc -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:19 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:19 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

### `nvidia` runtime

```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=nvidia -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcudadebugger.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcudadebugger.so.1
        libcuda.so.1 (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so.1
        libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
        libcuda.so (libc6,x86-64) => /usr/local/cuda-12.8/compat/libcuda.so
        libcuda.so (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:20 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:20 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```

### `nvidia` runtime with `disable-cuda-compat-hook = true`
```
$ docker run --rm -ti --gpus=all -e NVIDIA_DISABLE_REQUIRE=1 --runtime=runc -v $(pwd):/work -w /work nvidia/cuda:12.8.1-base-ubuntu20.04 bash -c "./check-compat.sh"
+ ldconfig -p
+ grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12
        libcuda.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcuda.so.1
+ ls -al /usr/lib/x86_64-linux-gnu/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
lrwxrwxrwx 1 root root       12 May 13 13:22 /usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 root root       21 May 13 13:22 /usr/lib/x86_64-linux-gnu/libcuda.so.1 -> libcuda.so.515.105.01
-rw-r--r-- 1 root root 20988032 Feb 27  2023 /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
+ mount
+ grep libcuda
/dev/sda2 on /usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01 type ext4 (ro,nosuid,nodev,relatime,nodelalloc,errors=remount-ro,stripe=64)
```