### PR TITLE
Fix mode detection on Thor-based systems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NVIDIA/nvidia-container-toolkit
 go 1.22
 
 require (
-	github.com/NVIDIA/go-nvlib v0.6.1
+	github.com/NVIDIA/go-nvlib v0.7.2
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/moby/sys/symlink v0.3.0
@@ -11,7 +11,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/mod v0.20.0
 	golang.org/x/sys v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/NVIDIA/go-nvlib v0.6.1 h1:0/5FvaKvDJoJeJ+LFlh+NDQMxMlVw9wOXrOVrGXttfE=
-github.com/NVIDIA/go-nvlib v0.6.1/go.mod h1:9UrsLGx/q1OrENygXjOuM5Ey5KCtiZhbvBlbUIxtGWY=
+github.com/NVIDIA/go-nvlib v0.7.2 h1:7sy/NVUa4sM9FLKwH6CjBfHSWrJUmv8emVyxLTzjfOA=
+github.com/NVIDIA/go-nvlib v0.7.2/go.mod h1:2Kh2kYSP5IJ8EKf0/SYDzHiQKb9EJkwOf2LQzu6pXzY=
 github.com/NVIDIA/go-nvml v0.12.4-1 h1:WKUvqshhWSNTfm47ETRhv0A0zJyr1ncCuHiXwoTrBEc=
 github.com/NVIDIA/go-nvml v0.12.4-1/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -60,8 +60,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/internal/info/auto_test.go
+++ b/internal/info/auto_test.go
@@ -216,7 +216,7 @@ func TestResolveAutoMode(t *testing.T) {
 				HasTegraFilesFunc: func() (bool, string) {
 					return tc.info["tegra"], "tegra"
 				},
-				UsesOnlyNVGPUModuleFunc: func() (bool, string) {
+				HasOnlyIntegratedGPUsFunc: func() (bool, string) {
 					return tc.info["nvgpu"], "nvgpu"
 				},
 			}

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/mig_device.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/mig_device.go
@@ -63,7 +63,7 @@ func (m *migdevice) GetProfile() (MigProfile, error) {
 		return m.profile, nil
 	}
 
-	parent, ret := m.Device.GetDeviceHandleFromMigDeviceHandle()
+	parent, ret := m.GetDeviceHandleFromMigDeviceHandle()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting parent device handle: %v", ret)
 	}
@@ -73,17 +73,17 @@ func (m *migdevice) GetProfile() (MigProfile, error) {
 		return nil, fmt.Errorf("error getting parent memory info: %v", ret)
 	}
 
-	attributes, ret := m.Device.GetAttributes()
+	attributes, ret := m.GetAttributes()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting MIG device attributes: %v", ret)
 	}
 
-	giID, ret := m.Device.GetGpuInstanceId()
+	giID, ret := m.GetGpuInstanceId()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting MIG device GPU Instance ID: %v", ret)
 	}
 
-	ciID, ret := m.Device.GetComputeInstanceId()
+	ciID, ret := m.GetComputeInstanceId()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting MIG device Compute Instance ID: %v", ret)
 	}

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/api.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/api.go
@@ -30,12 +30,14 @@ type PlatformResolver interface {
 // PropertyExtractor provides a set of functions to query capabilities of the
 // system.
 //
-//go:generate moq -rm -out property-extractor_mock.go . PropertyExtractor
+//go:generate moq  -rm -fmt=goimports -out property-extractor_mock.go . PropertyExtractor
 type PropertyExtractor interface {
 	HasDXCore() (bool, string)
 	HasNvml() (bool, string)
 	HasTegraFiles() (bool, string)
 	// Deprecated: Use HasTegraFiles instead.
 	IsTegraSystem() (bool, string)
+	// Deprecated: Use HasOnlyIntegratedGPUs
 	UsesOnlyNVGPUModule() (bool, string)
+	HasOnlyIntegratedGPUs() (bool, string)
 }

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/property-extractor_mock.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/property-extractor_mock.go
@@ -23,6 +23,9 @@ var _ PropertyExtractor = &PropertyExtractorMock{}
 //			HasNvmlFunc: func() (bool, string) {
 //				panic("mock out the HasNvml method")
 //			},
+//			HasOnlyIntegratedGPUsFunc: func() (bool, string) {
+//				panic("mock out the HasOnlyIntegratedGPUs method")
+//			},
 //			HasTegraFilesFunc: func() (bool, string) {
 //				panic("mock out the HasTegraFiles method")
 //			},
@@ -45,6 +48,9 @@ type PropertyExtractorMock struct {
 	// HasNvmlFunc mocks the HasNvml method.
 	HasNvmlFunc func() (bool, string)
 
+	// HasOnlyIntegratedGPUsFunc mocks the HasOnlyIntegratedGPUs method.
+	HasOnlyIntegratedGPUsFunc func() (bool, string)
+
 	// HasTegraFilesFunc mocks the HasTegraFiles method.
 	HasTegraFilesFunc func() (bool, string)
 
@@ -62,6 +68,9 @@ type PropertyExtractorMock struct {
 		// HasNvml holds details about calls to the HasNvml method.
 		HasNvml []struct {
 		}
+		// HasOnlyIntegratedGPUs holds details about calls to the HasOnlyIntegratedGPUs method.
+		HasOnlyIntegratedGPUs []struct {
+		}
 		// HasTegraFiles holds details about calls to the HasTegraFiles method.
 		HasTegraFiles []struct {
 		}
@@ -72,11 +81,12 @@ type PropertyExtractorMock struct {
 		UsesOnlyNVGPUModule []struct {
 		}
 	}
-	lockHasDXCore           sync.RWMutex
-	lockHasNvml             sync.RWMutex
-	lockHasTegraFiles       sync.RWMutex
-	lockIsTegraSystem       sync.RWMutex
-	lockUsesOnlyNVGPUModule sync.RWMutex
+	lockHasDXCore             sync.RWMutex
+	lockHasNvml               sync.RWMutex
+	lockHasOnlyIntegratedGPUs sync.RWMutex
+	lockHasTegraFiles         sync.RWMutex
+	lockIsTegraSystem         sync.RWMutex
+	lockUsesOnlyNVGPUModule   sync.RWMutex
 }
 
 // HasDXCore calls HasDXCoreFunc.
@@ -130,6 +140,33 @@ func (mock *PropertyExtractorMock) HasNvmlCalls() []struct {
 	mock.lockHasNvml.RLock()
 	calls = mock.calls.HasNvml
 	mock.lockHasNvml.RUnlock()
+	return calls
+}
+
+// HasOnlyIntegratedGPUs calls HasOnlyIntegratedGPUsFunc.
+func (mock *PropertyExtractorMock) HasOnlyIntegratedGPUs() (bool, string) {
+	if mock.HasOnlyIntegratedGPUsFunc == nil {
+		panic("PropertyExtractorMock.HasOnlyIntegratedGPUsFunc: method is nil but PropertyExtractor.HasOnlyIntegratedGPUs was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockHasOnlyIntegratedGPUs.Lock()
+	mock.calls.HasOnlyIntegratedGPUs = append(mock.calls.HasOnlyIntegratedGPUs, callInfo)
+	mock.lockHasOnlyIntegratedGPUs.Unlock()
+	return mock.HasOnlyIntegratedGPUsFunc()
+}
+
+// HasOnlyIntegratedGPUsCalls gets all the calls that were made to HasOnlyIntegratedGPUs.
+// Check the length with:
+//
+//	len(mockedPropertyExtractor.HasOnlyIntegratedGPUsCalls())
+func (mock *PropertyExtractorMock) HasOnlyIntegratedGPUsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockHasOnlyIntegratedGPUs.RLock()
+	calls = mock.calls.HasOnlyIntegratedGPUs
+	mock.lockHasOnlyIntegratedGPUs.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/resolver.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/resolver.go
@@ -48,13 +48,13 @@ func (p platformResolver) ResolvePlatform() Platform {
 	hasNVML, reason := p.propertyExtractor.HasNvml()
 	p.logger.Debugf("Is NVML-based system? %v: %v", hasNVML, reason)
 
-	usesOnlyNVGPUModule, reason := p.propertyExtractor.UsesOnlyNVGPUModule()
-	p.logger.Debugf("Uses nvgpu kernel module? %v: %v", usesOnlyNVGPUModule, reason)
+	hasOnlyIntegratedGPUs, reason := p.propertyExtractor.HasOnlyIntegratedGPUs()
+	p.logger.Debugf("Has only integrated GPUs? %v: %v", hasOnlyIntegratedGPUs, reason)
 
 	switch {
 	case hasDXCore:
 		return PlatformWSL
-	case (hasTegraFiles && !hasNVML), usesOnlyNVGPUModule:
+	case (hasTegraFiles && !hasNVML), hasOnlyIntegratedGPUs:
 		return PlatformTegra
 	case hasNVML:
 		return PlatformNVML

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/mmio/mmio.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/mmio/mmio.go
@@ -107,7 +107,7 @@ func (m *mmio) BigEndian() Mmio {
 }
 
 func (m *mmio) Close() error {
-	err := syscall.Munmap(*m.Bytes.Raw())
+	err := syscall.Munmap(*m.Raw())
 	if err != nil {
 		return fmt.Errorf("failed to munmap file: %v", err)
 	}
@@ -117,7 +117,7 @@ func (m *mmio) Close() error {
 func (m *mmio) Sync() error {
 	_, _, errno := syscall.Syscall(
 		syscall.SYS_MSYNC,
-		uintptr(unsafe.Pointer(&(*m.Bytes.Raw())[0])),
+		uintptr(unsafe.Pointer(&(*m.Raw())[0])),
 		uintptr(m.Len()),
 		uintptr(syscall.MS_SYNC|syscall.MS_INVALIDATE))
 	if errno != 0 {

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/mmio/mock.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/mmio/mock.go
@@ -70,8 +70,8 @@ func (m *mockMmio) Sync() error {
 	if !m.rw {
 		return fmt.Errorf("opened read-only")
 	}
-	for i := range *m.Bytes.Raw() {
-		(*m.source)[m.offset+i] = (*m.Bytes.Raw())[i]
+	for i := range *m.Raw() {
+		(*m.source)[m.offset+i] = (*m.Raw())[i]
 	}
 	return nil
 }

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/mock.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/mock.go
@@ -98,7 +98,7 @@ func (m *MockNvpci) AddMockA100(address string, numaNode int, sriov *SriovInfo) 
 	if err != nil {
 		return err
 	}
-	_, err = numa.WriteString(fmt.Sprintf("%v", numaNode))
+	_, err = fmt.Fprintf(numa, "%v", numaNode)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func createNVIDIAgpuFiles(deviceDir string) error {
 	if err != nil {
 		return err
 	}
-	_, err = vendor.WriteString(fmt.Sprintf("0x%x", PCINvidiaVendorID))
+	_, err = fmt.Fprintf(vendor, "0x%x", PCINvidiaVendorID)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func createNVIDIAgpuFiles(deviceDir string) error {
 	if err != nil {
 		return err
 	}
-	_, err = class.WriteString(fmt.Sprintf("0x%x", PCI3dControllerClass))
+	_, err = fmt.Fprintf(class, "0x%x", PCI3dControllerClass)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func createNVIDIAgpuFiles(deviceDir string) error {
 	if err != nil {
 		return err
 	}
-	_, err = resource.WriteString(fmt.Sprintf("0x%x 0x%x 0x%x", bar0[0], bar0[1], bar0[2]))
+	_, err = fmt.Fprintf(resource, "0x%x 0x%x 0x%x", bar0[0], bar0[1], bar0[2])
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func (m *MockNvpci) createVf(pfAddress string, id, iommu_group, numaNode int) er
 	if err != nil {
 		return err
 	}
-	_, err = numa.WriteString(fmt.Sprintf("%v", numaNode))
+	_, err = fmt.Fprintf(numa, "%v", numaNode)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/resources.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/resources.go
@@ -112,7 +112,7 @@ func (mrs MemoryResources) GetTotalAddressableMemory(roundUp bool) (uint64, uint
 		if key >= pciIOVNumBAR || numBAR == pciIOVNumBAR {
 			break
 		}
-		numBAR = numBAR + 1
+		numBAR++
 
 		region := mrs[key]
 
@@ -123,10 +123,10 @@ func (mrs MemoryResources) GetTotalAddressableMemory(roundUp bool) (uint64, uint
 		memSize := (region.End - region.Start) + 1
 
 		if memType32bit {
-			memSize32bit = memSize32bit + uint64(memSize)
+			memSize32bit += uint64(memSize)
 		}
 		if memType64bit {
-			memSize64bit = memSize64bit + uint64(memSize)
+			memSize64bit += uint64(memSize)
 		}
 
 	}

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/pciids/default_pci.ids
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/pciids/default_pci.ids
@@ -1,8 +1,8 @@
 #
 #	List of PCI ID's
 #
-#	Version: 2024.06.23
-#	Date:    2024-06-23 03:15:02
+#	Version: 2025.03.04
+#	Date:    2025-03-04 03:15:02
 #
 #	Maintained by Albert Pool, Martin Mares, and other volunteers from
 #	the PCI ID Project at https://pci-ids.ucw.cz/.
@@ -44,15 +44,24 @@
 	7a0f  DMA (Direct Memory Access) Controller
 # Found on some boards with two sockets
 	7a10  Hyper Transport Bridge Controller
+	7a13  7A2000 PCH Gigabit Ethernet Controller
 	7a14  EHCI USB Controller
 	7a15  Vivante GPU (Graphics Processing Unit)
+	7a18  SATA 3 AHCI Controller
 	7a19  PCI-to-PCI Bridge
+	7a1b  SPI Controller
 	7a24  OHCI USB Controller
 # Found on 7A2000 PCH
 	7a25  LG100 GPU
+	7a27  7A2000 PCH I2S Controller
 	7a29  PCI-to-PCI Bridge
+	7a34  xHCI USB Controller
 # Found on 7A2000 PCH
 	7a36  Display Controller
+	7a39  PCIe x1 Root Port
+	7a49  PCIe x4 Root Port
+	7a59  PCIe x8 Root Port
+	7a69  PCIe x16 Root Port
 0018  Fn-Link Technology Limited
 	6252  6252CPUB 802.11ax PCIe Wireless Network Adapter
 001c  PEAK-System Technik GmbH
@@ -138,6 +147,11 @@
 	1702  IS64PH ISDN Adapter
 	1703  ISDN Adapter (PCI Bus, DV, W)
 	1704  ISDN Adapter (PCI Bus, D, C)
+0709  LJMicro Co., Ltd
+	0101  GP101
+	0102  GP102
+	0201  GP201
+	0202  GP202
 0721  Sapphire, Inc.
 0731  Jingjia Microelectronics Co Ltd
 	7200  JM7200 Series GPU
@@ -183,6 +197,7 @@
 	6666  MediaPress (MPEG2 encoder board)
 07d1  D-Link System Inc
 0824  T1042 [Freescale]
+0911  Hantick
 0925  VIA Technologies, Inc. (Wrong ID)
 0a89  BREA Technologies Inc
 0b0b  Rhino Equipment Corp.
@@ -1099,8 +1114,13 @@
 		1000 04db  3808N iMR ROMB
 		1000 04dc  3808N iMR ROMB
 		1000 04dd  3808N iMR ROMB
+# String pulled from Broadcom storcli "Product Name"
+		1000 40d5  MegaRAID 9540-8i
+# String pulled from Broadcom storcli "Product Name"
+		1000 40d6  MegaRAID 9520-8i
 		1000 40d8  MegaRAID 9524-8i
 		1000 40e0  MegaRAID 9540-2M2
+		1028 1a3d  BOSS-MR1
 		1028 2172  PERC H355 Adapter
 		1028 2173  PERC H355 Front
 		1028 2174  PERC H350 Mini
@@ -1201,6 +1221,7 @@
 	9100  INI-9100/9100W SCSI Host
 # nee ATI Technologies, Inc.
 1002  Advanced Micro Devices, Inc. [AMD/ATI]
+	1114  Krackan [Radeon 840M / 860M Graphics]
 	1304  Kaveri
 	1305  Kaveri
 	1306  Kaveri
@@ -1228,6 +1249,7 @@
 	131b  Kaveri [Radeon R4 Graphics]
 	131c  Kaveri [Radeon R7 Graphics]
 	131d  Kaveri [Radeon R6 Graphics]
+	13c0  Granite Ridge [Radeon Graphics]
 	13e9  Ariel/Navi10Lite
 	13f9  Oberon/Navi12Lite
 	13fe  Cyan Skillfish [BC-250]
@@ -1237,12 +1259,14 @@
 	1478  Navi 10 XL Upstream Port of PCI Express Switch
 	1479  Navi 10 XL Downstream Port of PCI Express Switch
 	1506  Mendocino
+	150e  Strix [Radeon 880M / 890M]
 	154c  Kryptos [Radeon RX 350]
 		1462 7c28  MS-7C28 Motherboard
 	154e  Garfield
 	1551  Arlene
 	1552  Pooky
 	1561  Anubis
+	1586  Strix Halo [Radeon Graphics / Radeon 8050S Graphics / Radeon 8060S Graphics]
 	15bf  Phoenix1
 	15c8  Phoenix2
 	15d8  Picasso/Raven 2 [Radeon Vega Series / Radeon Vega Mobile Series]
@@ -3963,10 +3987,11 @@
 		1458 231d  Radeon RX 5600 XT/REV 2.0 [Windforce 6GB OC]
 		148c 2398  AXRX 5700 XT 8GBD6-3DHE/OC [PowerColor Red Devil Radeon RX 5700 XT]
 		1682 5701  RX 5700 XT RAW II
+		1849 5102  RX5700 CLD 8GO [ASRock Challenger D RX 5700 OC]
 		1849 5120  Radeon RX 5600 XT
 		1da2 e409  Sapphire Technology Limited Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
 		1da2 e410  Sapphire NITRO+ RX 5700 XT
-		1da2 e411  Radeon RX 5600 XT
+		1da2 e411  Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
 	7340  Navi 14 [Radeon RX 5500/5500M / Pro 5500M]
 	7341  Navi 14 [Radeon Pro W5500]
 	7347  Navi 14 [Radeon Pro W5500M]
@@ -3984,6 +4009,7 @@
 # Reference
 		1002 0e3a  Radeon RX 6950 XT
 		1849 5230  Navi 21 [ASRock OC Forumla Radeon RX 6950XT]
+		1849 5238  Navi 21 [ASRock Radeon RX 6950 XT Phantom Gaming OC]
 		1da2 441d  Navi 21 [Sapphire Nitro+ Radeon RX 6950 XT]
 		1eae 6950  Navi 21 [XFX Speedster MERC319 Radeon RX 6950 XT]
 	73ab  Navi 21 Pro-XLA [Radeon Pro W6800X/Radeon Pro W6800X Duo]
@@ -4022,6 +4048,8 @@
 	73e4  Navi 23 USB
 	73ef  Navi 23 [Radeon RX 6650 XT / 6700S / 6800S]
 		1458 2405  Navi 23 [Radeon RX 6650 XT]
+# This is the refreshed MSI MECH series card equipped with the same Navi 23 GPU as ID 5021
+		1462 5027  RX 6650XT MECH 2X
 		1849 5236  RX 6650 XT Challenger D OC
 	73f0  Navi 33 [Radeon RX 7600M XT]
 	73ff  Navi 23 [Radeon RX 6600/6600 XT/6600M]
@@ -4041,24 +4069,38 @@
 		1da2 e457  PULSE AMD Radeon RX 6500 XT
 	7446  Navi 31 USB
 	7448  Navi 31 [Radeon Pro W7900]
-	744c  Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
-		1002 0e3b  RX 7900 GRE [XFX]
+	744a  Navi 31 [Radeon Pro W7900 Dual Slot]
+	744c  Navi 31 [Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M]
+		1002 0e3b  RX 7900 XTX / RX 7900 GRE [XFX]
 		1043 0506  TUF Gaming Radeon RX 7900 XTX OC
+		148c 2425  HELLHOUND RX 7900 GRE
 		1849 5304  Radeon RX 7900 XTX
 		1da2 471e  PULSE RX 7900 XTX
 		1da2 475e  PULSE RX 7900 GRE
 		1da2 e471  NITRO+ RX 7900 XTX Vapor-X
 		1eae 7901  RX-79XMERCB9 [SPEEDSTER MERC 310 RX 7900 XTX]
+		1eae 790a  RX-79GMERCBR [XFX RX 7900 GRE]
 	745e  Navi 31 [Radeon Pro W7800]
-	7460  7460 Navi32 GL-XL [AMD Radeon PRO V710]
+	7460  Navi32 GL-XL [AMD Radeon PRO V710]
+	7461  Navi 32 [AMD Radeon PRO V710]
 	7470  Navi 32 [Radeon PRO W7700]
 	747e  Navi 32 [Radeon RX 7700 XT / 7800 XT]
 	7480  Navi 33 [Radeon RX 7600/7600 XT/7600M XT/7600S/7700S / PRO W7600]
 		1849 5313  RX 7600 Challenger OC
+	7481  Navi 33 [Radeon Graphics]
 	7483  Navi 33 [Radeon RX 7600M/7600M XT]
+	7487  Navi 33 [Radeon Graphics]
 	7489  Navi 33 [Radeon Pro W7500]
+	748b  Navi 33 [Radeon Graphics]
+	7499  Navi 33 [Radeon RX 7400/7300/Pro W7400]
 	74a0  Aqua Vanjaram [Instinct MI300A]
 	74a1  Aqua Vanjaram [Instinct MI300X]
+	74a2  Aqua Vanjaram [Instinct MI308X]
+	74a5  Aqua Vanjaram [Instinct MI325X]
+	74a9  Aqua Vanjaram [Instinct MI300X HF]
+	74b5  Aqua Vanjaram [Instinct MI300X VF]
+	74bd  Aqua Vanjaram [Instinct MI300X HF]
+	7550  Navi 48 [RX 9070/9070 XT]
 	7833  RS350 Host Bridge
 	7834  RS350 [Radeon 9100 PRO/XT IGP]
 	7835  RS350M [Mobility Radeon 9000 IGP]
@@ -4330,7 +4372,7 @@
 	9840  Kabini HDMI/DP Audio
 		1043 8623  AM1I-A Motherboard
 		1849 9840  QC5000-ITX/PH
-	9850  Mullins [Radeon R3 Graphics]
+	9850  Mullins [Radeon R2/R3 Graphics]
 	9851  Mullins [Radeon R4/R5 Graphics]
 		1179 f928  Beema [Radeon R5 Graphics]
 	9852  Mullins [Radeon R2 Graphics]
@@ -4417,7 +4459,6 @@
 	99a2  Trinity 2 [Radeon HD 7420G]
 	99a4  Trinity 2 [Radeon HD 7400G]
 	aa00  R600 HDMI Audio [Radeon HD 2900 GT/PRO/XT]
-	aa01  RV635 HDMI Audio [Radeon HD 3650/3730/3750]
 	aa08  RV630 HDMI Audio [Radeon HD 2600 PRO/XT / HD 3610]
 	aa10  RV610 HDMI Audio [Radeon HD 2350 PRO / 2400 PRO/XT / HD 3410]
 		174b aa10  Radeon HD 2400 PRO
@@ -4907,6 +4948,8 @@
 		1014 04fc  PCIe3 x8 12Gb Quad SAS RAID+ Adapter(580A)
 	04ed  Internal Shared Memory (ISM) virtual PCI device
 	0611  4769 Cryptographic Adapter
+	06a7  Spyre Accelerator
+	06a8  Spyre Accelerator Virtual Function
 	3022  QLA3022 Network Adapter
 	4022  QLA3022 Network Adapter
 	ffff  MPIC-2 interrupt controller
@@ -4985,11 +5028,43 @@
 	1101  K8 [Athlon64/Opteron] Address Map
 	1102  K8 [Athlon64/Opteron] DRAM Controller
 	1103  K8 [Athlon64/Opteron] Miscellaneous Control
+	1110  Krackan Internal PCIe GPP Bridge 0 to Bus A
+	1111  Krackan Internal PCIe GPP Bridge 0 to Bus B
+	1112  Krackan Internal PCIe GPP Bridge 0 to Bus C
+	1113  Krackan PCIe Dummy Function
+	1116  Krackan PCIe Dummy Function
+	1117  Krackan PCIe Dummy Function
+	1122  Krackan Root Complex
+	1123  Krackan IOMMU
 	1200  Family 10h Processor HyperTransport Configuration
 	1201  Family 10h Processor Address Map
 	1202  Family 10h Processor DRAM Controller
 	1203  Family 10h Processor Miscellaneous Control
 	1204  Family 10h Processor Link Control
+	1248  Krackan Data Fabric; Function 0
+	1249  Krackan Data Fabric; Function 1
+	124a  Krackan Data Fabric; Function 2
+	124b  Krackan Data Fabric; Function 3
+	124c  Krackan Data Fabric; Function 4
+	124d  Krackan Data Fabric; Function 5
+	124e  Krackan Data Fabric; Function 6
+	124f  Krackan Data Fabric; Function 7
+	12b8  Strix Halo Data Fabric; Function 0
+	12b9  Strix Halo Data Fabric; Function 1
+	12ba  Strix Halo Data Fabric; Function 2
+	12bb  Strix Halo Data Fabric; Function 3
+	12bc  Strix Halo Data Fabric; Function 4
+	12bd  Strix Halo Data Fabric; Function 5
+	12be  Strix Halo Data Fabric; Function 6
+	12bf  Strix Halo Data Fabric; Function 7
+	12c0  Turin Data Fabric; Function 0
+	12c1  Turin Data Fabric; Function 1
+	12c2  Turin Data Fabric; Function 2
+	12c3  Turin Data Fabric; Function 3
+	12c4  Turin Data Fabric; Function 4
+	12c5  Turin Data Fabric; Function 5
+	12c6  Turin Data Fabric; Function 6
+	12c7  Turin Data Fabric; Function 7
 	1300  Family 11h Processor HyperTransport Configuration
 	1301  Family 11h Processor Address Map
 	1302  Family 11h Processor DRAM Controller
@@ -5113,6 +5188,7 @@
 	1480  Starship/Matisse Root Complex
 		1462 7c37  X570-A PRO motherboard
 		15d9 1b95  H12SSL-i
+		1849 1480  ROME2D32LM3
 	1481  Starship/Matisse IOMMU
 	1482  Starship/Matisse PCIe Dummy Host Bridge
 	1483  Starship/Matisse GPP Bridge
@@ -5146,18 +5222,72 @@
 	149c  Matisse USB 3.0 Host Controller
 		1462 7c37  X570-A PRO motherboard
 	149d  Vangogh CVIP
+	149e  Genoa/Bergamo IOMMU
+	149f  Genoa/Bergamo Dummy Host Bridge
+	14a4  Genoa/Bergamo Root Complex
+	14a5  Genoa/Bergamo GPP Bridge
+	14a6  Genoa/Bergamo RCEC
+	14a7  Genoa/Bergamo Internal PCIe GPP Bridge to Bus [D:B]
+	14aa  Genoa/Bergamo GPP Bridge
+	14ab  Genoa/Bergamo GPP Bridge
+	14ac  Genoa/Bergamo Dummy Function
+	14ad  Genoa/Bergamo Data Fabric; Function 0
+	14ae  Genoa/Bergamo Data Fabric; Function 1
+	14af  Genoa/Bergamo Data Fabric; Function 2
+	14b0  Genoa/Bergamo Data Fabric; Function 3
+	14b1  Genoa/Bergamo Data Fabric; Function 4
+	14b2  Genoa/Bergamo Data Fabric; Function 5
+	14b3  Genoa/Bergamo Data Fabric; Function 6
+	14b4  Genoa/Bergamo Data Fabric; Function 7
 	14b5  Family 17h-19h PCIe Root Complex
 	14b6  Family 17h-19h IOMMU
 	14b7  Family 17h-19h PCIe Dummy Host Bridge
 	14b8  Family 17h-19h PCIe GPP Bridge
 	14b9  Family 17h-19h Internal PCIe GPP Bridge
 	14ba  Family 17h-19h PCIe GPP Bridge
+	14c1  Secondary vNTB
 # Server device
 	14ca  Genoa CCP/PSP 4.0 Device
 	14cd  Family 19h USB4/Thunderbolt PCIe tunnel
-	14de  Phoenix PCIe Dummy Function
+	14d8  Raphael/Granite Ridge Root Complex
+	14d9  Raphael/Granite Ridge IOMMU
+	14da  Raphael/Granite Ridge Dummy Host Bridge
+	14db  Raphael/Granite Ridge GPP Bridge
+	14dc  SDXI
+	14dd  Raphael/Granite Ridge Internal GPP Bridge to Bus [C:A]
+	14de  Raphael/Granite Ridge PCIe Dummy Function
+	14e0  Raphael/Granite Ridge Data Fabric; Function 0
+	14e1  Raphael/Granite Ridge Data Fabric; Function 1
+	14e2  Raphael/Granite Ridge Data Fabric; Function 2
+	14e3  Raphael/Granite Ridge Data Fabric; Function 3
+	14e4  Raphael/Granite Ridge Data Fabric; Function 4
+	14e5  Raphael/Granite Ridge Data Fabric; Function 5
+	14e6  Raphael/Granite Ridge Data Fabric; Function 6
+	14e7  Raphael/Granite Ridge Data Fabric; Function 7
+	14e8  Phoenix Root Complex
+	14e9  Phoenix IOMMU
+	14ea  Phoenix Dummy Host Bridge
+	14eb  Phoenix Internal GPP Bridge to Bus [C:A]
+	14ec  Phoenix Dummy Function
+	14ed  Phoenix GPP Bridge
+	14ee  Phoenix GPP Bridge
 	14ef  Family 19h USB4/Thunderbolt PCIe tunnel
+	14f0  Phoenix Data Fabric; Function 0
+	14f1  Phoenix Data Fabric; Function 1
+	14f2  Phoenix Data Fabric; Function 2
+	14f3  Phoenix Data Fabric; Function 3
+	14f4  Phoenix Data Fabric; Function 4
+	14f5  Phoenix Data Fabric; Function 5
+	14f6  Phoenix Data Fabric; Function 6
+	14f7  Phoenix Data Fabric; Function 7
 	1502  AMD IPU Device
+	1507  Strix/Strix Halo Root Complex
+	1508  Strix/Strix Halo IOMMU
+	1509  Strix/Strix Halo Dummy Host Bridge
+	150a  Strix/Strix Halo PCIe USB4 Bridge
+	150b  Strix/Strix Halo GPP Bridge
+	150c  Strix/Strix Halo Internal GPP Bridge to Bus [C:A]
+	150d  Strix/Strix Halo PCIe Dummy Function
 	1510  Family 14h Processor Root Complex
 		174b 1001  PURE Fusion Mini
 	1512  Family 14h Processor Root Port
@@ -5177,6 +5307,11 @@
 	1537  Kabini/Mullins PSP-Platform Security Processor
 	1538  Family 16h Processor Function 0
 	1539  Kabini P2P Bridge for PCIe Ports[4:0]
+	153a  Turin Root Complex
+	153b  Turin IOMMU
+	153c  Turin RCEC
+	153d  Turin PCIe Dummy Host Bridge
+	153e  Turin GPP Bridge
 	1540  Kryptos/Cato/Garfield/Garfield+/Arlene/Pooky HT Configuration
 	1541  Kryptos/Cato/Garfield/Garfield+/Arlene/Pooky Address Maps
 	1542  Kryptos/Cato/Garfield/Garfield+/Arlene/Pooky DRAM Configuration
@@ -5193,6 +5328,11 @@
 	154f  Anubis Audio Processor
 	1550  Garfield+/Arlene/Pooky/Anubis SPLL Configuration
 	1553  Arlene/Pooky P2P Bridge for PCIE (3:0)
+	1554  Turin GPP Bridge
+	1555  Turin Internal PCIe GPP Bridge to Bus [D:C]
+	1556  Turin PCIe Dummy Function
+	1557  Turin USB 3.1 xHCI
+	1559  Turin Secondary PCIe Dummy Function
 	155b  Anubis Root Complex
 	155c  Anubis IOMMU
 	155d  Anubis UMI PCIe Dummy Bridge
@@ -5201,6 +5341,7 @@
 	1566  Family 16h (Models 30h-3fh) Processor Root Complex
 	1567  Mullins IOMMU
 	156b  Family 16h (Models 30h-3fh) Host Bridge
+	156e  Turin CCP/ASP
 	1570  Family 15h (Models 60h-6fh) Processor Function 0
 	1571  Family 15h (Models 60h-6fh) Processor Function 1
 	1572  Family 15h (Models 60h-6fh) Processor Function 2
@@ -5239,11 +5380,14 @@
 	15b3  Stoney Miscellaneous Configuration
 	15b4  Stoney PM Configuration
 	15b5  Stoney NB Performance Monitor
+	15b6  Raphael/Granite Ridge USB 3.1 xHCI
+	15b7  Raphael/Granite Ridge USB 3.1 xHCI
+	15b8  Raphael/Granite Ridge USB 2.0 xHCI
 	15bc  Stoney PCIe [GFX,GPP] Bridge [4:0]
 	15be  Stoney Audio Processor
 	15c4  Phoenix USB4/Thunderbolt NHI controller #1
 	15c5  Phoenix USB4/Thunderbolt NHI controller #2
-	15c7  Family 19h (Model 74h) CCP/PSP 3.0 Device
+	15c7  Phoenix CCP/PSP 3.0 Device
 	15d0  Raven/Raven2 Root Complex
 		103c 8615  Pavilion Laptop 15-cw1xxx
 		1043 876b  PRIME B450M-A Motherboard
@@ -5282,7 +5426,7 @@
 	15e2  ACP/ACP3X/ACP6x Audio Coprocessor
 		17aa 5124  ThinkPad E595
 		ea50 ce19  mCOM10-L1900
-	15e3  Family 17h/19h HD Audio Controller
+	15e3  Family 17h/19h/1ah HD Audio Controller
 		103c 8615  Pavilion Laptop 15-cw1xxx
 		103c 8b17  ProBook 445 G9/455 G9
 		1043 86c7  PRIME B450M-A Motherboard
@@ -5375,6 +5519,8 @@
 	1647  VanGogh PCIe GPP Bridge
 	1648  VanGogh Internal PCIe GPP Bridge to Bus
 	1649  Family 19h PSP/CCP
+	164a  Sensor Fusion Hub
+	164b  Non-Sensor Fusion Hub
 	164f  Milan IOMMU
 	1650  Milan Data Fabric; Function 0
 	1651  Milan Data Fabric; Function 1
@@ -5410,6 +5556,14 @@
 	167e  Rembrandt Data Fabric: Device 18h; Function 5
 	167f  Rembrandt Data Fabric: Device 18h; Function 6
 	1680  Rembrandt Data Fabric: Device 18h; Function 7
+	16f8  Strix Data Fabric; Function 0
+	16f9  Strix Data Fabric; Function 1
+	16fa  Strix Data Fabric; Function 2
+	16fb  Strix Data Fabric; Function 3
+	16fc  Strix Data Fabric; Function 4
+	16fd  Strix Data Fabric; Function 5
+	16fe  Strix Data Fabric; Function 6
+	16ff  Strix Data Fabric; Function 7
 	1700  Family 12h/14h Processor Function 0
 	1701  Family 12h/14h Processor Function 1
 	1702  Family 12h/14h Processor Function 2
@@ -5427,6 +5581,8 @@
 	1716  Family 12h/14h Processor Function 5
 	1718  Family 12h/14h Processor Function 6
 	1719  Family 12h/14h Processor Function 7
+	17e0  Strix/Krackan/Strix Halo CCP/ASP
+	17f0  Strix/Krackan/Strix Halo Neural Processing Unit
 	2000  79C97x [PCnet32 LANCE]
 		1014 2000  NetFinity 10/100 Fast Ethernet
 		1022 2000  PCnet - Fast 79C971
@@ -5506,6 +5662,7 @@
 	43f5  600 Series Chipset PCIe Switch Downstream Port
 	43f6  600 Series Chipset SATA Controller
 	43f7  600 Series Chipset USB 3.2 Controller
+	43fd  800 Series Chipset USB 3.x XHCI Controller
 	57a3  Matisse PCIe GPP Bridge
 	57a4  Matisse PCIe GPP Bridge
 	57ad  Matisse Switch Upstream
@@ -5781,7 +5938,8 @@
 	5225  M5225
 	5229  M5229
 	5235  M5235
-	5237  M5237 PCI USB Host Controller
+	5237  OHCI USB Controller
+	5239  EHCI USB Controller
 	5240  EIDE Controller
 	5241  PCMCIA Bridge
 	5242  General Purpose Controller
@@ -6704,28 +6862,28 @@
 	c066  3010S Ultra3 Dual Channel
 1045  OPTi Inc.
 	a0f8  82C750 [Vendetta] USB Controller
-	c101  92C264
+	c101  82C264 GUI Accelerator
 	c178  92C178
 	c556  82X556 [Viper]
 	c557  82C557 [Viper-M]
 	c558  82C558 [Viper-M ISA+IDE]
-	c567  82C750 [Vendetta], device 0
-	c568  82C750 [Vendetta], device 1
+	c567  82C750 [Vendetta] Host Bridge
+	c568  82C750 [Vendetta] ISA Bridge
 	c569  82C579 [Viper XPress+ Chipset]
-	c621  82C621 [Viper-M/N+]
+	c621  82C621A PCI IDE Contoller
 	c700  82C700 [FireStar]
-	c701  82C701 [FireStar Plus]
-	c814  82C814 [Firebridge 1]
+	c701  82C700 [FireStar] Host Bridge
+	c814  82C814 [FireBridge II] Docking Stration Controller
 	c822  82C822
-	c824  82C824
-	c825  82C825 [Firebridge 2]
+	c824  82C824 [FireFox] 32-Bit PC Card Controller
+	c825  82C825 [FireBridge II] Docking Stration Controller
 	c832  82C832
-	c861  82C861 OHCI USB Host
+	c861  82C861/2/3 [FireLink] PCI-USB Host Bridge
 	c881  82C881 [FireLink] 1394 OHCI Link Controller
 	c895  82C895
-	c935  EV1935 ECTIVA MachOne PCIAudio
-	d568  82C825 [Firebridge 2]
-	d721  IDE [FireStar]
+	c935  82С935 [MachOne] Integrated PCI Audio Processor
+	d568  82C700 [FireStar] PCI IDE Controller
+	d721  82C700 [FireStar] PCI IDE Controller
 1046  IPC Corporation, Ltd.
 1047  Genoa Systems Corp
 1048  Elsa AG
@@ -7124,12 +7282,13 @@
 	0001  W83769F
 	0033  W89C33D 802.11 a/b/g BB/MAC
 	0105  W82C105
+	0628  W83628F/W83629D PCI to ISA Bridge Set
 	0840  W89C840
 		1050 0001  W89C840 Ethernet Adapter
 		1050 0840  W89C840 Ethernet Adapter
 	0940  W89C940
-	5a5a  W89C940F
-	6692  W6692
+	5a5a  W89C940 Twisted-pair Ether-LAN Controller With PCI Interface [ELANC-PCI]
+	6692  W6692 PCI ISDN S/T-Controller
 		1043 1702  ISDN Adapter (PCI Bus, D, W)
 		1043 1703  ISDN Adapter (PCI Bus, DV, W)
 		1043 1707  ISDN Adapter (PCI Bus, DV, W)
@@ -7138,6 +7297,7 @@
 		144f 1707  ISDN Adapter (PCI Bus, DV, W)
 	9921  W99200F MPEG-1 Video Encoder
 	9922  W99200F/W9922PF MPEG-1/2 Video Encoder
+	9960  W9960CF Video Codec
 	9970  W9970CF
 1051  Anigma, Inc.
 1052  ?Young Micro Systems
@@ -7162,6 +7322,7 @@
 1055  Microchip Technology / SMSC
 	7430  LAN7430
 	7431  LAN7431
+		1059 01a0  RD10055 M.2 Dual 1GbE-T1 40m
 	9130  SLC90E66 [Victory66] IDE
 	9460  SLC90E66 [Victory66] ISA
 	9462  SLC90E66 [Victory66] USB
@@ -8597,6 +8758,7 @@
 		1093 72f7  PXIe-6535
 		1093 72f8  PXIe-6536
 		1093 72f9  PXIe-6537
+		1093 730a  PXIe-5142
 		1093 7326  PCIe-6509
 		1093 736c  PXIe-4140
 		1093 738b  PXIe-5622
@@ -8666,6 +8828,7 @@
 		1093 762e  PXIe-5606
 		1093 7644  PXIe-4841
 		1093 764a  PCIe-8237R-S
+		1093 7652  PXIe-4080
 		1093 7658  PXIe-5162 (4CH)
 		1093 76ab  PXIe-4322
 		1093 76ad  PXIe-4112
@@ -8682,6 +8845,8 @@
 		1093 76ce  CVS-1459
 		1093 76d0  PXIe-5160 (2CH)
 		1093 76d1  PXIe-5160 (4CH)
+		1093 76d8  PXIe-4081
+		1093 76d9  PXIe-4082
 		1093 76dc  PXIe-4610
 		1093 76ec  PXIe-2524
 		1093 76ed  PXIe-2525
@@ -8719,6 +8884,8 @@
 		1093 7790  PXIe-5170R (4CH)
 		1093 7791  PXIe-5170R (8CH)
 		1093 7793  PXIe-5171R (8CH)
+		1093 7794  PXIe-5172 (4CH - 325T)
+		1093 7795  PXIe-5172 (8CH - 410T)
 		1093 77a5  PXIe-6345
 		1093 77a6  PXIe-6355
 		1093 77a7  PXIe-6365
@@ -8742,18 +8909,44 @@
 		1093 7802  PXIe-4302
 		1093 7803  PXIe-4303
 		1093 7805  PXIe-4305
+		1093 781e  PXIe-4135
+		1093 7820  PXIe-5164
+		1093 783d  PXIe-6570
+		1093 7851  PXIe-5172 (8CH - 325T)
 		1093 786f  PXIe-4163
+		1093 7881  PXIe-5163
 		1093 788e  PXIe-4304
+		1093 78d5  PXIe-5413 (1CH)
+		1093 78d6  PXIe-5413 (2CH)
+		1093 78d7  PXIe-5423 (1CH)
+		1093 78d8  PXIe-5423 (2CH)
+		1093 78d9  PXIe-5433 (1CH)
+		1093 78da  NI PXIe-5433 (2CH)
 		1093 78f8  NI FlexRIO Module (KU035)
 		1093 78f9  NI FlexRIO Module (KU040)
 		1093 78fa  NI FlexRIO Module (KU060)
 		1093 78ff  PXIe-4162
+		1093 792f  PXIe-4190
+		1093 7935  PXIe-5111
+		1093 7936  PXIe-5110
 		1093 7995  PXIe-7911R
 		1093 7996  PXIe-7912R
 		1093 7997  PXIe-7915R
+		1093 79cd  PXIe-5113
 		1093 79d3  NI FlexRIO PCIe Module (KU035)
 		1093 79d4  NI FlexRIO PCIe Module (KU040)
 		1093 79d5  NI FlexRIO PCIe Module (KU060)
+		1093 79f8  PXIe-6571
+		1093 7a16  PXIe-4147
+		1093 7a9a  PXIe-4137 (40W)
+		1093 7aa4  PXIe-4135 (40W)
+		1093 7aca  PXIe-4051
+		1093 7acb  PXIe-4150
+		1093 7acc  PXIe-4151
+		1093 7ae0  PXIe-4163 (10 pA)
+		1093 7ae1  PXIe-4162 (10 pA)
+		1093 7aef  PXIe-4190 (500 kHz)
+		1093 7b1f  PXIe-6571 (8CH)
 	c801  PCI-GPIB
 	c811  PCI-GPIB+
 	c821  PXI-GPIB
@@ -9104,13 +9297,13 @@
 	5842  2051 ISA bridge
 10ab  Digicom
 10ac  Honeywell IAC
-10ad  Symphony Labs
+10ad  Winbond Electronics Corp / Symphony Labs
 	0001  W83769F
 	0003  SL82C103
 	0005  SL82C105
 	0103  SL82c103
-	0105  SL82c105
-	0565  W83C553F/W83C554F
+	0105  SL82C105/W83C55xF Bus Master IDE
+	0565  W83C553F/554F ISA bridge
 10ae  Cornerstone Technology
 10af  Micro Computer Systems Inc
 10b0  CardExpert Technology
@@ -12988,17 +13181,22 @@
 	223f  GA102GL
 	228b  GA104 High Definition Audio Controller
 	228e  GA106 High Definition Audio Controller
+	2291  GA107 High Definition Audio Controller
 	2296  Tegra PCIe Endpoint Virtual Network
 	22a3  GH100 [H100 NVSwitch]
 	22ba  AD102 High Definition Audio Controller
 	22bc  AD104 High Definition Audio Controller
 	22bd  AD106M High Definition Audio Controller
+	22be  AD107 High Definition Audio Controller
 	2302  GH100
+	230e  GH100 [H20 NVL16]
 	2313  GH100 [H100 CNX]
 	2321  GH100 [H100L 94GB]
 	2322  GH100 [H800 PCIe]
 	2324  GH100 [H800]
+	2328  GH100 [H20B]
 	2329  GH100 [H20]
+	232c  GH100 [H20 HBM3e]
 	2330  GH100 [H100 SXM5 80GB]
 	2331  GH100 [H100 PCIe]
 	2335  GH100 [H200 SXM 141GB]
@@ -13007,10 +13205,12 @@
 	2338  GH100 [H100 SXM5 96GB]
 	2339  GH100 [H100 SXM5 94GB]
 	233a  GH100 [H800L 94GB]
+	233b  GH100 [H200 NVL]
 	233d  GH100 [H100 96GB]
 	2342  GH100 [GH200 120GB / 480GB]
 	2343  GH100
 	2345  GH100 [GH100-88K-A1]
+	2348  GH100 [GH200 144G HBM3e]
 	237f  GH100 [Skinny Joe]
 	23b0  GH100
 	23f0  GH100
@@ -13089,7 +13289,7 @@
 	25a9  GA107M [GeForce RTX 2050]
 	25aa  GA107M [GeForce MX570 A]
 	25ab  GA107M [GeForce RTX 3050 4GB Laptop GPU]
-	25ac  GN20-P0-R-K2 [GeForce RTX 3050 6GB Laptop GPU]
+	25ac  GA107BM / GN20-P0-R-K2 [GeForce RTX 3050 6GB Laptop GPU]
 	25ad  GA107 [GeForce RTX 2050]
 	25af  GA107 [GeForce RTX 3050 Engineering Sample]
 	25b0  GA107GL [RTX A1000]
@@ -13106,7 +13306,7 @@
 	25e0  GA107BM [GeForce RTX 3050 Ti Mobile]
 	25e2  GA107BM [GeForce RTX 3050 Mobile]
 	25e5  GA107BM [GeForce RTX 3050 Mobile]
-	25ec  GN20-P0-R-K2 [GeForce RTX 3050 6GB Laptop GPU]
+	25ec  GA107BM / GN20-P0-R-K2 [GeForce RTX 3050 6GB Laptop GPU]
 	25ed  GA107 [GeForce RTX 2050]
 	25f9  GA107 [RTX A1000 Embedded GPU ]
 	25fa  GA107 [RTX A2000 Embedded GPU]
@@ -13115,6 +13315,7 @@
 	2684  AD102 [GeForce RTX 4090]
 	2685  AD102 [GeForce RTX 4090 D]
 	2689  AD102 [GeForce RTX 4070 Ti SUPER]
+	26af  AD102 [PG137]
 	26b1  AD102GL [RTX 6000 Ada Generation]
 	26b2  AD102GL [RTX 5000 Ada Generation]
 	26b3  AD102GL [RTX 5880 Ada Generation]
@@ -13123,15 +13324,16 @@
 	26b8  AD102GL [L40G]
 	26b9  AD102GL [L40S]
 	26ba  AD102GL [L20]
+	26bb  AD102GL [L30]
 	26f5  AD102GL [L40 CNX]
 	2702  AD103 [GeForce RTX 4080 SUPER]
 	2703  AD103 [GeForce RTX 4080 SUPER]
 	2704  AD103 [GeForce RTX 4080]
 	2705  AD103 [GeForce RTX 4070 Ti SUPER]
 	2709  AD103 [GeForce RTX 4070]
-	2717  GN21-X11 [GeForce RTX 4090 Laptop GPU]
+	2717  AD103M / GN21-X11 [GeForce RTX 4090 Laptop GPU]
 	2730  AD103GLM [RTX 5000 Ada Generation Laptop GPU]
-	2757  GN21-X11
+	2757  AD103M / GN21-X11 [GeForce RTX 4090 Laptop GPU]
 	2770  AD103GLM [RTX 5000 Ada Generation Embedded GPU]
 	2782  AD104 [GeForce RTX 4070 Ti]
 	2783  AD104 [GeForce RTX 4070 SUPER]
@@ -13154,12 +13356,14 @@
 	2805  AD106 [GeForce RTX 4060 Ti 16GB]
 	2808  AD106 [GeForce RTX 4060]
 	2820  AD106M [GeForce RTX 4070 Max-Q / Mobile]
+	2822  AD106M [GeForce RTX 3050 A Laptop GPU]
 	2838  AD106GLM [RTX 3000 Ada Generation Laptop GPU]
 	2860  AD106M [GeForce RTX 4070 Max-Q / Mobile]
 	2878  AD106GLM [RTX 3000 Ada Generation Embedded GPU]
 	2882  AD107 [GeForce RTX 4060]
 	28a0  AD107M [GeForce RTX 4060 Max-Q / Mobile]
 	28a1  AD107M [GeForce RTX 4050 Max-Q / Mobile]
+	28a3  AD107M [GeForce RTX 3050 A Laptop GPU]
 	28b0  AD107GL [RTX 2000 / 2000E Ada Generation]
 	28b8  AD107GLM [RTX 2000 Ada Generation Laptop GPU]
 	28b9  AD107GLM [RTX 1000 Ada Generation Laptop GPU]
@@ -13167,7 +13371,37 @@
 	28bb  AD107GLM [RTX 500 Ada Generation Laptop GPU]
 	28e0  AD107M [GeForce RTX 4060 Max-Q / Mobile]
 	28e1  AD107M [GeForce RTX 4050 Max-Q / Mobile]
+	28e3  AD107M [GeForce RTX 3050 A Laptop GPU]
 	28f8  AD107GLM [RTX 2000 Ada Generation Embedded GPU]
+	2900  GB100 [Reserved Dev ID A]
+	2901  GB100 [B200]
+	2920  GB100 [TS4]
+	2940  GB100 [Reserved Dev ID B]
+	2941  GB100 [HGX GB200]
+	2980  GB102 [Reserved Dev ID A]
+	29bc  GB102 [B100]
+	29c0  GB102 [Reserved Dev ID B]
+	2b85  GB202 [GeForce RTX 5090]
+	2b87  GB202 [GeForce RTX 5090 D]
+	2c02  GB203 [GeForce RTX 5080]
+	2c05  GB203 [GeForce RTX 5070 Ti]
+	2c18  GB203M / GN22 [GeForce RTX 5090 Max-Q / Mobile]
+	2c19  GB203M / GN22 [GeForce RTX 5080 Max-Q / Mobile]
+	2c2c  GB6-256(N22W-ES-A1)
+	2c58  GB203M / GN22-X11 [GeForce RTX 5090 Max-Q / Mobile]
+	2c59  GB203M / GN22-X9 [GeForce RTX 5080 Max-Q / Mobile]
+	2d18  AD108M [GeForce RTX 5070 Max-Q / Mobile]
+	2d19  AD108M [GeForce RTX 5060 Max-Q / Mobile]
+	2d2c  GB6-128 (N22Y-ES-A1)
+	2d58  AD108M [GeForce RTX 5070 Max-Q / Mobile]
+	2d59  AD108M [GeForce RTX 5060 Max-Q / Mobile]
+	2d98  AD108M [GeForce RTX 5050 Max-Q / Mobile]
+	2dd8  AD108M [GeForce RTX 5050 Max-Q / Mobile]
+	2f04  GN22 [GeForce RTX 5070]
+	2f18  AD108M [GeForce RTX 5070 Ti Max-Q / Mobile]
+	2f58  AD108M [GeForce RTX 5070 Ti Max-Q / Mobile]
+	31c0  GB110
+	3340  GB120
 10df  Emulex Corporation
 	0720  OneConnect NIC (Skyhawk)
 		103c 1934  FlexFabric 20Gb 2-port 650M Adapter
@@ -13269,6 +13503,8 @@
 	f500  LPe37000/LPe38000 Series 32Gb/64Gb Fibre Channel Adapter
 		1014 06c1  PCIe4 4-Port 32Gb Fibre Channel Adapter for POWER (FC EN1L/EN1M; CCIN 2CFC)
 		1014 06c2  PCIe4 2-Port 64Gb Fibre Channel Adapter for POWER (FC EN1N/EN1P; CCIN 2CFD)
+		1590 0454  Synergy 5331C 32Gb Fibre Channel Host Bus Adapter
+	f600  LPe37100S/LPe38100S Series 32Gb/64Gb Fibre Channel Adapter
 	f700  LP7000 Fibre Channel Host Adapter
 	f701  LP7000 Fibre Channel Host Adapter Alternate ID (JX1:2-3, JX2:1-2)
 	f800  LP8000 Fibre Channel Host Adapter
@@ -13431,6 +13667,7 @@
 		1af4 1100  QEMU Virtual Machine
 	8125  RTL8125 2.5GbE Controller
 		4c52 2022  LRES2022PT Single-port 2.5Gb Ethernet Network Adapter
+	8126  RTL8126 5GbE Controller
 	8129  RTL-8129
 		10ec 8129  RT8129 Fast Ethernet Adapter
 		11ec 8129  RTL8111/8168 PCIe Gigabit Ethernet (misconfigured)
@@ -13525,7 +13762,7 @@
 		1043 16d5  U6V/U31J laptop
 		1043 81aa  P5B
 		1043 82c6  M3A78 Series Motherboard
-		1043 83a3  M4A785/P7P55 Motherboard
+		1043 83a3  M4A785/P7P55/AT3IONT-I Motherboard
 		1043 8432  P8P67 and other motherboards
 		1043 8505  P8 series motherboard
 		1043 8554  H81M-C Motherboard
@@ -13607,7 +13844,9 @@
 	8813  RTL8813AE 802.11ac PCIe Wireless Network Adapter
 	8821  RTL8821AE 802.11ac PCIe Wireless Network Adapter
 	8852  RTL8852AE 802.11ax PCIe Wireless Network Adapter
+	8922  RTL8922AE 802.11be PCIe Wireless Network Adapter
 	a85a  RTL8852AE WiFi 6 802.11ax PCIe Adapter
+	b520  RTL8852BE-VT PCIe 802.11ax Wireless Network Controller
 	b723  RTL8723BE PCIe Wireless Network Adapter
 		10ec 8739  Dell Wireless 1801
 		17aa b736  Z50-75
@@ -13644,11 +13883,16 @@
 	3fc5  RME Hammerfall DSP
 	3fc6  RME Hammerfall DSP MADI
 	5000  Alveo U200 XDMA Platform
+		10ee 000e  Alveo card
 	5004  Alveo U250 XDMA Platform
+		10ee 000e  Alveo card
 	5005  Alveo U250
 	500c  Alveo U280 XDMA Platform
+		10ee 000e  Alveo card
 	5020  Alveo U50 XMDA Platform
+		10ee 000e  Alveo card
 	505c  Alveo U55C
+		10ee 000e  Alveo card
 	5074  Alveo X3522, Quad Port, 10/25GbE Adaptable Accelerator Card
 	5084  Alveo X3522, Quad Port, 10/25GbE Low Latency Network Adapter
 	6987  SmartSSD
@@ -13664,9 +13908,13 @@
 	9234  SmartSSD
 	9434  SmartSSD
 	d000  Alveo U200 Golden Image
+		10ee 000e  Alveo card
 	d004  Alveo U250 Golden Image
+		10ee 000e  Alveo card
 	d00c  Alveo U280 Golden Image
+		10ee 000e  Alveo card
 	d020  Alveo U50 Golden Image
+		10ee 000e  Alveo card
 	d154  Copley Controls CAN card (PCI-CAN-02)
 # SED is assigned Xilinx PCI device IDs ebf0 through ebff
 	ebf0  SED Systems Modulator/Demodulator
@@ -13972,6 +14220,7 @@
 	0410  VX900 Series Host Bridge: Host Control
 	0415  VT6415 PATA IDE Host Controller
 		1043 838f  Motherboard
+	0419  VN1000 Host Bridge
 	0501  VT8501 [Apollo MVP4]
 	0505  VT82C505
 # Shares chip with :0576. The VT82C576M has :1571 instead of :0561.
@@ -14063,6 +14312,7 @@
 	1364  CN896/VN896/P4M900 Host Bridge
 	1409  VX855/VX875 Error Reporting
 	1410  VX900 Series Error Reporting
+	1419  VN1000 Host Bridge
 	1571  VT82C576M/VT82C586
 	1595  VT82C595/97 [Apollo VP2/97]
 	1732  VT1732 [Envy24 II] PCI Multi-Channel Audio Controller
@@ -14088,11 +14338,12 @@
 	2364  CN896/VN896/P4M900 Host Bridge
 	2409  VX855/VX875 Host Bus Control
 	2410  VX900 Series CPU Bus Controller
+	2419  VN1000 Host Bridge
 	287a  VT8251 PCI to PCI Bridge
 	287b  VT8251 Host Bridge
 	287c  VT8251 PCIE Root Port
 	287d  VT8251 PCIE Root Port
-	287e  VT8237/8251 Ultra VLINK Controller
+	287e  VT8237/8251/8261 Ultra VLINK Controller
 	3022  CLE266
 	3038  VT82xx/62xx/VX700/8x0/900 UHCI USB 1.1 Controller
 		0925 1234  onboard UHCI USB 1.1 Controller
@@ -14257,7 +14508,7 @@
 	3116  VT8375 [KM266/KL266] Host Bridge
 		1297 f641  FX41 motherboard
 	3118  CN400/PM800/PM880/PN800/PN880 [S3 UniChrome Pro]
-	3119  VT6120/VT6121/VT6122 Gigabit Ethernet Adapter
+	3119  VT6120/VT6121/VT6122/VT6130 Gigabit Ethernet Adapter
 	3122  VT8623 [Apollo CLE266] integrated CastleRock graphics
 	3123  VT8623 [Apollo CLE266]
 	3128  VT8753 [P4X266 AGP]
@@ -14358,12 +14609,14 @@
 	3372  VT8237S PCI to ISA Bridge
 	337a  VT8237A PCI to PCI Bridge
 	337b  VT8237A Host Bridge
+	3402  VT8261 PCI to ISA Bridge
 	3403  VT6315 Series Firewire Controller
 		1043 8374  M5A88-V EVO
 		1043 8384  P8P67 Deluxe Motherboard
 	3409  VX855/VX875 DRAM Bus Control
 	3410  VX900 Series DRAM Bus Control
 		19da a179  ZBOX nano VD01
+	3419  VN1000 Host Bridge
 	3432  VL800/801 xHCI USB 3.0 Controller
 	3456  VX11 Standard Host Bridge
 	345b  VX11 Miscellaneous Bus
@@ -14392,6 +14645,7 @@
 	4409  VX855/VX875 Power Management Control
 	4410  VX900 Series Power Management and Chip Testing Control
 		19da a179  ZBOX nano VD01
+	4419  VN1000 Host Bridge
 	5030  VT82C596 ACPI [Apollo PRO]
 	5122  VX855/VX875 Chrome 9 HCM Integrated Graphics
 	5208  PT890 I/O APIC Interrupt Controller
@@ -14409,6 +14663,7 @@
 	5372  VT8237/8251 Serial ATA Controller
 	5409  VX855/VX875 APIC and Central Traffic Control
 	5410  VX900 Series APIC and Central Traffic Control
+	5419  VN1000 I/O APIC Interrupt Controller
 	6100  VT85C100A [Rhine II]
 	6122  VN1000 Graphics [Chrome 520 IGP]
 	6287  SATA RAID Controller
@@ -14419,6 +14674,7 @@
 	6409  VX855/VX875 Scratch Registers
 	6410  VX900 Series Scratch Registers
 		19da a179  ZBOX nano VD01
+	6419  VN1000 Host Bridge
 	7122  VX900 Graphics [Chrome9 HD]
 	7204  K8M800 Host Bridge
 	7205  KM400/KN400/P4M800 [S3 UniChrome]
@@ -14445,6 +14701,7 @@
 	7409  VX855/VX875 North-South Module Interface Control
 	7410  VX900 Series North-South Module Interface Control
 		19da a179  ZBOX nano VD01
+	7419  VN1000 Host Bridge
 	8231  VT8231 [PCI-to-ISA Bridge]
 	8235  VT8235 ACPI
 	8305  VT8363/8365 [KT133/KM133 AGP]
@@ -14469,12 +14726,14 @@
 	8a26  KL133/KL133A/KM133/KM133A [S3 ProSavage]
 	8d01  PN133/PN133T [S3 Twister]
 	8d04  KM266/P4M266/P4M266A/P4N266 [S3 ProSavageDDR]
+	9000  VT8261 IDE Controller [StorX IDE Controller - 9000]
 	9001  VX900 Series Serial-ATA Controller
+	9040  VT8261 SATA Controller [StorX RAID Controller - 9040]
 	9082  Standard AHCI 1.0 SATA Controller
 	9140  HDMI Audio Device
 	9201  USB3.0 Controller
 	9380  Ncore Coprocessor for Centaur CNS
-	9530  VX800/820/900 Series Secure Digital Memory Card Controller
+	9530  VX800/820/900/VT8261 Series Secure Digital Memory Card Controller
 	95d0  VX800/820/900 Series SDIO Host Controller
 	a208  PT890 PCI to PCI Bridge Controller
 	a238  K8T890 PCI to PCI Bridge Controller
@@ -14483,6 +14742,7 @@
 	a364  CN896/VN896/P4M900 PCI to PCI Bridge Controller
 	a409  VX855/VX875/VX900 Series USB Device Controller
 	a410  VX900 Series PCI Express Root Port 0
+	a419  VN1000 PCI to PCI Bridge
 	b091  VT8633 [Apollo Pro266 AGP]
 	b099  VT8366/A/7 [Apollo KT266/A/333 AGP]
 	b101  VT8653 AGP Bridge
@@ -14498,6 +14758,7 @@
 	b213  VPX/VPX2 I/O APIC Interrupt Controller
 	b353  VX855/VX875/VX900 PCI to PCI Bridge
 	b410  VX900 Series PCI Express Root Port 1
+	b419  VN1000 Host Bridge
 	b999  [K8T890 North / VT8237 South] PCI Bridge
 	c208  PT890 PCI to PCI Bridge Controller
 	c238  K8T890 PCI to PCI Bridge Controller
@@ -14507,22 +14768,26 @@
 	c364  CN896/VN896/P4M900 PCI to PCI Bridge Controller
 	c409  VX855/VX875 EIDE Controller
 	c410  VX900 Series PCI Express Root Port 2
+	c419  VN1000 PCI to PCI Bridge
 	d104  VT8237R USB UDCI Controller
 	d208  PT890 PCI to PCI Bridge Controller
 	d213  VPX/VPX2 PCI to PCI Bridge Controller
 	d238  K8T890 PCI to PCI Bridge Controller
 	d340  PT900 PCI to PCI Bridge Controller
 	d410  VX900 Series PCI Express Root Port 3
+	d419  VN1000 PCI to PCI Bridge
 	e208  PT890 PCI to PCI Bridge Controller
 	e238  K8T890 PCI to PCI Bridge Controller
 	e340  PT900 PCI to PCI Bridge Controller
 	e353  VX800/820-Series PCI-Express Root Port 0
 	e410  VX900 Series PCI Express Physical Layer Electrical Sub-block
+	e419  VN1000 PCI to PCI Bridge
 	f208  PT890 PCI to PCI Bridge Controller
 	f238  K8T890 PCI to PCI Bridge Controller
 	f340  PT900 PCI to PCI Bridge Controller
 	f353  VX800/820-Series PCI-Express Root Port 1
 	f410  VX900 Series PCI UART Port 0-3
+	f419  VN1000 PCI to PCI Bridge
 1107  Stratus Computers
 	0576  VIA VT82C570MV [Apollo] (Wrong vendor ID!)
 1108  Proteon, Inc.
@@ -15208,6 +15473,21 @@
 		1137 021a  VIC 1487 MLOM Ethernet NIC
 		1137 024a  VIC 1495 PCIe Ethernet NIC
 		1137 024b  VIC 1497 MLOM Ethernet NIC
+		1137 02af  VIC 1467 MLOM Ethernet NIC
+		1137 02b0  VIC 1477 MLOM Ethernet NIC
+		1137 02cf  VIC 14425 MLOM Ethernet NIC
+		1137 02d0  VIC 14825 Mezzanine Ethernet NIC
+		1137 02db  VIC 15231 MLOM Ethernet NIC
+		1137 02dc  VIC 15411 MLOM Ethernet NIC
+		1137 02dd  VIC 15428 MLOM Ethernet NIC
+		1137 02de  VIC 15420 MLOM Ethernet NIC
+		1137 02df  VIC 15230 MLOM Ethernet NIC
+		1137 02e0  VIC 15427 MLOM Ethernet NIC
+		1137 02e1  VIC 15422 Mezzanine Ethernet NIC
+		1137 02e4  VIC 15235 PCIe Ethernet NIC
+		1137 02e8  VIC 15238 MLOM Ethernet NIC
+		1137 02f2  VIC 15425 PCIe Ethernet NIC
+		1137 02f3  VIC 15237 MLOM Ethernet NIC
 	0044  VIC Ethernet NIC Dynamic
 		1137 0047  VIC P81E PCIe Ethernet NIC Dynamic
 		1137 0048  VIC M81KR Mezzanine Ethernet NIC Dynamic
@@ -15254,6 +15534,7 @@
 		1137 012e  VIC 1227 PCIe Userspace NIC
 		1137 0137  VIC 1380 Mezzanine Userspace NIC
 	023e  1GigE I350 LOM
+	02b7  VIC SR-IOV Ethernet VF
 1138  Ziatech Corporation
 	8905  8905 [STD 32 Bridge]
 1139  Dynamic Pictures, Inc
@@ -15630,6 +15911,8 @@
 1170  Inventec Corporation
 1171  Loughborough Sound Images Plc
 1172  Altera Corporation
+# Unknown card with Altera ACE EP1K50TC144-2 as the PCI interface and has 4 BNC inputs connected to 4 TL3016 Comparators and one TRS output connected to two LTC1650 DACs
+	0004  PF5102 board
 	00a7  Stratix V
 	0530  Stratix IV
 	646c  KT-500/KT-521 board
@@ -15723,15 +16006,22 @@
 		117c 00a2  Celerity FC-321E
 		117c 00a3  Celerity FC-322E
 		117c 00ac  Celerity FC-324E
+		117c 40a6  ThunderLink TLFC-3162
+		117c 40a7  ThunderLink TLFC-3322
+	00a5  ExpressSAS 24Gb/s SAS/SATA HBA
+		117c 00d0  ExpressSAS H24F0
+		117c 00d1  ExpressSAS H240F
+		117c 00d2  ExpressSAS H240N
 	00bb  Celerity FC 32/64Gb/s Gen 7 Fibre Channel HBA
 		117c 00bc  Celerity FC-321P
 		117c 00bd  Celerity FC-322P
 		117c 00be  Celerity FC-324P
 		117c 00c9  Celerity FC-641E
 		117c 00ca  Celerity FC-642E
+		117c 00d4  Celerity FC-644E
 	00c5  ExpressNVM PCIe Gen4 Switch
 		117c 00c6  ExpressNVM S48F PCIe Gen4
-		117c 00c7  ExpressNVM S468 PCIe Gen4
+		117c 00cb  ExpressNVM S4FF PCIe Gen4
 	00e6  ExpressSAS GT 12Gb/s SAS/SATA HBA
 		117c 00c0  ExpressSAS H1280 GT
 		117c 00c1  ExpressSAS H1208 GT
@@ -15745,9 +16035,11 @@
 		117c 0070  ExpressSAS H1280
 		117c 0071  ExpressSAS H1208
 		117c 0080  ExpressSAS H1244
+		117c 40ae  ThunderLink TLSH-3128
 	8072  ExpressSAS 12Gb/s SAS/SATA HBA
 		117c 0072  ExpressSAS H12F0
 		117c 0073  ExpressSAS H120F
+		117c 0081  ExpressSAS H1248
 		117c 0082  ExpressSAS H1288
 117d  Becton & Dickinson
 117e  T/R Systems
@@ -16579,6 +16871,12 @@
 11f2  Picture Tel Japan K.K.
 11f3  Keithley Metrabyte
 	0011  KPCI-PIO24
+	4200  42x0-SMU
+	4205  4205-VPU
+	4215  4200-VPU
+	4216  422x-PxU
+	4220  4200-CVU
+	4221  4210-CVU
 11f4  Kinetic Systems Corporation
 	2915  CAMAC controller
 11f5  Computing Devices International
@@ -16592,7 +16890,20 @@
 		11f6 2011  ReadyLink 100TX
 	9881  RL100TX Fast Ethernet
 11f7  Scientific Atlanta
-11f8  PMC-Sierra Inc.
+# née PMC-Sierra Inc.
+11f8  Microchip Technology
+	5000  PM50100 Switchtec PFX 100xG5 Fanout PCIe Switch
+	5028  PM50028 Switchtec PFX 28xG5 Fanout PCIe Switch
+	5036  PM50036 Switchtec PFX 36xG5 Fanout PCIe Switch
+	5052  PM50052 Switchtec PFX 52xG5 Fanout PCIe Switch
+	5068  PM50068 Switchtec PFX 68xG5 Fanout PCIe Switch
+	5084  PM50084 Switchtec PFX 84xG5 Fanout PCIe Switch
+	5100  PM51100 Switchtec PSX 100xG5 Programmable PCIe Switch
+	5128  PM51028 Switchtec PSX 28xG5 Programmable PCIe Switch
+	5136  PM51036 Switchtec PSX 36xG5 Programmable PCIe Switch
+	5152  PM51052 Switchtec PSX 52xG5 Programmable PCIe Switch
+	5168  PM51068 Switchtec PSX 68xG5 Programmable PCIe Switch
+	5184  PM51084 Switchtec PSX 84xG5 Programmable PCIe Switch
 	5220  BR522x [PMC-Sierra maxRAID SAS Controller]
 	7364  PM7364 [FREEDM - 32 Frame Engine & Datalink Mgr]
 	7375  PM7375 [LASAR-155 ATM SAR]
@@ -16918,9 +17229,7 @@
 123b  Seeq Technology, Inc.
 123c  Century Systems, Inc.
 123d  Engineering Design Team, Inc.
-	0000  EasyConnect 8/32
-	0002  EasyConnect 8/64
-	0003  EasyIO
+	0000  PCI 11W
 	0047  PCIe4 CDa
 	004b  PCIe4 CDa 16
 	009d  VisionLink F1
@@ -17034,7 +17343,9 @@
 		1028 0085  ES1968 Maestro-2 PCI
 		1033 8051  ES1968 Maestro-2 Audiodrive
 	1969  ES1938/ES1946/ES1969 Solo-1 Audiodrive
+		1014 0162  16 Bit PCI Audio Adapter (37L4457)
 		1014 0166  ES1969 SOLO-1 AudioDrive on IBM Aptiva Mainboard
+		121f 8800  eDio Hi-Live SC1938
 		125d 8888  Solo-1 Audio Adapter
 		125d 8898  ES1938S TTSOLO1-SL [TerraTec 128i PCI]
 		153b 111b  Terratec 128i PCI
@@ -17053,6 +17364,8 @@
 		125d 1999  Allegro-1 AudioDrive
 	1989  ESS Modem
 		125d 1989  ESS Modem
+	1990  ES1990S Canyon3D 2LE
+	1992  ES1992S Canyon3D 2
 	1998  ES1983S Maestro-3i PCI Audio Accelerator
 		1028 00b1  Latitude C600
 		1028 00e5  Latitude C810
@@ -18020,6 +18333,40 @@
 	51b9  6500 ION NVMe SSD
 		1028 22e6  Ent NVMe 6500 RI 30.72TB
 		1028 22f6  Ent NVMe 6500 RI FIPS 30.72TB
+	51bb  9550 PRO NVMe SSD
+		1028 2318  MTFDLBQ30T7THA-1BK1JABDA
+		1028 2319  MTFDLBQ15T3THA-1BK1JABDA
+		1028 231a  MTFDLBQ7T6THA-1BK1JABDA
+		1028 231b  MTFDLBQ3T8THA-1BK1JABDA
+		1028 2320  MTFDLAL30T7THA-1BK1JABDA
+		1028 2321  MTFDLAL15T3THA-1BK1JABDA
+		1028 2322  MTFDLAL7T6THA-1BK1JABDA
+		1028 2323  MTFDLAL3T8THA-1BK1JABDA
+		1028 2328  MTFDLAL30T7THA-1BK1DFCDA
+		1028 2329  MTFDLAL15T3THA-1BK1DFCDA
+		1028 232a  MTFDLAL7T6THA-1BK1DFCDA
+		1028 232b  MTFDLAL3T8THA-1BK1DFCDA
+		1028 235c  MTFDLBQ30T7THA-1BK1DFCDA
+		1028 235d  MTFDLBQ15T3THA-1BK1DFCDA
+		1028 235e  MTFDLBQ7T6THA-1BK1DFCDA
+		1028 235f  MTFDLBQ3T8THA-1BK1DFCDA
+	51bd  9550 MAX NVMe SSD
+		1028 231c  MTFDLBQ25T6THB-1BK1JABDA
+		1028 231d  MTFDLBQ12T8THB-1BK1JABDA
+		1028 231e  MTFDLBQ6T4THB-1BK1JABDA
+		1028 231f  MTFDLBQ3T2THB-1BK1JABDA
+		1028 2324  MTFDLAL25T6THB-1BK1JABDA
+		1028 2325  MTFDLAL12T8THB-1BK1JABDA
+		1028 2326  MTFDLAL6T4THB-1BK1JABDA
+		1028 2327  MTFDLAL3T2THB-1BK1JABDA
+		1028 232c  MTFDLAL25T6THB-1BK1DFCDA
+		1028 232d  MTFDLAL12T8THB-1BK1DFCDA
+		1028 232e  MTFDLAL6T4THB-1BK1DFCDA
+		1028 232f  MTFDLAL3T2THB-1BK1DFCDA
+		1028 2360  MTFDLBQ25T6THB-1BK1DFCDA
+		1028 2361  MTFDLBQ12T8THB-1BK1DFCDA
+		1028 2362  MTFDLBQ6T4THB-1BK1DFCDA
+		1028 2363  MTFDLBQ3T2THB-1BK1DFCDA
 	51c0  7400 PRO NVMe SSD
 		1028 2162  EC NVMe OPAL 7400 RI M.2 480GB
 		1028 2163  EC NVMe OPAL 7400 RI M.2 960GB
@@ -18090,6 +18437,11 @@
 		1028 2293  DC NVMe SED 7450 MU U.2 12.8TB
 		1028 2294  DC NVMe ISE 7450 MU U.2 12.8TB
 		1344 3000  U.3 1600GB [MTFDKCB1T6TFS/MTFDKCC1T6TFS]
+	51cb  6550 ION NVMe SSD
+		1028 2379  MTFDLBQ61T4THL-1BK1JABDA
+		1028 23a6  MTFDLBQ30T7THL-1BK1JABDA
+		1028 23a7  MTFDLAL61T4THL-1BK1JABDA
+		1028 23a8  MTFDLAL30T7THL-1BK1JABDA
 	5404  2210 NVMe SSD [Cobain]
 	5405  2300 NVMe SSD [Santana]
 	5407  3400 NVMe SSD [Hendrix]
@@ -18099,6 +18451,9 @@
 	5414  3460 NVMe SSD
 	5415  3500 NVMe SSD
 	5416  2550 NVMe SSD (DRAM-less)
+	5425  2500 NVMe SSD (DRAM-less)
+	5427  2650 NVMe SSD (DRAM-less)
+	5429  2600 NVMe SSD (DRAM-less)
 	6001  2100AI NVMe SSD [Nitro]
 1345  Arescom Inc
 1347  Odetics
@@ -18278,7 +18633,9 @@
 	0206  GPS180PEX GPS Receiver (PCI Express)
 	0207  GLN180PEX GPS/GLONASS receiver (PCI Express)
 	0208  GPS180AMC GPS Receiver (PCI Express / MicroTCA / AdvancedMC)
-	0209  GNS181PEX GPS/Galileo/GLONASS/BEIDOU receiver (PCI Express)
+	0209  GNS181PEX GNSS receiver (PCI Express)
+	020a  GPS183PEX GPS Receiver (PCI Express)
+	020b  GNS183PEX GNSS receiver (PCI Express)
 	0301  TCR510PCI IRIG Timecode Reader
 	0302  TCR167PCI IRIG Timecode Reader
 	0303  TCR511PCI IRIG Timecode Reader
@@ -18552,6 +18909,7 @@
 	0254  XR17V254 Quad UART PCI controller
 	0258  XR17V258 Octal UART PCI controller
 	0352  XR17V3521 Dual PCIe UART
+		4c52 9252  LRUS9252H 2-Port RS232 Serial Adapter
 13a9  Siemens Medical Systems, Ultrasound Group
 13aa  Broadband Networks Inc
 13ab  Arcom Control Systems Ltd
@@ -19917,6 +20275,7 @@
 		1028 215a  DC NVMe PM9A3 RI U.2 960GB
 		1028 215b  DC NVMe PM9A3 RI U.2 1.92TB
 		1028 215c  DC NVMe PM9A3 RI U.2 3.84TB
+		1028 215d  Dell DC NVMe PM9A3 RI U.2 7.68TB
 		1028 2166  DC NVMe PM9A3 RI 110M.2 960GB
 		1028 2167  DC NVMe PM9A3 RI 110M.2 1.92TB
 		1028 2168  DC NVMe PM9A3 RI 80M.2 480GB
@@ -19930,6 +20289,8 @@
 	a80b  NVMe SSD Controller PM9B1 (DRAM-less)
 	a80c  NVMe SSD Controller S4LV008[Pascal]
 	a80d  NVMe SSD Controller PM9C1a (DRAM-less)
+	a80e  NVMe SSD Controller PM9D3a
+	a80f  BM9C1 QLC NVME SSD (DRAM-less)
 	a820  NVMe SSD Controller 171X
 		1028 1f95  Express Flash NVMe XS1715 SSD 400GB
 		1028 1f96  Express Flash NVMe XS1715 SSD 800GB
@@ -20053,6 +20414,45 @@
 		1028 225e  NVMe FIPS PM1745 MU U.2 12.8TB
 		1028 225f  NVMe PM1745 MU U.2 12.8TB
 	a900  NVMe SSD Controller PM9DXa
+		1028 230f  DC NVMe PM9D3a RI 80M.2 480GB ISE
+		1028 2310  DC NVMe PM9D3a RI 80M.2 960GB ISE
+		1028 2311  DC NVMe PM9D3a RI 80M.2 1.92TB ISE
+		1028 2341  DC NVMe PM9D3a RI U.2 960GB　
+		1028 2342  DC NVMe PM9D3a RI U.2 1.92TB
+		1028 2343  DC NVMe PM9D3a RI U.2 3.84TB
+		1028 2344  DC NVMe PM9D3a RI U.2 7.68GTB
+		1028 2345  DC NVMe PM9D3a RI U.2 15.36TB
+		1028 2346  DC NVMe FIPS PM9D3a RI U.2 960GB
+		1028 2347  DC NVMe FIPS PM9D3a RI U.2 1.92TB
+		1028 2348  DC NVMe FIPS PM9D3a RI U.2 3.84TB
+		1028 2349  DC NVMe FIPS PM9D3a RI U.2 7.68TB
+		1028 234a  DC NVMe FIPS PM9D3a RI U.2 15.36TB　
+		1028 234d  DC NVMe PM9D3a RI E3s 1.92TB
+		1028 234e  DC NVMe PM9D3a RI E3s 3.84TB　
+		1028 234f  DC NVMe PM9D3a RI E3s 7.68GTB
+		1028 2350  DC NVMe PM9D3a RI E3s 15.36TB
+		1028 2351  DC NVMe FIPS PM9D3a RI E3s 1.92TB
+		1028 2352  DC NVMe FIPS PM9D3a RI E3s 3.84TB
+		1028 2353  DC NVMe FIPS PM9D3a RI E3s 7.68TB
+		1028 2354  DC NVMe FIPS PM9D3a RI E3s 15.36TB
+		1028 2355  DC NVMe PM9D5a MU U.2 800GB
+		1028 2356  DC NVMe PM9D5a MU U.2 1.6TB
+		1028 2357  DC NVMe PM9D5a MU U.2 3.2TB
+		1028 2358  DC NVMe PM9D5a MU U.2 6.4TB
+		1028 2359  DC NVMe PM9D5a MU E3.s 1.6TB
+		1028 235a  DC NVMe PM9D5a MU E3.s 3.2TB
+		1028 235b  DC NVMe PM9D5a MU E3.s 6.4TB
+	aa00  NVMe SSD Controller BM1743
+		1028 2312  NVMe FIPS BM1743 QLC U.2 15.36TB
+		1028 2313  NVMe FIPS BM1743 QLC U.2 30.72TB
+		1028 2314  NVMe FIPS BM1743 QLC U.2 61.44TB
+		1028 2315  NVMe BM1743 QLC U.2 15.36TB
+		1028 2316  NVMe BM1743 QLC U.2 30.72TB
+		1028 2317  NVMe BM1743 QLC U.2 61.44TB
+		1028 2364  NVMe BM1743 QLC U.2 122.88TB
+		1028 2366  MZ3MO15THCLCAD3
+		1028 2367  MZ3MO30THCLFAD3
+	ac00  NVMe SSD Controller PM175x
 	ecec  Exynos 8895 PCIe Root Complex
 144e  OLITEC
 144f  Askey Computer Corp.
@@ -20084,6 +20484,8 @@
 	f436  AVerTV Hybrid+FM
 1462  Micro-Star International Co., Ltd. [MSI]
 	3483  MSI USB 3.0 (VIA VL80x-based xHCI USB Controller)
+# This is MSI refreshed variant of their MECH series Navi 23 GPU card (73EF)
+	5027  RX 6650XT MECH 2X
 	7c56  Realtek Ethernet controller RTL8111H
 	aaf0  Radeon RX 580 Gaming X 8G
 1463  Fast Corporation
@@ -20174,6 +20576,7 @@
 14a3  Maverick Networks
 14a4  Lite-On Technology Corporation
 	2100  CA1-8D128 NVMe SSD
+	21f1  Plextor NVMe SSD
 	2200  CX2-8B256, CX2-8B512 NVMe SSD
 	22a0  EP2-KB960 NVMe SSD
 	22f1  M8Pe Series NVMe SSD
@@ -20181,6 +20584,7 @@
 	23f1  M9PeG, M9PeGN, M9PeY NVMe SSD
 	2f00  CAZ-82512 NVMe SSD
 	3500  CA5-8D512 NVMe SSD
+	35f1  PLEXTOR PX-256M9PGN+ NVMe SSD
 # Wrong vendor ID used
 	4318  Broadcom BCM4318 [AirForce One 54g] 802.11g WLAN Controller
 	5100  CB1-SD256, CB1-SD512 NVMe SSD
@@ -20250,6 +20654,7 @@
 14c3  MEDIATEK Corp.
 	0608  MT7921K (RZ608) Wi-Fi 6E 80MHz
 	0616  MT7922 802.11ax PCI Express Wireless Network Adapter
+	4d75  T700 5G Modem [5G Solution 5000]
 	7603  MT7603E 802.11bgn PCI Express Wireless Network Adapter
 	7612  MT7612E 802.11acbgn PCI Express Wireless Network Adapter
 	7615  MT7615E 802.11ac PCI Express Wireless Network Adapter
@@ -20257,12 +20662,16 @@
 	7650  MT7650 802.11ac
 # MT7612E too?
 	7662  MT7662E 802.11ac PCI Express Wireless Network Adapter
+	7663  MT7663 802.11ac PCI Express Wireless Network Adapter
 	7915  MT7915E 802.11ax PCI Express Wireless Network Adapter
 	7916  MT7905D/MT7975
 # WiFi 6E capable
 	7922  MT7922 802.11ax PCI Express Wireless Network Adapter
 		1a3b 5300  ASUS PCE-AXE59BT
 	7961  MT7921 802.11ax PCI Express Wireless Network Adapter
+	7988  MT7988 PCI Express Host Bridge [Filogic 880]
+	7990  MT7996 802.11be PCI Express Wireless Network Adapter (Port 0)
+	7991  MT7996 802.11be PCI Express Wireless Network Adapter (Port 1)
 	8650  MT7650 Bluetooth
 14c4  IWASAKI Information Systems Co Ltd
 14c5  Automation Products AB
@@ -20788,6 +21197,7 @@
 	16d4  BCM57402 NetXtreme-E Ethernet Partition
 	16d5  BCM57407 NetXtreme-E 10GBase-T Ethernet Controller
 	16d6  BCM57412 NetXtreme-E 10Gb RDMA Ethernet Controller
+		1059 01b0  RD10057 10GbE interface
 		117c 00cd  FastFrame N4S2 Dual-port 10Gb Ethernet Adapter
 		14e4 1202  BCM957412M4122C OCP 1x25G Type1 wRoCE
 		14e4 4120  NetXtreme E-Series Advanced Dual-port 10Gb SFP+ Ethernet Network Daughter Card
@@ -20871,15 +21281,17 @@
 		17aa 3a23  IdeaPad S10e
 	1750  BCM57508 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
 		117c 00cf  FastFrame N412 Dual-port 100Gb Ethernet Adapter
+		117c 40d6  ThunderLink TLNS-5102 Dual-port 100Gb Ethernet Adapter
 		14e4 2100  NetXtreme-E Dual-port 100G QSFP56 Ethernet PCIe4.0 x16 Adapter (BCM957508-P2100G)
 		14e4 5208  NetXtreme-E Dual-port 100G QSFP56 Ethernet OCP 3.0 Adapter (BCM957508-N2100G)
 		14e4 520a  NetXtreme-E Dual-port 100G DSFP Ethernet OCP 3.0 Adapter (BCM957508-N2100GD)
 		14e4 d124  NetXtreme-E P2100D BCM57508 2x100G QSFP PCIE
 		14e4 d324  NetXtreme-E N2100D BCM57508 2x100G QSFP OCP3.0 Ethernet
 		14e4 df24  NetXtreme-E NGM2100D BCM57508 2x100G KR Mezz Ethernet
-	1751  BCM57504 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
+	1751  BCM57504 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb Ethernet
 		1028 09d4  PowerEdge XR11/XR12 LOM
 		1028 0b1b  PowerEdge XR5610 LOM
+		117c 00da  FastFrame N424 Quad-port 25Gb Ethernet Adapter
 		14e4 4250  NetXtreme-E Quad-port 25G SFP28 Ethernet PCIe4.0 x16 Adapter (BCM957504-P425G)
 		14e4 5045  NetXtreme-E BCM57504 4x25G OCP3.0
 		14e4 5100  NetXtreme-E Single-port 100G QSFP56 Ethernet OCP 3.0 Adapter (BCM957504-N1100G)
@@ -20889,24 +21301,42 @@
 		14e4 d142  NetXtreme-E P425D BCM57504 4x25G SFP28 PCIE
 		1590 0420  HPE Ethernet 25/50Gb 2-port 6310C Adapter
 	1752  BCM57502 NetXtreme-E 10Gb/25Gb/40Gb/50Gb Ethernet
-	1760  BCM57608 10Gb/25Gb/50Gb/100Gb/200Gb/400Gb Ethernet
+	1760  BCM57608 25Gb/50Gb/100Gb/200Gb/400Gb Ethernet
+		14e4 9110  BCM57608 1x400G PCIe Ethernet NIC
+		14e4 9120  BCM57608 2x200G PCIe Ethernet NIC
+		14e4 9121  BCM57608 2x100G PCIe Ethernet NIC
+		14e4 9125  BCM57608 2x200G PCIe Ethernet NIC
+		14e4 9126  BCM57608 2x100G PCIe Ethernet NIC
+		14e4 9140  BCM57608 1x400G QSFP-DD PCIe Ethernet NIC
+		14e4 9310  BCM57608 1x400G QSFP-DD OCP Ethernet NIC
+		14e4 9311  BCM57608 1x400G OCP Ethernet NIC
+		14e4 9312  BCM57608 1x200G OCP Ethernet NIC
+		14e4 9320  BCM57608 2x200G OCP Ethernet NIC
+		14e4 9325  BCM57608 2x200G OCP Ethernet NIC
+		14e4 9326  BCM57608 2x100G OCP Ethernet NIC
+		14e4 9340  BCM57608 4x100G OCP Ethernet NIC
 		14e4 d125  BCM57608 2x200G PCIe Ethernet NIC
 	1800  BCM57502 NetXtreme-E Ethernet Partition
 	1801  BCM57504 NetXtreme-E Ethernet Partition
+		1590 0420  Ethernet NPAR 6310C Adapter
 	1802  BCM57508 NetXtreme-E Ethernet Partition
 		14e4 df24  BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet Partition
 	1803  BCM57502 NetXtreme-E RDMA Partition
 	1804  BCM57504 NetXtreme-E RDMA Partition
+		1590 0420  Ethernet NPAR RoCE 6310C Adapter
 	1805  BCM57508 NetXtreme-E RDMA Partition
 		14e4 df24  NetXtreme-E NGM2100D BCM57508 2x100G KR Mezz RDMA Partition
 	1806  BCM5750X NetXtreme-E Ethernet Virtual Function
 		14e4 df24  BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet Virtual Function
+		1590 0420  Ethernet SRIOV 6310C Adapter
 	1807  BCM5750X NetXtreme-E RDMA Virtual Function
 		14e4 df24  BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz RDMA Virtual Function
+		1590 0420  Ethernet SRIOV RoCE 6310C Adapter
 	1808  BCM5750X NetXtreme-E Ethernet Virtual Function
 		14e4 df24  BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet Virtual Function
 	1809  BCM5750X NetXtreme-E RDMA Virtual Function
 		14e4 df24  BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz RDMA Virtual Function
+	1819  BCM5760X Ethernet Virtual Function
 	2711  BCM2711 PCIe Bridge
 	2712  BCM2712 PCIe Bridge
 	3352  BCM3352
@@ -21144,9 +21574,11 @@
 	4717  BCM47xx Sentry5 USB Device Controller
 	4718  Sentry5 Crypto Accelerator
 	4719  BCM47xx/53xx RoboSwitch Core
+	471a  BCM47xx EHCI Host Controller
 	4720  BCM4712 MIPS CPU
 	4727  BCM4313 802.11bgn Wireless Network Adapter
 		1028 0010  Inspiron M5010 / XPS 8300
+	472a  BCM47xx xHCI Host Controller
 	5365  BCM5365P Sentry5 Host Bridge
 	5600  BCM5600 StrataSwitch 24+2 Ethernet Switch Controller
 	5605  BCM5605 StrataSwitch 24+2 Ethernet Switch Controller
@@ -21176,6 +21608,7 @@
 	5f71  BRCM4387 Bluetooth Controller
 # Bluetooth PCI function of the BRCM4377 Wireless Network Adapter
 	5fa0  BRCM4377 Bluetooth Controller
+	8411  BCM47xx PCIe Bridge
 	8602  BCM7400/BCM7405 Serial ATA Controller
 	9026  CN99xx [ThunderX2] Integrated USB 3.0 xHCI Host Controller
 	9027  CN99xx [ThunderX2] Integrated AHCI/SATA 3 Host Controller
@@ -21880,6 +22313,7 @@
 	6893  3U OpenVPX Multi-function I/O Board [Model 68C3]
 15ad  VMware
 	0405  SVGA II Adapter
+	0406  SVGA II Adapter (Fusion)
 	0710  SVGA Adapter
 	0720  VMXNET Ethernet Controller
 	0740  Virtual Machine Communication Interface
@@ -21933,6 +22367,10 @@
 	0223  CX8 PCIe Switch Family [ConnectX-8 PCIe Switch Secure Flash Recovery-RMA]
 	0224  CX9 Family [ConnectX-9 Flash Recovery]
 	0225  CX9 Family [ConnectX-9 Secure Flash Recovery-RMA]
+	0226  CX10 Family [ConnectX-10 Flash Recovery]
+	0227  CX10 Family [ConnectX-10 Secure Flash Recovery-RMA]
+	0228  CX9 PCIe Switch Family [ConnectX-9 PCIe Switch Flash Recovery]
+	0229  CX9 PCIe Switch Family [ConnectX-9 PCIe Switch Secure Flash Recovery-RMA]
 	024e  MT53100 [Spectrum-2, Flash recovery mode]
 	024f  MT53100 [Spectrum-2, Secure Flash recovery mode]
 	0250  Spectrum-3, Flash recovery mode
@@ -21953,12 +22391,15 @@
 	0263  MT27710 [ConnectX-4 Lx Programmable Virtual Function] EN
 	0264  Innova-2 Flex Burn image
 	0270  Spectrum-5 in Flash Recovery Mode
-	0271  Spectrum-4L, RMA
+	0271  Spectrum-5 RMA
 	0274  Spectrum-6 in Flash Recovery Mode
-	0275  Spectrum-4C RMA
-	0277  Spectrum-4TOR RMA
+	0275  Spectrum-6 RMA
+	0277  Spectrum-6 Tile
 	0278  Quantum-4 in Flash Recovery Mode
 	0279  Quantum-4 RMA
+	027a  Eros Chiplet
+	027c  Quantum-5 in Flash Recovery Mode
+	027d  Quantum-5 RMA
 	0281  NPS-600 Flash Recovery
 	0282  ArcusE Flash recovery
 	0283  ArcusE RMA
@@ -21969,6 +22410,11 @@
 # Flash recovery
 	0288  Arcus2
 	0289  Arcus2 RMA
+	0290  SagittaZ
+	02a0  Quantum-6 in Flash Recovery Mode
+	02a1  Quantum-6 RMA
+	02a2  Spectrum-7 in Flash Recovery Mode
+	02a3  Spectrum-7 RMA
 	1002  MT25400 Family [ConnectX-2 Virtual Function]
 	1003  MT27500 Family [ConnectX-3]
 		1014 04b5  PCIe3 40GbE RoCE Converged Host Bus Adapter for Power
@@ -22020,6 +22466,8 @@
 	1012  MT27600 Family [Connect-IB Virtual Function]
 	1013  MT27700 Family [ConnectX-4]
 		1014 04f7  PCIe3 2-port 100 GbE (NIC and RoCE) QSFP28 Adapter for Power
+		117c 00af  FastFrame N351 Single-port 50Gb Ethernet Adapter
+		117c 00b0  FastFrame N352 Dual-port 50Gb Ethernet Adapter
 		15b3 0003  Mellanox Technologies ConnectX-4 Stand-up single-port 40GbE MCX413A-BCAT
 		15b3 0005  Mellanox Technologies ConnectX-4 Stand-up single-port 40GbE MCX415A-BCAT
 		15b3 0006  MCX416A-BCAT, ConnectX-4 EN, 40/56GbE 2P, PCIe3.0 x16
@@ -22030,6 +22478,9 @@
 		15b3 0050  ConnectX-4 100 GbE Dual Port QSFP28 Adapter
 	1014  MT27700 Family [ConnectX-4 Virtual Function]
 	1015  MT27710 Family [ConnectX-4 Lx]
+		117c 00b4  FastFrame N322 Dual-port 25Gb Ethernet Adapter
+		117c 40b7  ThunderLink TLN3-3252 Dual-port 25Gb Ethernet Adapter
+		117c 40b8  ThunderLink TLN3-3102 Dual-port 10Gb Ethernet Adapter
 		15b3 0001  ConnectX-4 Lx EN network interface card, 25GbE single-port SFP28, PCIe3.0 x8, tall bracket, ROHS R6
 		15b3 0003  Stand-up ConnectX-4 Lx EN, 25GbE dual-port SFP28, PCIe3.0 x8, MCX4121A-ACAT
 		15b3 0004  ConnectX-4 Lx Stand-up dual-port 10GbE MCX4121A-XCAT
@@ -22045,8 +22496,11 @@
 		193d 1083  NIC-ETH640F-3S-2P
 # NIC-ETH540F-3S-2P OCP3.0 2x10G Card
 		193d 1084  NIC-ETH540F-3S-2P
+		1e81 0c10  25GbE dual-port SFP28, PCIe3.0 x8 [3SC10]
 	1016  MT27710 Family [ConnectX-4 Lx Virtual Function]
 	1017  MT27800 Family [ConnectX-5]
+		117c 00b1  FastFrame N311 Single-port 10Gb Ethernet Adapter
+		117c 00b2  FastFrame N312 Dual-port 10Gb Ethernet Adapter
 		15b3 0006  ConnectX-5 EN network interface card, 100GbE single-port QSFP28, PCIe3.0 x16, tall bracket; MCX515A-CCAT
 		15b3 0007  Mellanox ConnectX-5 MCX516A-CCAT
 		15b3 0020  ConnectX-5 EN network interface card, 10/25GbE dual-port SFP28, PCIe3.0 x8, tall bracket ; MCX512A-ACAT
@@ -22063,14 +22517,20 @@
 	101b  MT28908 Family [ConnectX-6]
 	101c  MT28908 Family [ConnectX-6 Virtual Function]
 	101d  MT2892 Family [ConnectX-6 Dx]
+		193d 1055  NIC-ETH1040F-LP-2P QSFP56 2x100GbE PCIe Network Adapter
 	101e  ConnectX Family mlx5Gen Virtual Function
 	101f  MT2894 Family [ConnectX-6 Lx]
 		193d 1035  NIC-ETH641F-LP-2P SFP28 2x25GbE PCIe Network Adapter
+		1bd4 00ac  O252MCX6Lx
+		1bd4 00ae  S252MCX6Lx
+		1ff9 00ad  ENFM6251-SP2
+		1ff9 00af  ENPM6251-SP2
 	1020  MT28860
 	1021  MT2910 Family [ConnectX-7]
 	1023  CX8 Family [ConnectX-8]
 	1024  CX8 PCIe Switch Family [ConnectX-8 PCIe Switch]
 	1025  CX9 Family [ConnectX-9]
+	1027  CX10 Family [ConnectX-10]
 	1974  MT28800 Family [ConnectX-5 PCIe Bridge]
 	1975  MT416842 Family [BlueField SoC PCIe Bridge]
 	1976  MT28908 Family [ConnectX-6 PCIe Bridge]
@@ -22082,6 +22542,7 @@
 	197c  ConnectX/BlueField Family mlx5Gen PCIe Bridge [PCIe Bridge]
 	197d  CX8 Family [ConnectX-8 PCIe Bridge]
 	197e  CX9 Family [ConnectX-9 PCIe Bridge]
+	197f  CX10 Family [ConnectX-10 PCIe Bridge]
 	2020  MT2892 Family [ConnectX-6 Dx Emulated PCIe Bridge]
 	2021  MT42822 Family [BlueField-2 SoC Emulated PCIe Bridge]
 	2023  MT2910 Family [ConnectX-7 Emulated PCIe Bridge]
@@ -22172,13 +22633,16 @@
 	cf6c  MT53100 [Spectrum-2]
 	cf70  Spectrum-3
 	cf80  Spectrum-4
-	cf82  Spectrum-4L
-	cf84  Spectrum-4C
+	cf82  Spectrum-5
+	cf84  Spectrum-6
+	cf86  Spectrum-7
 	d2f0  Quantum HDR (200Gbps) switch
 	d2f2  Quantum-2 NDR (400Gbps) switch
 	d2f4  Quantum-3
 	d2f6  Quantum-3CPO
 	d2f8  Quantum-4
+	d2fa  Quantum-5
+	d2fc  Quantum-6
 15b4  CCI/TRIAD
 15b5  Cimetrics Inc
 15b6  Texas Memory Systems Inc
@@ -22208,7 +22672,7 @@
 	5006  SanDisk Extreme Pro / WD Black SN750 / PC SN730 / Red SN700 NVMe SSD
 	5007  IX SN530 NVMe SSD (DRAM-less)
 	5008  PC SN530 NVMe SSD (DRAM-less)
-	5009  SanDisk Ultra 3D / WD Blue SN550 NVMe SSD
+	5009  SanDisk Ultra 3D / WD PC SN530, IX SN530, Blue SN550 NVMe SSD (DRAM-less)
 		15b7 5009  WD Blue SN550 NVMe SSD
 	500b  PC SN530 NVMe SSD
 		1414 500b  Xbox Series X
@@ -22231,6 +22695,9 @@
 	5036  WD PC SN5000S M.2 2280 NVMe SSD (DRAM-less)
 	5041  WD Blue SN580 NVMe SSD (DRAM-less)
 	5042  WD Black SN770M NVMe SSD (DRAM-less)
+	5045  WD_BLACK SN7100 NVMe SSD (DRAM-less)
+	5046  SanDisk Extreme NVMe SSD (DRAM-less)
+	5049  SN8000S NVMe SSD
 15b8  ADDI-DATA GmbH
 	1001  APCI1516 SP controller (16 digi outputs)
 	1003  APCI1032 SP controller (32 digi inputs w/ opto coupler)
@@ -23328,6 +23795,7 @@
 	8084  GL880 USB 2.0 EHCI controller
 	9750  GL9750 SD Host Controller
 	9755  GL9755 SD Host Controller
+	9767  GL9767 SD Host Controller
 	e763  GL9763E eMMC Controller
 17aa  Lenovo
 	0003  LENSE20256GMSP34MEAT2TA
@@ -23335,7 +23803,6 @@
 # 250GB nvme ssd from lenovo, can be found in Thinkpad x380 yoga
 	0005  LENSE30256GMSP34MEAT3TA
 	0006  LENSE30512GMSP34MEAT3TA
-	3181  ThinkCentre M75n IoT
 	402b  Intel 82599ES 10Gb 2-port Server Adapter X520-2
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 17ab  Phillips Components
@@ -23616,6 +24083,7 @@
 	0404  DOMINO Melody
 	0407  DOMINO Symphony
 	0408  DOMINO Symphony PCIe
+	0814  Coaxlink Quad CXP-12
 1809  Lumanate, Inc.
 180c  IEI Integration Corp
 1813  Ambient Technologies Inc
@@ -23821,6 +24289,8 @@
 # Sitecom HFC-S based ISDN controller card DC-105v2
 	3069  DC-105v2 ISDN controller
 18d4  Celestica
+# OCP-TAP
+	1007  Time Card
 18d8  Dialogue Technology Corp.
 18dd  Artimi Inc
 	4c6f  Artimi RTMI-100 UWB adapter
@@ -23913,6 +24383,7 @@
 	01e5  NT100A01 Network Adapter
 	0215  NT400D11 Network Adapter
 	0225  NT40A11 Network Adapter
+	0295  NT400D13 Network Adapter
 18f6  NextIO
 	1000  [Nexsis] Switch Virtual P2P PCIe Bridge
 	1001  [Texsis] Switch Virtual P2P PCIe Bridge
@@ -23966,7 +24437,8 @@
 	2031  SC92031 PCI Fast Ethernet Adapter
 	8139  RTL8139D [Realtek] PCI 10/100BaseTX ethernet adaptor
 1905  Micronas USA, Inc.
-1912  Renesas Technology Corp.
+# since the merger with NEC Electronics in 2010
+1912  Renesas Electronics Corp.
 	0002  SH7780 PCI Controller (PCIC)
 	0011  SH7757 PCIe End-Point [PBI]
 	0012  SH7757 PCIe-PCI Bridge [PPB]
@@ -24092,12 +24564,20 @@
 		1924 802b  XtremeScale X2552 OCP 2.0 Dual Port SFP28
 		1924 802c  XtremeScale X2522-25G PCIe Dual Port SFP28
 		1924 802d  XtremeScale X2562 OCP 3.0 Dual Port SFP28
+	0c03  NS9480 1/10/25/40/50/100Gb Ethernet Controller PLUS
+		1924 8031  X4522 Express and Enterprise Ethernet Adapter
+		1924 8032  X4542 Express and Enterprise Ethernet Adapter
 	1803  SFC9020 10G Ethernet Controller (Virtual Function)
 	1813  SFL9021 10GBASE-T Ethernet Controller (Virtual Function)
 	1903  SFC9120 10G Ethernet Controller (Virtual Function)
 	1923  SFC9140 10/40G Ethernet Controller (Virtual Function)
 	1a03  SFC9220 10/40G Ethernet Controller (Virtual Function)
 	1b03  XtremeScale SFC9250 10/25/40/50/100G Ethernet Controller (Virtual Function)
+	1c03  NS9480 1/10/25/40/50/100Gb Ethernet Controller PLUS (Virtual Function)
+	2c03  NS9480 1/10/25/40/50/100Gb Ethernet Controller
+		1924 8031  X4522 Enterprise Ethernet Adapter
+		1924 8032  X4542 Enterprise Ethernet Adapter
+	3c03  NS9480 1/10/25/40/50/100Gb Ethernet Controller (Virtual Function)
 	6703  SFC4000 rev A iSCSI/Onload [Solarstorm]
 		10b8 0102  SMC10GPCIe-10BT (A2) [TigerCard]
 		10b8 0103  SMC10GPCIe-10BT (A3) [TigerCard]
@@ -24367,6 +24847,7 @@
 	5021  PS5021-E21 PCIe4 NVMe Controller (DRAM-less)
 	5026  PS5026-E26 PCIe5 NVMe Controller
 	5027  PS5027-E27T PCIe4 NVMe Controller (DRAM-less)
+	5031  PS5031-E31T PCIe5 NVMe Controller
 1989  Montilio Inc.
 	0001  RapidFile Bridge
 	8001  RapidFile
@@ -24460,12 +24941,17 @@
 		19e5 d148  Hi1822 SP527 (2*16G FC)
 		19e5 d301  Hi1822 SP520 (2*16G FC)
 		19e5 d305  Hi1822 SP525 (2*16G FC)
+	0204  Hi1822 Family (4*10GE)
 	0205  Hi1822 Family (2*100GE)
 		19e5 df27  Hi1822 MZ731 MEZZ (2*100GE)
 	0206  Hi1822 Family (2*25GE)
 		19e5 d138  Hi1822 SP582 (2*25GE)
 		19e5 d13a  Hi1822 SC381 (2*25GE)
 		19e5 d145  Hi1822 SP586 (2*25GE)
+	0208  Hi1822 Family (2*100GE)
+	020b  Hi1822 Family (4*25GE)
+	020c  Hi1822 Family (4*32G FC)
+	020d  Hi1822 Family (2*40GE)
 	0210  Hi1822 Family (4*25GE)
 		19e5 df2e  Hi1822 MZ532 MEZZ (4*25GE)
 	0211  Hi1822 Family (4*25GE)
@@ -24499,10 +24985,21 @@
 		19e5 6213  NVMe SSD ES3500P V6 3840GB 2.5" U.2
 		19e5 6214  NVMe SSD ES3500P V6 7680GB 2.5" U.2
 		19e5 6215  NVMe SSD ES3500P V6 15360GB 2.5" U.2
+	3758  SP686C RAID Controller Card
+		19e5 0185  RAID SP686C-M-16i 2G
+		19e5 01a1  RAID SP686C-M-40i 2G
+		19e5 01a4  RAID SP686C-M-16i 4G
+		19e5 01a8  RAID SP686C-MH-32i 4G
+		19e5 01ad  RAID SP686C-M-40i 4G
 	375e  Hi1822 Family Virtual Function
 	375f  Hi1822 Family Virtual Function
 	379e  Hi1822 Family Virtual Function
 	379f  Hi1822 Family Virtual Function
+	3858  SP186 HBA Controller Card
+		19e5 0120  HBA SP186-M-32i
+		19e5 0125  HBA SP186-M-40i
+		19e5 0180  HBA SP186-M-16i
+		19e5 0188  HBA SP186-M-8i
 	a120  HiSilicon PCIe Root Port with Gen4
 	a121  HiSilicon PCI-PCI Bridge
 	a122  HiSilicon Embedded DMA Engine
@@ -24549,6 +25046,7 @@
 1a03  ASPEED Technology, Inc.
 	1150  AST1150 PCI-to-PCI Bridge
 	2000  ASPEED Graphics Family
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 		15d9 1b95  H12SSL-i
 1a05  deltaww
@@ -24596,6 +25094,7 @@
 1a32  Quanta Microsystems, Inc
 1a3b  AzureWave
 	1112  AR9285 Wireless Network Adapter (PCI-Express)
+1a3e  Micro-Research Finland Oy
 1a41  Tilera Corp.
 	0001  TILE64 processor
 	0002  TILEPro processor
@@ -24698,6 +25197,7 @@
 1ad7  Spectracom Corporation
 	8000  TSync-PCIe Time Code Processor
 	9100  TPRO-PCI-66U Timecode Reader/Generator
+	a000  OCP-TAP [ARTCard]
 1ade  Spin Master Ltd.
 	1501  Swipetech barcode scanner
 	3038  PCIe Video Bridge
@@ -24879,6 +25379,10 @@
 	1824  ASM1824 12-Port PCIe x8 Gen2 Packet Switch
 	2142  ASM2142/ASM3142 USB 3.1 Host Controller
 		1462 7a72  H270 PC MATE
+	2421  ASM4242 PCIe Switch Upstream Port
+	2423  ASM4242 PCIe Switch Downstream Port
+	2425  ASM4242 USB 4 / Thunderbolt 3 Host Router
+	2426  ASM4242 USB 3.2 xHCI Controller
 	2806  ASM2806 4-Port PCIe x2 Gen3 Packet Switch
 	2812  ASM2812 6-Port PCIe x4 Gen3 Packet Switch
 	2824  ASM2824 PCIe Gen3 Packet Switch
@@ -24963,7 +25467,7 @@
 		1028 2151  BOSS-N1 Modular ET
 		1028 2196  ROR-N1
 		1028 2286  BOSS-N1 DC-MHS
-		1028 2287  BOSS-N1 Modular
+		1028 2287  BOSS-N1 Modular DC-MHS
 		1b4b 2241  Santa Cruz NVMe Host Adapter
 		1b96 4000  WD_BLACK AN1500 NVMe SSD
 		1d49 0306  ThinkSystem M.2 NVMe 2-Bay RAID Enablement Kit
@@ -25081,6 +25585,7 @@
 	2720  Ultrastar DC SN650 NVMe SSD
 	2721  Ultrastar DC SN650 NVMe SSD
 	2722  Ultrastar DC SN655 NVMe SSD
+	2751  Ultrastar DC SN861 NVMe SSD
 	3001  RapidFlex C2000 NVMe Initiator
 	3714  PC SN730 NVMe SSD
 	3734  PC SN730 NVMe SSD
@@ -25199,10 +25704,11 @@
 # Nytro 5060H (Rocinante High Performance) non-SED
 		1bb1 0181  Nytro 5060H
 		1bb1 01a1  Nytro XP7102
+	0155  Nytro 5x50 NVMe SSD
 	5012  FireCuda/IronWolf 510 SSD
 	5013  BarraCuda Q5 NVMe SSD (DRAM-less)
 	5016  FireCuda 520/IronWolf 525 SSD
-	5018  FireCuda 530 SSD
+	5018  E18 PCIe SSD
 	5019  BarraCuda PCIe SSD (DRAM-less)
 # 2TB
 	5021  FireCuda 520 SSD
@@ -25234,6 +25740,8 @@
 	5236  PCIe 4TG2-P Controller
 1bcd  Apacer Technology
 	0120  NVMe SSD Drive 960GB
+	0180  PB4480 NVMe PCIe SSD (DRAM-less)
+	0310  NVMe SSD Drive 480GB
 1bcf  NEC Corporation
 	001c  Vector Engine 1.0
 1bd0  Astronics Corporation
@@ -25254,7 +25762,7 @@
 	1201  NG3 Series ARINC 429 Interface
 	1202  NG3 Series Avionics Discrete & Serial Interface
 	1203  NG3 Series Avionics Discrete Interface
-1bd4  Inspur Electronic Information Industry Co., Ltd.
+1bd4  IEIT SYSTEMS Co., Ltd
 	0911  Arria10_PCIe_F10A1150
 	1000  NS8600G1U160 NVME SSD
 	1001  NS8600G1U320 NVME SSD
@@ -25328,6 +25836,8 @@
 	0021  FD722
 	0022  FD788
 	0023  FD722-M2
+	0024  FD722 with bypass
+	0025  FD922
 1c28  Lite-On IT Corp. / Plextor
 	0122  M6e PCI Express SSD [Marvell 88SS9183]
 # previously Fiberblaze
@@ -25407,7 +25917,9 @@
 	1739  BC701 NVMe Solid State Drive
 	174a  Gold P31/BC711/PC711 NVMe Solid State Drive
 	1959  Platinum P41/PC801 NVMe Solid State Drive
+	1969  PC811 NVMe Solid State Drive
 	1d59  BC901 NVMe Solid State Drive (DRAM-less)
+	1f69  PVC10 NVMe Solid State Drive (DRAM-less)
 	2204  960GB TLC PCIe Gen3 x4 NVMe M.2 22110
 	2427  PE6010 NVMe Solid State Drive
 	2429  PE6011 NVMe Solid State Drive
@@ -25437,7 +25949,39 @@
 	284a  PE8110 Series NVMe Solid State Drive
 	2a49  PE9110 Series NVMe Solid State Drive
 	2a59  PE9010 Series NVMe Solid State Drives
-	2b59  PS10x0 Series NVMe Solid State Drives
+	2b59  Px10x0 Series NVMe Solid State Drives
+		1028 2295  NVMe ISE PS1010 RI U.2 1.92TB
+		1028 2296  NVMe ISE PS1010 RI U.2 3.84TB
+		1028 2297  NVMe ISE PS1010 RI U.2 7.68TB
+		1028 2298  NVMe ISE PS1010 RI U.2 15.36TB
+		1028 2299  NVMe ISE PS1030 MU U.2 1.6TB
+		1028 229a  NVMe ISE PS1030 MU U.2 3.2TB
+		1028 229b  NVMe ISE PS1030 MU U.2 6.4TB
+		1028 229c  NVMe ISE PS1030 MU U.2 12.8TB
+		1028 22a7  NVMe ISE PS1010 RI E3.S 1.92TB
+		1028 22a8  NVMe ISE PS1010 RI E3.S 3.84TB
+		1028 22a9  NVMe ISE PS1010 RI E3.S 7.68TB
+		1028 22aa  NVMe ISE PS1010 RI E3.S 15.36TB
+		1028 22ab  NVMe ISE PS1030 MU E3.S 1.6TB
+		1028 22ac  NVMe ISE PS1030 MU E3.S 3.2TB
+		1028 22ad  NVMe ISE PS1030 MU E3.S 6.4TB
+		1028 22ae  NVMe ISE PS1030 MU E3.S 12.8TB
+		1028 22dc  NVMe FIPS PS1010 RI E3.S 1.92TB
+		1028 22dd  NVMe FIPS PS1010 RI E3.S 3.84TB
+		1028 22de  NVMe FIPS PS1010 RI E3.S 7.68TB
+		1028 22df  NVMe FIPS PS1010 RI E3.S 15.36TB
+		1028 22e0  NVMe FIPS PS1030 MU E3.S 1.6TB
+		1028 22e1  NVMe FIPS PS1030 MU E3.S 3.2TB
+		1028 22e2  NVMe FIPS PS1030 MU E3.S 6.4TB
+		1028 22e3  NVMe FIPS PS1030 MU E3.S 12.8TB
+		1028 22f8  NVMe ISE PE1010 RI E3.S 1.92TB
+		1028 22f9  NVMe ISE PE1010 RI E3.S 3.84TB
+		1028 22fa  NVMe ISE PE1010 RI E3.S 7.68TB
+		1028 22fb  NVMe ISE PE1010 RI E3.S 15.36TB
+		1028 22fc  NVMe ISE PE1030 MU E3.S 1.6TB
+		1028 22fd  NVMe ISE PE1030 MU E3.S 3.2TB
+		1028 22fe  NVMe ISE PE1030 MU E3.S 6.4TB
+		1028 22ff  NVMe ISE PE1030 MU E3.S 12.8TB
 1c5f  Beijing Memblaze Technology Co. Ltd.
 	000d  PBlaze5 520/526
 		1c5f 0220  NVMe SSD PBlaze5 520 1920G AIC
@@ -25495,6 +26039,12 @@
 		1c5f 5437  NVMe SSD PBlaze6 6647 3200G 2.5" U.2(dual port)
 		1c5f 5441  NVMe SSD PBlaze6 6547 6400G 2.5" U.2
 		1c5f 5447  NVMe SSD PBlaze6 6647 6400G 2.5" U.2(dual port)
+	0027  PBlaze7 7A40/7A46 NVMe SSD
+		1c5f 1421  NVMe SSD PBlaze7 7A40 1920G 2.5" U.2
+		1c5f 1431  NVMe SSD PBlaze7 7A40 3840G 2.5" U.2
+		1c5f 1441  NVMe SSD PBlaze7 7A40 7680G 2.5" U.2
+		1c5f 5431  NVMe SSD PBlaze7 7A46 3200G 2.5" U.2
+		1c5f 5441  NVMe SSD PBlaze7 7A46 6400G 2.5" U.2
 	003d  PBlaze5 920/926
 		1c5f 0a30  NVMe SSD PBlaze5 920 3840G AIC
 		1c5f 0a31  NVMe SSD PBlaze5 920 3840G 2.5" U.2
@@ -25518,9 +26068,12 @@
 		1c5f 4b61  NVMe SSD PBlaze6 6936 25600GB 2.5" U.3
 	003f  PBlaze7 7940/7946 NVMe SSD
 		1c5f 0431  NVMe SSD PBlaze7 7940 3840G 2.5" U.2
+		1c5f 0441  NVMe SSD PBlaze7 7940 7680G 2.5" U.2
+		1c5f 0451  NVMe SSD PBlaze7 7940 15360G 2.5" U.2
 		1c5f 0c31  NVMe SSD PBlaze7 7940 3840G 2.5" U.2
 		1c5f 0c41  NVMe SSD PBlaze7 7940 7680G 2.5" U.2
 		1c5f 0c51  NVMe SSD PBlaze7 7940 15360G 2.5" U.2
+		1c5f 0c61  NVMe SSD PBlaze7 7940 30720G 2.5" U.2
 		1c5f 1430  NVMe SSD PBlaze7 7940 3840G AIC
 		1c5f 1431  NVMe SSD PBlaze7 7940 3840G 2.5" U.2
 		1c5f 1435  NVMe SSD PBlaze7 7940 3840G E1.S
@@ -25529,6 +26082,9 @@
 		1c5f 1445  NVMe SSD PBlaze7 7940 7680G E1.S
 		1c5f 1450  NVMe SSD PBlaze7 7940 15360G AIC
 		1c5f 1451  NVMe SSD PBlaze7 7940 15360G 2.5" U.2
+		1c5f 4431  NVMe SSD PBlaze7 7946 3200G 2.5" U.2
+		1c5f 4441  NVMe SSD PBlaze7 7946 6400G 2.5" U.2
+		1c5f 4451  NVMe SSD PBlaze7 7946 12800G 2.5" U.2
 		1c5f 4c31  NVMe SSD PBlaze7 7946 3200G 2.5" U.2
 		1c5f 4c41  NVMe SSD PBlaze7 7946 6400G 2.5" U.2
 		1c5f 4c51  NVMe SSD PBlaze7 7946 12800G 2.5" U.2
@@ -25548,16 +26104,24 @@
 		1ea0 2201  TP2511 Series U.2 NVMe Datacenter SSD(7.68TB)
 		1ea0 2210  TP2510 Series E3.S NVMe Datacenter SSD(7.68TB)
 		1ea0 2211  TP2511 Series E3.S NVMe Datacenter SSD(7.68TB)
+		1ea0 2301  TP2511 Series U.2 NVMe Datacenter SSD (15.36TB)
 	0540  PBlaze4 NVMe SSD
 	0550  PBlaze5 700/900
 	0555  PBlaze5 510/516
 	0557  PBlaze5 910/916
 1c63  Science and Research Centre of Computer Technology (JSC "NICEVT")
 	0008  K1927BB1Ya [EC8430] Angara Interconnection Network Adapter
+# Other World Computing
+1c7a  OWC
 1c7e  TTTech Computertechnik AG
 	0200  zFAS Debug Port
 1c7f  Elektrobit Austria GmbH
+	0300  EBX3
 	5100  EB5100
+	7200  EB 7200 Automotive logging and replay card
+# This is a EB7200 card compatibly with a EB PCIe driver
+	7201  EB7200 with EB PCIe Driver Interface
+	7211  EB7210
 1c8a  TSF5 Corporation
 	0001  Hunter PCI Express
 1c8c  Mobiveil, Inc.
@@ -25589,6 +26153,7 @@
 1cb8  Dawning Information Industry Co., Ltd.
 1cc1  ADATA Technology Co., Ltd.
 	1202  IM2P32A8 NVMe SSD (DRAM-less)
+	1602  LEGEND 900 NVMe SSD (DRAM-less)
 # SX6000LNP
 	2263  XPG SX6000 Lite NVMe SSD (DRAM-less)
 	32a8  SM2P32A8 NVMe SSD (DRAM-less)
@@ -25610,10 +26175,13 @@
 	621a  LEGEND 850 NVMe SSD (DRAM-less)
 	622a  LEGEND 960 NVMe SSD
 	624a  LEGEND 700, XPG GAMMIX S20 NVMe SSD (DRAM-less)
+	625a  LEGEND 850 LITE NVMe SSD (DRAM-less)
 # 1TB
 	627a  LEGEND 800 NVMe SSD (DRAM-less)
 # 500GB
 	628a  LEGEND 800 NVMe SSD (DRAM-less)
+	633a  LEGEND 900 NVMe SSD (DRAM-less)
+	642a  XPG GAMMIX S50 CORE NVMe SSD (DRAM-less)
 	8201  XPG SX8200 Pro PCIe Gen3x4 M.2 2280 Solid State Drive
 1cc4  Shenzhen Unionmemory Information System Ltd.
 	1203  NVMe SSD Controller UHXXXa series
@@ -25634,7 +26202,7 @@
 	17ab  AH631 PCIe 3.0 NVMe SSD 256GB
 	2263  AM611 PCIe 3.0 x2 NVMe SSD 256GB
 	5008  AM610 PCIe 3.0 x2 NVMe SSD 128GB, 256GB
-	5012  RPITJ512PED2OWX NVMe SSD 512GB
+	5012  AH530 PCIe 3.0 NVMe SSD 512GB
 	5212  AM521 PCIe 3.0 NVMe SSD 256GB
 	6201  AM620 PCIe 3.0 NVMe SSD 128GB
 	6202  AM620 PCIe 3.0 NVMe SSD 256GB
@@ -25643,10 +26211,16 @@
 	6302  AM630 PCIe 4.0 NVMe SSD 256GB
 	6303  AM630 PCIe 4.0 x4 NVMe SSD Controller
 	6304  AM630 PCIe 4.0 NVMe SSD 1024GB
+	660c  RPETJ1T24MHP2QDQ PCIe 4.0 NVMe SSD 1024GB
+	6a01  AM620 PCIe 3.0 NVMe SSD 128GB
 	6a02  AM6A0 PCIe 4.0 NVMe SSD 256GB
 	6a03  RPETJ512MKP1QDQ PCIe 4.0 NVMe SSD 512GB (DRAM-less)
+	6a04  RPETJ1T24MKP2QDQ PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
 	6a13  RPJYJ512MKN1QWQ PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6a14  RPEYJ1T24MKN2QWY PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
+	6b04  AM6B0 PCIe 4.0 NVMe SSD
+	6b13  RPJYJ512MLR1QWY PCIe 4.0 NVMe SSD 512GB (DRAM-less)
+	6b14  RPJYJ1T24MLR1HWY PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
 	8030  NVMe SSD Controller UH8X2X/UH7X2X series
 		1cc4 1122  NVMe SSD UH812a U.2 1.92TB
 		1cc4 1123  NVMe SSD UH812a U.2 3.84TB
@@ -25668,6 +26242,10 @@
 		1cc4 3123  NVMe SSD UH712a U.2 3.84TB
 		1cc4 3124  NVMe SSD UH712a U.2 7.68TB
 		1cc4 3125  NVMe SSD UH712a U.2 15.36TB
+		1ea0 4124  NVMe SSD TP3511 U.2 7.68TB
+		1ea0 4125  NVMe SSD TP3511 U.2 15.36TB
+		1ea0 4224  NVMe SSD TP3511 E3.S 7.68TB
+		1ea0 4225  NVMe SSD TP3511 E3.S 15.36TB
 1cc5  Embedded Intelligence, Inc.
 	0100  PCIe-CAN-02 Dual CAN bus (9-pin male). PCI Express x1.
 	0101  PCIe-CAN-01 Single CAN bus (9-pin male). PCI Express x1.
@@ -25676,7 +26254,7 @@
 	0250  RMS-250 U.2 NVMe SSD
 1ccf  Zoom Corporation
 	0001  TAC-2 Thunderbolt Audio Converter
-1cd2  SesKion GmbH
+1cd2  Seskion GmbH
 	0301  Simulyzer-RT CompactPCI Serial DIO-1 card
 	0302  Simulyzer-RT CompactPCI Serial PSI5-ECU-1 card
 	0303  Simulyzer-RT CompactPCI Serial PSI5-SIM-1 card
@@ -25685,6 +26263,9 @@
 # supports 8x CAN (-FD) interfaces
 	0306  Simulyzer-RT CompactPCI Serial CAN-2 card (CAN-FD)
 	0307  Simulyzer-RT CompactPCI Serial DIO-2 card [Xilinx Zynq UltraScale+]
+	0308  Simulyzer-RT CompactPCI Serial SENT-DIO-2 card
+# 8-Channel ADC
+	0309  Simulyzer-RT CompactPCI Serial SN-ADC card
 1cd7  Nanjing Magewell Electronics Co., Ltd.
 	0002  Pro Capture AIO
 	0010  Pro Capture Endpoint
@@ -25715,7 +26296,9 @@
 1cfd  Mangstor
 	6300  MX6300 series PCIe x8 NVMe SSD
 1d00  Pure Storage
-1d05  Tongfang Hongkong Limited
+1d05  AIstone Global Limited
+	6027  B760-N2D5 motherboard
+	7001  H610-N2 motherboard
 1d0f  Amazon.com, Inc.
 	7064  NeuronDevice (Inferentia)
 	7164  NeuronDevice (Trainium)
@@ -25728,6 +26311,7 @@
 	efa0  Elastic Fabric Adapter (EFA)
 	efa1  Elastic Fabric Adapter (EFA)
 	efa2  Elastic Fabric Adapter (EFA)
+	efa3  Elastic Fabric Adapter (EFA)
 1d17  Zhaoxin
 	070f  ZX-100 PCI Express Root Port
 	0710  ZX-100/ZX-200 PCI Express Root Port
@@ -25843,6 +26427,8 @@
 	00c0  Turbocard3 Accelerator
 	0140  Open Network Interface Card 40G
 	e004  AB01/EMB01 Development Board
+1d2a  KAYA Instruments
+	1000  Frame grabber
 1d37  NovaSparks
 	0013  PM3
 	0014  PM4
@@ -25861,13 +26447,17 @@
 1d62  Nebbiolo Technologies
 1d65  Imagine Communications Corp.
 	04de  Taurus/McKinley
-1d69  Celeno Communications
+# nee Celeno Communications
+1d69  Renesas Electronics Corp.
 	2432  CL2432
 	2440  CL2440
+	8000  CL80x0 Wireless Network Adapter
+	8046  CL8046 Wireless Network Adapter
 1d6a  Aquantia Corp.
 	0001  AQC107 NBase-T/IEEE 802.3bz Ethernet Controller [AQtion]
 		4c52 6880  LREC6880BT Single-port 10Gb Ethernet Network Adapter
 	00b1  AQtion AQC100 NBase-T/IEEE 802.3an Ethernet Controller [Atlantic 10G]
+		1043 874a  XG-C100F 10GbE SFP+ Ethernet Adapter
 	00c0  Antigua NBase-T/IEEE 802.3an Ethernet Controller - Engineering Sample
 	04c0  AQtion AQC113 NBase-T/IEEE 802.3an Ethernet Controller [Antigua 10G]
 		4c52 1053  LRES1053PT Quad-port 10Gb Ethernet Network Adapter
@@ -25885,9 +26475,11 @@
 	14c0  AQC113C NBase-T/IEEE 802.3an Ethernet Controller [Marvell Scalable mGig]
 	80b1  AQtion AQC100S NBase-T/IEEE 802.3an Ethernet Controller [Atlantic 10G]
 	87b1  AQtion AQC107S NBase-T/IEEE 802.3an Ethernet Controller [Atlantic 10G]
+		1c7a de2b  Thunderbolt 10G Ethernet Adapter
 	93c0  AQtion AQC114CS NBase-T/IEEE 802.3bz Ethernet Controller [Antigua 5G]
 	94c0  AQtion AQC113CS NBase-T/IEEE 802.3an Ethernet Controller [Antigua 10G]
 		1043 87f5  ProArt X570-CREATOR WIFI
+		1043 8812  ASUS XG-C100C 10G PCI-E Network Adapter
 	d107  AQtion AQC107 NBase-T/IEEE 802.3an Ethernet Controller [Atlantic 10G]
 		1043 8741  XG-C100C
 	d108  AQC108 NBase-T/IEEE 802.3bz Ethernet Controller [AQtion]
@@ -25935,6 +26527,9 @@
 	1027  AR-P2P-DBG [P2P Debug Function]
 	1028  AR-P2P-ATR [P2P Actor Function]
 	1029  AR-P2P-UTL [P2P Utility Function]
+	102a  AR-TK242-FX2 [4x100GbE Gen5 Packet Capture-Replay Device]
+	102b  AR-ARKV-FX1 [Arkville 128B DPDK Data Mover for Versal/CPM5]
+	102c  AR-TK242-V80 [Gen5 PCAP Processor]
 	4200  A5PL-E1-10GETI [10 GbE Ethernet Traffic Instrument]
 1d72  Xiaomi
 1d78  DERA Storage
@@ -25996,6 +26591,14 @@
 		1d78 7108  D7436 U.2 15mm 7.68TB NVMe SSD
 		1d78 7109  D7456 U.2 15mm 12.8TB NVMe SSD
 		1d78 710a  D7436 U.2 15mm 15.36TB NVMe SSD
+		1d78 7143  D7556 U.2 15mm 1.6TB dual port NVMe SSD
+		1d78 7144  D7536 U.2 15mm 1.92TB dual port NVMe SSD
+		1d78 7145  D7556 U.2 15mm 3.2TB dual port NVMe SSD
+		1d78 7146  D7536 U.2 15mm 3.84TB dual port NVMe SSD
+		1d78 7147  D7556 U.2 15mm 6.4TB dual port NVMe SSD
+		1d78 7148  D7536 U.2 15mm 7.68TB dual port NVMe SSD
+		1d78 7149  D7556 U.2 15mm 12.8TB dual port NVMe SSD
+		1d78 714a  D7536 U.2 15mm 15.36TB dual port NVMe SSD
 		1d78 7202  Aliflash V2 U.2 15mm 1.92TB NVMe SSD
 		1d78 7204  Aliflash V2 U.2 15mm 3.84TB NVMe SSD
 		1d78 7208  Aliflash V2 U.2 15mm 7.68TB NVMe SSD
@@ -26013,6 +26616,7 @@
 	0102  Codensity D408 PCIe Gen4 NVMe SSD
 	0202  Codensity T408 Video Encoding-Decoding Accelerator
 	0401  Quadra Video Processing Unit (VPU)
+	0411  Quadra Video Processing Unit (VPU) Virtual Function
 # nee Fuzhou Rockchip Electronics Co., Ltd
 1d87  Rockchip Electronics Co., Ltd
 	0100  RK3399 PCI Express Root Port
@@ -26023,7 +26627,7 @@
 	3588  RK3588
 1d89  YEESTOR Microelectronics Co., Ltd
 	0280  PCIe NVMe SSD
-1d8f  Enyx
+1d8f  Exegy
 1d92  Abaco Systems Inc.
 1d93  YADRO
 1d94  Chengdu Haiguang IC Design Co., Ltd.
@@ -26075,8 +26679,11 @@
 1d9b  Meta Platforms, Inc.
 	0010  Networking DOM Engine
 	0011  IO Bridge
+	0013  Host Network Interface
+	0400  Time Card
 1da1  Teko Telecom S.r.l.
 1da2  Sapphire Technology Limited
+	475d  Radeon RX 7800 XT [PULSE]
 	e26a  Radeon R7 250
 	e445  Sapphire Radeon RX 6700
 1da3  Habana Labs Ltd.
@@ -26089,6 +26696,9 @@
 	1010  HL-2000 AI Training Accelerator [Gaudi secured]
 # PCIe accelerator card for Deep Learning training tasks
 	1020  Gaudi2 AI Training Accelerator
+	1060  Gaudi3 AI Training Accelerator
+	1063  Gaudi3 AI Training Accelerator Add-In Family
+		1da3 1063  HL-338 Gaudi3 AI Accelerator PCIe Add-In Card
 1da8  Corigine, Inc.
 	3800  Network Flow Processor 3800
 	3803  Network Flow Processor 3800 Virtual Function
@@ -26117,12 +26727,16 @@
 	dc36  LDMA Controller [X100 Series]
 	dc38  LSD_CFG Controller [X100 Series]
 	dc3a  SWITCH Controller [X100 Series]
+	dc3b  MAC Controller [D3000M Series]
 	dc3c  GPU_DMA Controller [X100 Series]
+	dc3e  DCController [E2000 Series]
+	dc3f  SATA Controller [D3000M Series]
 1dbb  NGD Systems, Inc.
 1dbe  INNOGRIT Corporation
-	5216  NVMe SSD Controller IG5216 (DRAM-less)
-	5220  NVMe SSD Controller IG5220 (DRAM-less)
-	5236  NVMe SSD Controller IG5236
+	5208  NVMe SSD Controller IG5208 [Shasta] (DRAM-less)
+	5216  NVMe SSD Controller IG5216 [Shasta+] (DRAM-less)
+	5220  NVMe SSD Controller IG5220 [RainierQX] (DRAM-less)
+	5236  NVMe SSD Controller IG5236 [RainierPC]
 		1dbe 4001  Dongting-B1 DC SSD M.2 480GB
 		1dbe 4002  Dongting-B1 DC SSD M.2 960GB
 	5636  NVMe DC SSD IG5636
@@ -26144,7 +26758,15 @@
 		1dbe 3001  Donghu-Z2 DC ZNS SSD U.2 4000GB
 		1dbe 3002  Donghu-Z2 DC ZNS SSD U.2 8000GB
 	5666  NVMe SSD Controller IG5666
-	5668  NVMe SSD Controller IG5668
+	5668  NVMe PCIe 5.0 DC SSD
+		1dbe 5003  Dongting-N3 DC SSD U.2 3200GB
+		1dbe 5004  Dongting-N3 DC SSD U.2 3840GB
+		1dbe 5005  Dongting-N3 DC SSD U.2 6400GB
+		1dbe 5006  Dongting-N3 DC SSD U.2 7680GB
+		1dbe 5007  Dongting-N3 DC SSD U.2 12800GB
+		1dbe 5008  Dongting-N3 DC SSD U.2 15360GB
+		1dbe 5009  Dongting-N3 DC SSD U.2 25600GB
+		1dbe 5010  Dongting-N3 DC SSD U.2 30720GB
 	5669  NVMe SSD Controller IG5669 [Tacoma]
 1dbf  Guizhou Huaxintong Semiconductor Technology Co., Ltd
 	0401  StarDragon4800 PCI Express Root Port
@@ -26159,6 +26781,15 @@
 	0010  N-10m2 NVMe SSD
 	0016  N-16
 	0020  EN-20 BGA NVMe SSD (DRAM-less)
+	0030  N-30m2 NVMe SSD
+	0036  N-36m2 NVMe SSD
+	1200  D1200 NVMe SSD
+	3000  N3000 NVMe SSD
+	3002  N3002 NVMe SSD
+	3602  N3602 NVMe SSD
+	4131  A1x NVMe SSD Series
+	4432  D2x NVMe SSD Series
+	5200  N5200 NVMe SSD
 1dd8  AMD Pensando Systems
 	0002  DSC2 Elba Upstream Port
 		1dd8 100e  Distributed Services Card
@@ -26172,6 +26803,10 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+	0008  DSC3 Salina Upstream Port
+		1dd8 100e  Distributed Services Card
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
+		1dd8 5201  POLLARA-1Q400 100/200/400G 1-port Card
 	1000  DSC Capri Upstream Port
 		1dd8 4000  Naples 100Gb 2-port QSFP28 x16 8GB
 		1dd8 4001  Naples 100Gb 2-port QSFP28 x16 4GB
@@ -26205,6 +26840,8 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
+		1dd8 5201  POLLARA-1Q400 100/200/400G 1-port Card
 	1002  DSC Ethernet Controller
 		1dd8 100e  Distributed Services Card
 		1dd8 4000  Naples 100Gb 2-port QSFP28 x16 8GB
@@ -26227,6 +26864,8 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
+		1dd8 5201  POLLARA-1Q400 100/200/400G 1-port Card
 	1003  DSC Ethernet Controller VF
 		1dd8 100e  Distributed Services Card
 		1dd8 4000  Naples 100Gb 2-port QSFP28 x16 8GB
@@ -26249,6 +26888,8 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
+		1dd8 5201  POLLARA-1Q400 100/200/400G 1-port Card
 	1004  DSC Management Controller
 		1dd8 100e  Distributed Services Card
 		1dd8 4000  Naples 100Gb 2-port QSFP28 x16 8GB
@@ -26271,6 +26912,8 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
+		1dd8 5201  POLLARA-1Q400 100/200/400G 1-port Card
 	1005  DSC NVMe Controller
 		1dd8 100e  Distributed Services Card
 		1dd8 5001  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 Services Card
@@ -26283,6 +26926,7 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
 	1006  DSC NVMe Controller VF
 		1dd8 100e  Distributed Services Card
 		1dd8 5001  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 Services Card
@@ -26295,6 +26939,7 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
 	1007  DSC Storage Accelerator
 		1dd8 100e  Distributed Services Card
 		1dd8 4000  Naples 100Gb 2-port QSFP28 x16 8GB
@@ -26365,6 +27010,8 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
+		1dd8 5201  POLLARA-1Q400 100/200/400G 1-port Card
 	100d  DSC Virtio Network Device VF
 		1dd8 100e  Distributed Services Card
 		1dd8 5001  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 Services Card
@@ -26377,6 +27024,7 @@
 		1dd8 500d  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4
 		1dd8 500e  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R5
 		1dd8 500f  DSC2-200 50/100/200G 2-port 32G RAM 64G eMMC G2 DPU R4-T
+		1dd8 5200  DSC3-2Q400 100/200/400G 2-port DDR5 128G eMMC G3 Services Card
 1ddd  Thorlabs
 1de0  Groq
 	0000  TSP [GroqChip]
@@ -26407,7 +27055,18 @@
 1dee  Biwin Storage Technology Co., Ltd.
 	2262  HP EX950 NVMe SSD
 	2263  HP EX900 NVMe SSD (DRAM-less)
+	4121  PCIe 4.0 SP406/416 NVMe SSD
+		1dee 0000  NVMe SSD SP416 800G 2.5" U.2
+		1dee 0001  NVMe SSD SP416 1.6T 2.5" U.2
+		1dee 0002  NVMe SSD SP416 3.2T 2.5" U.2
+		1dee 0003  NVMe SSD SP416 6.4T 2.5" U.2
+		1dee 0010  NVMe SSD SP406 960G 2.5" U.2
+		1dee 0011  NVMe SSD SP406 1.92T 2.5" U.2
+		1dee 0012  NVMe SSD SP406 3.84T 2.5" U.2
+		1dee 0013  NVMe SSD SP406 7.68T 2.5" U.2
+	5161  BIWIN NVMe SSD SP506/SP516
 	5216  KingSpec NX series NVMe SSD (DRAM-less)
+	7700  BIWIN NVMe SSD SP50Y/SP51Y
 1def  Ampere Computing, LLC
 	e005  eMAG PCI Express Root Port 0
 	e006  eMAG PCI Express Root Port 1
@@ -26595,6 +27254,7 @@
 		1028 223d  Ent NVMe CM7 U.2 MU 3.2TB
 		1028 223e  Ent NVMe CM7 U.2 MU 1.6TB
 	002a  Exceria Plus G3 NVMe SSD (DRAM-less)
+	002b  NVMe SSD Controller CD8P
 	002c  NVMe SSD Controller CD8P EDSFF
 		1028 22bf  DC NVMe CD8P E3.S 15.36TB
 		1028 22c0  DC NVMe CD8P E3.S 7.68TB
@@ -26618,6 +27278,10 @@
 # JungleCat VU35P Module
 	1635  JCM35
 1e26  Fujitsu Client Computing Limited
+# nee Bitmain Technologies Ltd.
+1e30  Sophgo
+	1684  BM1684 [Sophon Series Deep Learning Accelerator]
+	2042  SG2042 Root Complex
 1e36  Shanghai Enflame Technology Co. Ltd
 	0001  T10 [CloudBlazer]
 	0002  T11 [CloudBlazer]
@@ -26649,9 +27313,15 @@
 	2263  270PM6, 270PM7 series NVMe SSD
 1e3b  DapuStor Corporation
 	0600  NVMe SSD Controller DP600
-		1e3b 0006  Enterprise NVMe SSD U.2 ODP 7.68TB (J5001)
+		1e3b 0006  Enterprise NVMe SSD U.2 7.68TB (J5000)
+		1e3b 000c  Enterprise NVMe SSD U.2 30.72TB (J5060)
+		1e3b 000d  Enterprise NVMe SSD U.2 61.44TB (J5060)
+		1e3b 000e  Enterprise NVMe SSD U.2 30.72TB (J5060D)
+		1e3b 000f  Enterprise NVMe SSD U.2 61.44TB (J5060D)
 		1e3b 0010  Enterprise NVMe SSD U.2 3.84TB (R5102)
 		1e3b 0013  Enterprise NVMe SSD U.2 3.20TB (R5302)
+		1e3b 0027  Enterprise NVMe SSD U.2 61.44TB (J5060)
+		1e3b 0028  Enterprise NVMe SSD U.2 61.44TB (J5060D)
 		1e3b 0030  Enterprise NVMe SSD U.2 3.84TB (J5100)
 		1e3b 0031  Enterprise NVMe SSD U.2 7.68TB (J5100)
 		1e3b 0032  Enterprise NVMe SSD U.2 15.36TB (J5100)
@@ -26684,49 +27354,50 @@
 		1e3b 0069  Enterprise NVMe SSD U.2 3.20TB (R5301D)
 		1e3b 006c  Enterprise NVMe SSD U.2 1.92TB (R5101)
 		1e3b 006d  Enterprise NVMe SSD U.2 1.60TB (J5301)
-		1e3b 00b9  Enterprise NVMe SSD U.2 ODP 25.60TB (R5301)/(J5301)
-		1e3b 00be  Enterprise NVMe SSD U.2 ODP 30.72TB (R5101)/(J5101)
-		1e3b 00c1  Enterprise NVMe SSD U.2 ODP 25.60TB (R5301D)/(J5301D)
-		1e3b 00c4  Enterprise NVMe SSD U.2 ODP 30.72TB (R5101D)/(J5101D)
-		1e3b 00c7  Enterprise NVMe SSD U.2 ODP 25.60TB (J5300)
-		1e3b 00c8  Enterprise NVMe SSD U.2 ODP 30.72TB (J5100)
-		1e3b 00c9  Enterprise NVMe SSD U.2 ODP 15.36TB (J5001)
-		1e3b 00ca  Enterprise NVMe SSD U.2 ODP 3.84TB (J5102)
-		1e3b 00cb  Enterprise NVMe SSD U.2 ODP 7.68TB (J5102)
-		1e3b 00cc  Enterprise NVMe SSD U.2 QDP 3.84TB (J5101)
-		1e3b 00cd  Enterprise NVMe SSD U.2 ODP 7.68TB (J5101)
-		1e3b 00ce  Enterprise NVMe SSD U.2 QDP 3.84TB (J5101D)
-		1e3b 00cf  Enterprise NVMe SSD U.2 ODP 7.68TB (J5101D)
-		1e3b 00dc  Enterprise NVMe SSD U.2 ODP 30.72TB with SAMSUNG 32GB DRAM (J5001)
-		1e3b 00dd  Enterprise NVMe SSD U.2 ODP 30.72TB with MT 32GB DRAM(J5001)
-		1e3b 00de  Enterprise NVMe SSD U.2 ODP 15.36TB with SK 16GB DRAM(J5001D)
-		1e3b 00df  Enterprise NVMe SSD U.2 ODP 30.72TB with SAMSUNG 32GB DRAM(J5001)
-		1e3b 00e7  Enterprise NVMe SSD U.2 ODP 30.72TB with MT 32GB DRAM(J5001D)
-		1e3b 00e8  Enterprise NVMe SSD U.2 QDP 3.20TB (J5301)
-		1e3b 00e9  Enterprise NVMe SSD U.2 ODP 6.40TB (J5301)
-		1e3b 00ea  Enterprise NVMe SSD U.2 QDP 3.20TB (J5301D)
-		1e3b 00eb  Enterprise NVMe SSD U.2 ODP 6.40TB (J5301D)
-		1e3b 00ec  Enterprise NVMe SSD U.2 ODP 30.72TB with MT 32GB DRAM(J5101)
-		1e3b 00ed  Enterprise NVMe SSD U.2 ODP 30.72TB with MT 32GB DRAM(R5101)
-		1e3b 00ee  Enterprise NVMe SSD U.2 ODP 15.36B with SK 16GB DRAM(J5101)
-		1e3b 00ef  Enterprise NVMe SSD U.2 ODP 12.80TB with SK 16GB DRAM(J5301)
+		1e3b 00b9  Enterprise NVMe SSD U.2 25.60TB
+		1e3b 00be  Enterprise NVMe SSD U.2 30.72TB
+		1e3b 00c1  Enterprise NVMe SSD U.2 25.60TB
+		1e3b 00c4  Enterprise NVMe SSD U.2 30.72TB
+		1e3b 00c7  Enterprise NVMe SSD U.2 25.60TB (J5301)
+		1e3b 00c8  Enterprise NVMe SSD U.2 30.72TB (J5000)
+		1e3b 00c9  Enterprise NVMe SSD U.2 15.36TB (J5000)
+		1e3b 00ca  Enterprise NVMe SSD U.2 3.84TB (J5102)
+		1e3b 00cb  Enterprise NVMe SSD U.2 7.68TB (J5102)
+		1e3b 00cc  Enterprise NVMe SSD U.2 3.84TB (J5101)
+		1e3b 00cd  Enterprise NVMe SSD U.2 7.68TB (J5101)
+		1e3b 00ce  Enterprise NVMe SSD U.2 3.84TB (J5101D)
+		1e3b 00cf  Enterprise NVMe SSD U.2 7.68TB (J5101D)
+		1e3b 00dc  Enterprise NVMe SSD U.2 30.72TB (J5000)
+		1e3b 00dd  Enterprise NVMe SSD U.2 30.72TB(J5000)
+		1e3b 00de  Enterprise NVMe SSD U.2 15.36TB (J5000D)
+		1e3b 00df  Enterprise NVMe SSD U.2 30.72TB (J5000)
+		1e3b 00e7  Enterprise NVMe SSD U.2 30.72TB (J5000D)
+		1e3b 00e8  Enterprise NVMe SSD U.2 3.20TB (J5301)
+		1e3b 00e9  Enterprise NVMe SSD U.2 6.40TB (J5301)
+		1e3b 00ea  Enterprise NVMe SSD U.2 3.20TB (J5301D)
+		1e3b 00eb  Enterprise NVMe SSD U.2 6.40TB (J5301D)
+		1e3b 00ec  Enterprise NVMe SSD U.2 30.72TB (J5101)
+		1e3b 00ed  Enterprise NVMe SSD U.2 30.72TB (R5101)
+		1e3b 00ee  Enterprise NVMe SSD U.2 15.36B (J5101)
+		1e3b 00ef  Enterprise NVMe SSD U.2 12.80TB (J5301)
 		1e3b 00f0  Enterprise NVMe SSD U.2 0.40TB (X2900)
 		1e3b 00f1  Enterprise NVMe SSD U.2 0.80TB (X2900)
 		1e3b 00f2  Enterprise NVMe SSD U.2 1.60TB (X2900)
 		1e3b 00f3  Enterprise NVMe SSD U.2 3.20TB (X2900)
 		1e3b 00f5  Enterprise NVMe SSD U.2 0.40TB (X2900P)
 		1e3b 00f6  Enterprise NVMe SSD U.2 0.80TB (X2900P)
-	0800  DP800
-		1e3b 0001  Enterprise NVMe SSD U.2 QDP 3.84TB(R6100)
-		1e3b 0007  Enterprise NVMe SSD U.2 ODP 15.36TB (R6100)
+	0800  NVMe SSD Controller DP800
+		1e3b 0001  Enterprise NVMe SSD U.2 3.84TB(R6100)
+		1e3b 0007  Enterprise NVMe SSD U.2 15.36TB (R6100)
 		1e3b 000a  Enterprise NVMe SSD U.2 3.20TB (R6300)
 		1e3b 000d  Enterprise NVMe SSD U.2 6.40TB (R6300)
 		1e3b 0010  Enterprise NVMe SSD U.2 12.80TB (R6300)
-		1e3b 0018  Enterprise NVMe SSD U.2 QDP 3.84TB (R6100C)
-		1e3b 0019  Enterprise NVMe SSD U.2 ODP 7.68TB (R6100C)
+		1e3b 0018  Enterprise NVMe SSD U.2 3.84TB (R6100C)
+		1e3b 0019  Enterprise NVMe SSD U.2 7.68TB (R6100C)
 		1e3b 001a  Enterprise NVMe SSD U.2 3.20TB (R6300C)
 		1e3b 001b  Enterprise NVMe SSD U.2 6.40TB (R6300C)
-		1e3b 001c  Enterprise NVMe SSD U.2 ODP 7.68TB (R6100)
+		1e3b 001c  Enterprise NVMe SSD U.2 7.68TB (R6100)
+		1e3b 001d  Enterprise NVMe SSD U.2 3.84TB (R6101)
 	1098  Haishen3 NVMe SSD
 		1e3b 0001  Enterprise NVMe SSD U.2 0.8TB (H2100)
 		1e3b 0002  Enterprise NVMe SSD U.2 0.96TB (H2200)
@@ -26759,16 +27430,62 @@
 		1e3b 008b  Enterprise NVMe SSD HHHL 1.6TB (H3900)
 		1e3b 0091  Enterprise NVMe SSD HHHL 0.75TB (H3900)
 	1333  Haishen5 NVMe SSD
+		1e3b 001a  Enterprise NVMe SSD E3.S 1T 3.84TB (H5100)
+		1e3b 001b  Enterprise NVMe SSD E3.S 1T 7.68TB (H5100)
+		1e3b 001d  Enterprise NVMe SSD E3.S 1T 3.2TB (H5300)
+		1e3b 001e  Enterprise NVMe SSD E3.S 1T 6.4TB (H5300)
+		1e3b 0031  Enterprise NVMe SSD U2 3.84TB (H5100)
+		1e3b 0032  Enterprise NVMe SSD U2 7.68TB (H5100)
+		1e3b 0033  Enterprise NVMe SSD U2 15.36TB (H5100)
+		1e3b 0034  Enterprise NVMe SSD U2 3.2TB (H5300)
+		1e3b 0035  Enterprise NVMe SSD U2 6.4TB (H5300)
+		1e3b 0036  Enterprise NVMe SSD U2 12.8TB (H5300)
+		1e3b 004a  Enterprise NVMe SSD E3.S 1T 7.68TB (H5100)
+		1e3b 004b  Enterprise NVMe SSD E3.S 1T 15.36TB (H5100)
+		1e3b 004c  Enterprise NVMe SSD E3.S 1T 6.4TB (H5300)
+		1e3b 004d  Enterprise NVMe SSD E3.S 1T 12.8TB (H5300)
 		1e3b 0081  Enterprise NVMe SSD U.2 3.84TB (H5100)
 		1e3b 0082  Enterprise NVMe SSD U.2 7.68TB (H5100)
 		1e3b 0084  Enterprise NVMe SSD U.2 3.2TB (H5300)
 		1e3b 0085  Enterprise NVMe SSD U.2 6.4TB (H5300)
+		1e3b 008a  Enterprise NVMe SSD U.2 7.68TB (H5100)
+		1e3b 008b  Enterprise NVMe SSD U.2 15.36TB (H5100)
+		1e3b 008c  Enterprise NVMe SSD U.2 30.72TB (H5100)
+		1e3b 008d  Enterprise NVMe SSD U.2 6.4TB (H5300)
+		1e3b 008e  Enterprise NVMe SSD U.2 12.8TB (H5300)
+		1e3b 008f  Enterprise NVMe SSD U.2 25.6TB (H5300)
+		1e3b 0090  Enterprise NVMe SSD E1.S 9.5mm 3.84TB (H5100)
+		1e3b 0091  Enterprise NVMe SSD E1.S 9.5mm 7.68TB (H5100)
+		1e3b 0092  Enterprise NVMe SSD E1.S 9.5mm 3.2TB (H5300)
+		1e3b 0093  Enterprise NVMe SSD E1.S 9.5mm 6.4TB (H5300)
+		1e3b 0094  Enterprise NVMe SSD E1.S 9.5mm 3.84TB (H5100)
+		1e3b 0096  Enterprise NVMe SSD E1.S 9.5mm 3.2TB (H5300)
+		1e3b 0098  Enterprise NVMe SSD E1.S 9.5mm 7.68TB (H5100)
+		1e3b 0099  Enterprise NVMe SSD E1.S 9.5mm 6.4TB (H5300)
+		1e3b 00f0  Enterprise NVMe SSD U2 Mold
+	3001  Ethernet Controller DN200 for 10GbE SFP+
+		1e3b 3001  Ethernet Network Adapter DN200-X1V for 10GbE SFP+ 2-port
+	3002  Ethernet Controller DN200 Series Virtual Function
+	300c  Ethernet RAID Combo Controller DN200C for 1GbE
+		1e3b 300c  Ethernet RAID Combo Adapter DN200C-G2V for 1GbE 4-port
+	300d  Ethernet RAID Combo Controller DN200C Series Virtual Function
+	5001  RAID Controller DP808A
+	5002  RAID Controller DP808AL
+	50b0  Flexraid6 BootRaid - Type I
+	50b1  Flexraid6 BootRaid - Type II
+		1e3b 0001  Flexraid6 BootRAID F6100
+	50c1  Combo Card of BootRaid and Ethernet - Type I
+	50c2  Combo Card of BootRaid and Ethernet - Type II
+	50d0  NVME RAID Card DP800
+	50d1  Flexraid6 NVMeRAID
 1e3d  Burlywood, Inc
 1e43  MaxLinear Inc
 	8904  MxL8904
 	8906  MxL8906
 	8908  MxL8908
 1e44  Valve Software
+# the actual PCI-SIG member is Elektrobit, a daughter company of Continental
+1e48  Continental
 1e49  Yangtze Memory Technologies Co.,Ltd
 	0001  ZHITAI PC005 NVMe SSD
 	0021  ZHITAI TiPro5000 NVMe SSD
@@ -26776,11 +27493,12 @@
 	0071  ZHITAI TiPlus7100
 # YMTC
 	1001  PC005 NVMe SSD
-	1011  PC210 NVMe SSD
-	1013  PC210 NVMe SSD
-	1031  PC300 NVMe SSD (DRAM-less)
-	1033  PC300 NVMe SSD (DRAM-less)
-	1071  PC411 NVMe SSD (DRAM-less)
+	1011  PC210 M.2 2280 NVMe SSD
+	1013  PC210 M.2 2242 NVMe SSD
+	1031  PC300 M.2 2280 NVMe SSD (DRAM-less)
+	1033  PC300 M.2 2242 NVMe SSD (DRAM-less)
+	1071  PC411 M.2 2280 NVMe SSD (DRAM-less)
+	1073  PC411 M.2 2242 NVMe SSD (DRAM-less)
 1e4b  MAXIO Technology (Hangzhou) Ltd.
 	1001  NVMe SSD Controller MAP1001
 	1002  NVMe SSD Controller MAP1002 (DRAM-less)
@@ -26793,6 +27511,7 @@
 1e4c  GSI Technology
 	0010  Associative Processing Unit [Leda]
 		1e4c 0120  SE120
+	0020  Associative Processing Unit [Leda-2]
 1e50  IP3 Tech (HK) Limited
 1e52  Tenstorrent Inc
 	401e  Wormhole
@@ -26815,9 +27534,13 @@
 	2864  Hailo-8 AI Processor
 1e67  Untether AI
 	0002  runAI200 AI Inference Accelerator
+	0004  speedAI240 AI Inference Accelerator
 1e68  Jiangsu Xinsheng Intelligent Technology Co., Ltd
 	8111  EP2000Pro PCIe 3 NVMe SSD (DRAM-less)
 1e6b  Axiado Corp.
+1e6c  Xsight Labs Ltd.
+	0001  XLX1A256A Switch ASIC
+	0002  XLX2B128A Switch ASIC
 1e7b  Dataland
 1e7c  Brainchip Inc
 	bca1  AKD1000 Neural Network Coprocessor [Akida]
@@ -26867,6 +27590,7 @@
 	2a18  Video Transcode Controller
 	2a20  Cloud Intelligent Inference and Training Controller
 	2a22  Cloud Intelligent Inference Controller
+	2a30  Cloud Video Transcode Controller
 1ea7  Intelliprop, Inc
 	223a  Typhon+ PCIe to Gen-Z Bridge
 	224a  IPA-PE224A CXL to Gen-Z Bridge [Sphinx]
@@ -26876,7 +27600,10 @@
 1eac  Quectel Wireless Solutions Co., Ltd.
 	1001  EM120R-GL LTE Modem
 	1002  EM160R-GL LTE Modem
+	2001  EM120R-GL
 1eae  XFX Limited
+1eb0  Shenzhen Electrical Appliances CO.
+	1901  NVMe SSD Controller (DRAM-less)
 1eb1  VeriSilicon Inc
 	1001  Video Accelerator
 1eb4  Quantum Nebula Microelectronics Technology Co.,Ltd.
@@ -26908,7 +27635,8 @@
 		1ec6 0062  VG1800
 		1ec6 0063  VG1000
 	020f  SG100 vGPU
-1ec8  Innosilicon Co Ltd
+# nee Innosilicon Co Ltd
+1ec8  Beijing Fantasy Technology Co., Ltd.
 	8800  Fantasy I
 		1ec8 12a2  Fantasy I Device
 	8810  Fantasy I
@@ -26928,10 +27656,7 @@
 	2283  Patriot P300 NVMe SSD (DRAM-less)
 1ed2  FuriosaAI, Inc.
 	0000  Warboy
-	1111  RNGD
-		0000 1111  RNGD-S
-		0000 2222  RNGD VF
-		0000 3333  RNGD-S VF
+	0001  RNGD
 	2222  RNGD-S
 1ed3  Yeston
 1ed5  Moore Threads Technology Co.,Ltd
@@ -26954,12 +27679,16 @@
 	0222  MTT S3000
 		1ed5 0001  C3150
 	0223  G2S4
+	0225  MTT S3000E
+		1ed5 0001  C3150
 	0251  G2N10
 	02ff  MTT HDMI/DP Audio
 	0300  MTT S90 Engineering Sample
 	0301  MTT S90
+	0313  MTT X500
 	0323  MTT S4000
 	0327  MTT S4000
+	0328  MTT S4000
 	03ff  MTT HDMI/DP Audio
 1ed8  Digiteq Automotive
 	0101  FG4 PCIe Frame Grabber (T100)
@@ -26972,7 +27701,106 @@
 		1ee1 000b  Airglow A430 NVMe SSD U.2 4.8TB
 		1ee1 0012  Airglow Z400 NVMe ZNS SSD U.2 5.76TB
 1ee4  PETAIO INC
-	1180  P8118 U.2 Single Port SSD
+	1180  PETA8118 NVMe SSD Series
+		1ee4 0015  NVMe SSD U.2 1.92TB (P8118E)
+		1ee4 0016  NVMe SSD U.2 3.84TB (P8118E)
+		1ee4 0017  NVMe SSD U.2 7.68TB (P8118E)
+		1ee4 0025  NVMe SSD U.2 1.6TB (P8118E)
+		1ee4 0026  NVMe SSD U.2 3.2TB (P8118E)
+		1ee4 0027  NVMe SSD U.2 6.4TB (P8118E)
+		1ee4 0115  NVMe SSD U.2 1.92TB (P8118Z)
+		1ee4 0116  NVMe SSD U.2 3.84TB (P8118Z)
+		1ee4 0117  NVMe SSD U.2 7.68TB (P8118Z)
+		1ee4 0125  NVMe SSD U.2 1.6TB (P8118Z)
+		1ee4 0126  NVMe SSD U.2 3.2TB (P8118Z)
+		1ee4 0127  NVMe SSD U.2 6.4TB (P8118Z)
+		1ee4 0215  NVMe SSD U.2 1.92TB (P8118X)
+		1ee4 0216  NVMe SSD U.2 3.84TB (P8118X)
+		1ee4 0217  NVMe SSD U.2 7.68TB (P8118X)
+		1ee4 0225  NVMe SSD U.2 1.6TB (P8118X)
+		1ee4 0226  NVMe SSD U.2 3.2TB (P8118X)
+		1ee4 0227  NVMe SSD U.2 6.4TB (P8118X)
+		1ee4 0315  NVMe SSD U.2 1.92TB (P8118E4)
+		1ee4 0316  NVMe SSD U.2 3.84TB (P8118E4)
+		1ee4 0317  NVMe SSD U.2 7.68TB (P8118E4)
+		1ee4 0325  NVMe SSD U.2 1.6TB (P8118E4)
+		1ee4 0326  NVMe SSD U.2 3.2TB (P8118E4)
+		1ee4 0327  NVMe SSD U.2 6.4TB (P8118E4)
+		1ee4 0415  NVMe SSD U.2 1.92TB (P8118Z3)
+		1ee4 0416  NVMe SSD U.2 3.84TB (P8118Z3)
+		1ee4 0417  NVMe SSD U.2 7.68TB (P8118Z3)
+		1ee4 0425  NVMe SSD U.2 1.6TB (P8118Z3)
+		1ee4 0426  NVMe SSD U.2 3.2TB (P8118Z3)
+		1ee4 0427  NVMe SSD U.2 6.4TB (P8118Z3)
+		1ee4 3013  NVMe SSD AIC 480GB (P8118E)
+		1ee4 3014  NVMe SSD AIC 960GB (P8118E)
+		1ee4 3015  NVMe SSD AIC 1.92TB (P8118E)
+		1ee4 3016  NVMe SSD AIC 3.84TB (P8118E)
+		1ee4 3017  NVMe SSD AIC 7.68TB (P8118E)
+		1ee4 3025  NVMe SSD AIC 1.6TB (P8118E)
+		1ee4 3026  NVMe SSD AIC 3.2TB (P8118E)
+		1ee4 3027  NVMe SSD AIC 6.4TB (P8118E)
+		1ee4 3113  NVMe SSD AIC 480GB (P8118Z)
+		1ee4 3114  NVMe SSD AIC 960GB (P8118Z)
+		1ee4 3115  NVMe SSD AIC 1.92TB (P8118Z)
+		1ee4 3116  NVMe SSD AIC 3.84TB (P8118Z)
+		1ee4 3117  NVMe SSD AIC 7.68TB (P8118Z)
+		1ee4 3125  NVMe SSD AIC 1.6TB (P8118Z)
+		1ee4 3126  NVMe SSD AIC 3.2TB (P8118Z)
+		1ee4 3127  NVMe SSD AIC 6.4TB (P8118Z)
+		1ee4 3213  NVMe SSD AIC 480GB (P8118X)
+		1ee4 3214  NVMe SSD AIC 960GB (P8118X)
+		1ee4 3215  NVMe SSD AIC 1.92TB (P8118X)
+		1ee4 3216  NVMe SSD AIC 3.84TB (P8118X)
+		1ee4 3217  NVMe SSD AIC 7.68TB (P8118X)
+		1ee4 3225  NVMe SSD AIC 1.6TB (P8118X)
+		1ee4 3226  NVMe SSD AIC 3.2TB (P8118X)
+		1ee4 3227  NVMe SSD AIC 6.4TB (P8118X)
+		1ee4 abcd  NVMe SSD U.2
+	1181  PETA8118 NVMe E1S Series
+		1ee4 2015  NVMe SSD E1.S 1.92TB (P8118E)
+		1ee4 2016  NVMe SSD E1.S 3.84TB (P8118E)
+		1ee4 2017  NVMe SSD E1.S 7.68TB (P8118E)
+		1ee4 2025  NVMe SSD E1.S 1.6TB (P8118E)
+		1ee4 2026  NVMe SSD E1.S 3.2TB (P8118E)
+		1ee4 2027  NVMe SSD E1.S 6.4TB (P8118E)
+		1ee4 2115  NVMe SSD E1.S 1.92TB (P8118Z)
+		1ee4 2116  NVMe SSD E1.S 3.84TB (P8118Z)
+		1ee4 2117  NVMe SSD E1.S 7.68TB (P8118Z)
+		1ee4 2125  NVMe SSD E1.S 1.6TB (P8118Z)
+		1ee4 2126  NVMe SSD E1.S 3.2TB (P8118Z)
+		1ee4 2127  NVMe SSD E1.S 6.4TB (P8118Z)
+		1ee4 2215  NVMe SSD E1.S 1.92TB (P8118X)
+		1ee4 2216  NVMe SSD E1.S 3.84TB (P8118X)
+		1ee4 2217  NVMe SSD E1.S 7.68TB (P8118X)
+		1ee4 2225  NVMe SSD E1.S 1.6TB (P8118X)
+		1ee4 2226  NVMe SSD E1.S 3.2TB (P8118X)
+		1ee4 2227  NVMe SSD E1.S 6.4TB (P8118X)
+	1182  PETA8118 NVMe M2 Series
+		1ee4 1013  NVMe SSD M.2 480GB (P8118E)
+		1ee4 1014  NVMe SSD M.2 960GB (P8118E)
+		1ee4 1015  NVMe SSD M.2 1.92TB (P8118E)
+		1ee4 1016  NVMe SSD M.2 3.84TB (P8118E)
+		1ee4 1023  NVMe SSD M.2 400GB (P8118E)
+		1ee4 1024  NVMe SSD M.2 800GB (P8118E)
+		1ee4 1025  NVMe SSD M.2 1.6TB (P8118E)
+		1ee4 1026  NVMe SSD M.2 3.2TB (P8118E)
+		1ee4 1113  NVMe SSD M.2 480GB (P8118Z)
+		1ee4 1114  NVMe SSD M.2 960GB (P8118Z)
+		1ee4 1115  NVMe SSD M.2 1.92TB (P8118Z)
+		1ee4 1116  NVMe SSD M.2 3.84TB (P8118Z)
+		1ee4 1123  NVMe SSD M.2 400GB (P8118Z)
+		1ee4 1124  NVMe SSD M.2 800GB (P8118Z)
+		1ee4 1125  NVMe SSD M.2 1.6TB (P8118Z)
+		1ee4 1126  NVMe SSD M.2 3.2TB (P8118Z)
+		1ee4 1213  NVMe SSD M.2 480GB (P8118X)
+		1ee4 1214  NVMe SSD M.2 960GB (P8118X)
+		1ee4 1215  NVMe SSD M.2 1.92TB (P8118X)
+		1ee4 1216  NVMe SSD M.2 3.84TB (P8118X)
+		1ee4 1223  NVMe SSD M.2 400GB (P8118X)
+		1ee4 1224  NVMe SSD M.2 800GB (P8118X)
+		1ee4 1225  NVMe SSD M.2 1.6TB (P8118X)
+		1ee4 1226  NVMe SSD M.2 3.2TB (P8118X)
 1ee9  SUSE LLC
 1eec  Viscore Technologies Ltd
 	0102  VSE250231S Dual-port 10Gb/25Gb Ethernet PCIe
@@ -27017,6 +27845,16 @@
 1ef7  Shenzhen Gunnir Technology Development Co., Ltd
 1efb  Flexxon Pte Ltd
 1eff  Rebellions Inc.
+	1020  RBLN-CA2 (PF)
+	1021  RBLN-CA2 (VF)
+	1110  RBLN-CA11 (PF)
+	1111  RBLN-CA11 (VF)
+	1120  RBLN-CA12 (PF)
+	1121  RBLN-CA12 (VF)
+	1220  RBLN-CA22 (PF)
+	1221  RBLN-CA22 (VF)
+	1250  RBLN-CA25 (PF)
+	1251  RBLN-CA25 (VF)
 1f02  Beijing Dayu Technology
 1f03  Shenzhen Shichuangyi Electronics Co., Ltd
 	1202  MAP1202-Based NVMe SSD (DRAM-less)
@@ -27028,6 +27866,8 @@
 	5636  IG5636-Based NVMe SSD
 1f0a  Motorcomm Microelectronics.
 	6801  YT6801 Gigabit Ethernet Controller
+1f0d  DeGirum Corp.
+	0100  AI Accelerator [ORCA]
 1f0f  NebulaMatrix Technology
 	1041  D1055AS vDPA Ethernet Controller
 		1f0f 0001  D1055AS vDPA Ethernet Controller
@@ -27068,10 +27908,21 @@
 # XConn XC50256 CXL2.0/PCIe5.0 switch
 	c500  XC50256
 1f17  Zettastone Technology
+1f18  c-payne GmbH
+	0001  PCIe gen4 Switch Backplane 5x x16 - 4W
+	0002  PCIe gen4 Switch Backplane 4x x16 - 5W
+	0101  PCIe gen5 MCIO Switch 100-Lane
+	0102  PCIe gen5 MCIO Switch 52-Lane
+1f1c  Sophgo Technologies Inc.
+	1686  BM1684X [Sophon Series Deep Learning Accelerator]
 1f24  xFusion Digital Technologies Co., Ltd.
 	1058  EP500/EP600 NVMe SSD
 		1f24 1114  EP500 NVMe SSD(RI)
 		1f24 1115  EP600 NVMe SSD(MU)
+1f2e  AzurEngine Technologies
+	00a1  [AE] AzureBlade Accelerator
+	00b1  [AE] AzureBlade Accelerator
+	00c1  [AE] AzureBlade Accelerator
 1f2f  China Mobile (Hangzhou) Information Technology Co.Ltd.
 	1513  DERA MENG NVMe Controller
 		1f2f 6113  KM660 U.2 1.6TB NVMe SSD
@@ -27129,14 +27980,29 @@
 	5236  PCIe 4 INNOGRIT based NVMe SSD
 	5765  PCIe 3 NVMe SSD (DRAM-less)
 1f44  VVDN Technologies Private Limited
-# YUSUR Technology Co., Ltd.
-1f47  YUSUR Tech
+1f47  YUSUR Technology Co., Ltd.
+	1001  FLEXFLOW-2200T Ethernet Controller
+		1f47 0001  FLEXFLOW-2200T Ethernet 10G 2P
+		1f47 0002  FLEXFLOW-2200T Ethernet 25G 2P
+		1f47 0003  FLEXFLOW-2200T Ethernet 40G 2P
+		1f47 0004  FLEXFLOW-2200T Ethernet 100G 1P
+		1f47 0005  FLEXFLOW-2200T Ethernet 100G 2P
+		1f47 0006  FLEXFLOW-2200T Ethernet 10G 2P
+		1f47 0007  FLEXFLOW-2200T Ethernet 25G 2P
+		1f47 0008  FLEXFLOW-2200T Ethernet 40G 2P
+		1f47 0009  FLEXFLOW-2200T Ethernet 100G 1P
+		1f47 000a  FLEXFLOW-2200T Ethernet 100G 2P
+	1003  FLEXFLOW-2200T Ethernet Controller MGMT Function
 # Network Accelerating Card
 	2018  DPU Card
 # Network Accelerating Card
 	2020  DPU
 1f4b  Axera Semiconductor Co., Ltd
 1f52  MangoBoost Inc.
+	1008  Mango GPUBoost - RDMA
+	1020  Mango NetworkBoost - TCP
+	1022  Mango StorageBoost - NTI
+	1023  Mango StorageBoost - NTT
 1f56  SAPEON Inc.
 1f60  Accelecom
 	0001  XELE-NIC 25K5
@@ -27147,13 +28013,28 @@
 	1051  metaFusion DPU Physical Function
 	1052  metaFusion DPU Virtual Function
 	1059  metaFusion DPU SoC Network Interface
-	1111  metaScale SmartNIC Physical Function
+	1111  YSA-100 RDMA Ethernet Network Controller
+		1bd4 00b2  O1E2YYSA100
+		1ff9 00b1  ENFY1102-QP2
 	1112  metaScale SmartNIC Virtual Function
 	1151  metaVisor DPU Physical Function
 	1152  metaVisor DPU Virtual Function
+1f6c  CIX Technology Group Co., Ltd.
+	0001  CIX P1 CD8180 PCI Express Root Port
+1f73  Shenzhen Quanxing Tech Co., Ltd.
+1f7a  Efinix, Inc.
+	0100  Default ID for Titanium FPGA PCIe Interface (AXI)
+1f82  d-Matrix
+	0011  Corsair [DMX 1000 Series]
+1f99  Shenzhen Techwinsemi Technology Co., Ltd.
+1f9d  Axelera AI
+	1100  Metis AIPU (rev 02)
+	11aa  Metis AIPU (rev 01)
 1faa  Hexaflake (Shanghai) Information Technology Co., Ltd.
 	0c10  Compass C10 PF
 	0c11  Compass C10 VF
+	0c80  Compass2 C80 PF
+	0c81  Compass2 C80 VF
 1fab  Unifabrix Ltd.
 	0000  Nexus Alpha IVPU
 	0100  NoX Gamma
@@ -27253,6 +28134,9 @@
 1fd4  SUNIX Co., Ltd.
 	0001  Matrix multiport serial adapter
 	1999  Multiport serial controller
+1fdd  Wuqi Microelectronics Co., Ltd.
+	0001  WQ9201 802.11ax PCIe Wireless Network Adapter
+	1001  WQ9301 802.11ax PCIe Wireless Access Points
 1fde  Kratos Defense & Security Solutions, Inc.
 	1125  OpenEdge 1125P
 	2500  OpenEdge 2500P
@@ -27260,6 +28144,8 @@
 	1010  AWM 1
 	2000  AWM 2
 	2010  AWM 2-M
+1fe1  Beijing ESWIN Computing Technology Co., Ltd.
+	2030  EIC7700 Root Complex
 1fe4  HippStor Technology
 	1600  HP600 Series NVMe SSD
 		1fe4 0075  Enterprise NVMe SSD U.2 3.84TB(HP610)
@@ -27267,7 +28153,8 @@
 		1fe4 0077  Enterprise NVMe SSD U.2 6.40TB(HP630)
 		1fe4 0078  Enterprise NVMe SSD U.2 3.20TB(HP630)
 1fe9  MemryX
-# LinkData Technology (Tianjin) Co., LTD
+	0100  MX3
+# Linkdata Technology (Tianjin) Co., LTD
 1ff2  Linkdata
 	10a1  NIC1160 Ethernet Controller Family
 		1ff2 0c11  10GE Ethernet Adapter 1160-2X
@@ -27304,9 +28191,49 @@
 	5818  A5818
 2036  Netforward Microelectronics Co., Ltd.
 	1618  NF1618 PCI Express Ethernet Controller
+		2036 0860  NF1618 Family NX860 (2*25GE)
+		2036 0861  NF1618 Family NX861 (4*25GE)
+		2036 0862  NF1618 Family NX862 (2*50GE)
+		2036 0863  NF1618 Family NX863 (2*100GE)
+		2036 0864  NF1618 Family NX864 (1*200GE)
 	1619  NF1618 Family Virtual Function
 2046  GXMICRO Technology (Shanghai) Co., Ltd.
 2048  Beijing SpaceControl Technology Co.Ltd
+205c  Zhejiang VMing Semiconductor Co., Ltd.
+	1515  EP9410 U.2 3.84TB NVME SSD
+	1516  EP9410 U.2 7.68TB NVME SSD
+2061  Unis Flash Memory
+	4000  E4000 controller
+	4100  E4100 controller
+2063  Hubei Yangtze Mason Semiconductor Technology Co., Ltd.
+	1406  ME7000 NVMe SSD
+206d  GigaIO Networks, Inc.
+207d  HRDT
+	0612  SATA BootRAID Controller
+208a  MICIUS Laboratory
+2094  Shenzhen Wodposit Electronics Co., Ltd.
+	1281  WPBSNM8-256GTP
+	1282  WPSBNM8-512GTP
+	1283  WPBSNM8-1TTP
+	1284  WPBSNM8-256GMP
+	1285  WPBSNM8-512GMP
+	1286  WPBSNM8-2TMP
+	1287  WPBSNM8-1TMP
+	1661  WPBSN4M8-512GMP
+	1662  WPBSN4M8-1TMP
+	1663  WPBSN4M8-2TMP
+2096  Kaitian Information Technology Co., Ltd.
+	5401  KCP54(01) 2280 PCIe G4 x4 TLCKCP54(01) 2280 PCIe G4 x4 TLC
+	5402  KCP54(02) 2280 PCIe G4 x4 TLC
+	5403  KCP54(03) 2280 PCIe G4 x4 TLC
+	5404  KCP54(04) 2280 PCIe G4 x4 TLC
+209b  BitIntelligence Technology
+	1000  TCU Family - TCU-1
+209f  Mobilint, Inc.
+20a7  EEVengers Inc.
+20a9  LDA Technologies Ltd.
+	1008  NEOTAPX FPGA Accelerator Card
+	1104  NEOTAPX FPGA Timing Synchronization Card
 20f4  TRENDnet
 2116  ZyDAS Technology Corp.
 21b4  Hunan Goke Microelectronics Co., Ltd
@@ -27317,38 +28244,46 @@
 	1200  NVMe Streamer EP ERD
 2304  Colorgraphic Communications Corp.
 2321  Bruker AXS Inc.
+	0002  Hi-Star PCI Interface
 2348  Racore
 	2010  8142 100VG/AnyLAN
 256c  Graphics Technology (HK) Co., Ltd.
 	006d  HS610
 2646  Kingston Technology Company, Inc.
 	0010  HyperX Predator PCIe AHCI SSD
-	2262  KC2000/KC2500 NVMe SSD SM2262EN
-	2263  A2000 NVMe SSD SM2263EN
-	5008  A1000/U-SNS8154P3 x2 NVMe SSD
-	500a  DC1000B NVMe SSD E12DC
-	500b  DC1000M NVMe SSD SM2270
+	2262  KC2000/KC2500 NVMe SSD [SM2262EN]
+	2263  A2000 NVMe SSD [SM2263EN]
+	5008  A1000/U-SNS8154P3 x2 NVMe SSD [E8]
+	500a  DC1000B NVMe SSD [E12DC]
+	500b  DC1000M NVMe SSD [SM2270]
 	500c  OM8PCP Design-In PCIe 3 NVMe SSD (DRAM-less)
 	500d  OM3PDP3 NVMe SSD
-	500e  NV1 NVMe SSD E13T (DRAM-less)
-	500f  NV1 NVMe SSD SM2263XT (DRAM-less)
+	500e  NV1 NVMe SSD [E13T] (DRAM-less)
+	500f  NV1 NVMe SSD [SM2263XT] (DRAM-less)
 	5010  OM8SBP NVMe PCIe SSD (DRAM-less)
-	5012  DC1500M NVMe SSD SM2270
-	5013  KC3000/FURY Renegade NVMe SSD E18
+	5012  DC1500M NVMe SSD [SM2270]
+	5013  KC3000/FURY Renegade NVMe SSD [E18]
 	5014  OM8SEP4 Design-In PCIe 4 NVMe SSD (TLC) (DRAM-less)
-	5016  OM3PGP4 NVMe SSD
-	5017  NV2 NVMe SSD SM2267XT (DRAM-less)
-	5019  NV2 NVMe SSD E21T (DRAM-less)
+	5016  OM3PGP4 NVMe SSD (DRAM-less)
+	5017  NV2 NVMe SSD [SM2267XT] (DRAM-less)
+	5018  OM8SFP4 PCIe 4 NVMe SSD (DRAM-less)
+	5019  NV2 NVMe SSD [E21T] (DRAM-less)
 # 128GB
 	501a  OM8PGP4 Design-In PCIe 4 NVMe SSD (TLC) (DRAM-less)
 	501b  OM8PGP4 NVMe PCIe SSD (DRAM-less)
-	501c  NV2 NVMe SSD E19T (DRAM-less)
-	501d  NV2 NVMe SSD TC2200 (DRAM-less)
-	501f  FURY Renegade NVMe SSD with heatsink
+	501c  NV2 NVMe SSD [E19T] (DRAM-less)
+	501d  NV2 NVMe SSD [TC2200] (DRAM-less)
+	501e  OM3PGP4 NVMe SSD (DRAM-less)
+	501f  FURY Renegade NVMe SSD + Heatsink [E18]
 	5021  OM8SEP4 Design-In PCIe 4 NVMe SSD (QLC) (DRAM-less)
 	5022  OM8PGP4 Design-In PCIe 4 NVMe SSD (QLC) (DRAM-less)
-	5023  NV2 NVMe SSD SM2269XT (DRAM-less)
-	5024  DC2000B NVMe SSD E18DC
+	5023  NV2 NVMe SSD [SM2269XT] (DRAM-less)
+	5024  DC2000B NVMe SSD [E18DC]
+	5025  NV3 NVMe SSD [TC2201] (DRAM-less)
+	5026  NV3 NVMe SSD [E21T] (DRAM-less)
+	5027  NV3 NVMe SSD [E27T] (DRAM-less)
+	5028  NV3 NVMe SSD [SM2268XT2] (DRAM-less)
+	502c  DC3000ME NVMe SSD [SC5]
 270b  Xantel Corporation
 270f  Chaintech Computer Co. Ltd
 2711  AVID Technology Inc.
@@ -27357,8 +28292,10 @@
 	6e61  OHCI USB 1.1 controller
 2a15  3D Vision(???)
 2a18  Video Transcode Controller
+	2a22  Video Transcode Controller
 2bd8  ROPEX Industrie-Elektronik GmbH
 3000  Hansol Electronics Inc.
+30c9  Luxvisions Innovation Technology Ltd.
 3100  Dynabook Inc.
 3112  Satelco Ingenieria S.A.
 3130  AUDIOTRAK
@@ -27523,6 +28460,13 @@
 	7073  CH356 PCI Quad Serial and Parallel Ports Controller
 	7173  CH355 PCI Quad Serial Port Controller
 434e  Cornelis Networks
+	0001  CN5000 HFI Silicon, Dual Port, BGA [discrete]
+		434e 0001  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Air-Cooled
+		434e 0002  CN5000 HFI Adapter, Dual Port, QSFP-DD, x16 PCIe Gen 5, Air-Cooled
+		434e 0003  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Air-Cooled, Thermally Enhanced
+		434e 0004  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Conduction-Cooled
+	0002  CN6000 HFI Silicon, Dual Port, BGA [discrete]
+	8001  CN5000 Switch Silicon, 48 Port, BGA
 4444  Internext Compression Inc
 	0016  iTVC16 (CX23416) Video Decoder
 		0070 0003  WinTV PVR 250
@@ -27947,9 +28891,10 @@
 	8e40  2300E Graphics Processor
 	8e48  Matrix [Chrome S25 / S27]
 		5333 0130  Chrome S27 256M DDR2
+	9020  86C920 [Chrome 460 ESV]
 	9043  Chrome 430 GT
 	9045  Chrome 430 ULP / 435 ULP / 440 GTX
-	9060  Chrome 530 GT
+	9060  Chrome 530 GT / 5400E
 # Found in VIA Embedded uH4 graphics card
 	9070  Chrome 5400EW
 	9102  86C410 [Savage 2000]
@@ -28080,6 +29025,8 @@
 	0000  HTLv-1 / HTLv-2 / HTLv-13 / HTLv-23
 	0011  HTLv-53
 7bde  MIDAC Corporation
+7f70  Arrow Lake-S PCH CNVi WiFi
+	0094  WiFi 6E AX211 160MHz
 7fed  PowerTV
 8008  Quancom Electronic GmbH
 	0010  WDOG1 [PCI-Watchdog 1]
@@ -28087,6 +29034,8 @@
 	0015  Clock77/PCI & Clock77/PCIe (DCF-77 receiver)
 # Wrong ID used in subsystem ID of AsusTek PCI-USB2 PCI card.
 807d  Asustek Computer, Inc.
+8080  Chengdu Storeswift Technology Co., Ltd.
+	4016  CX4016A NVMe SSD Controller
 8086  Intel Corporation
 	0007  82379AB
 	0008  Extended Express System Support Controller
@@ -28387,6 +29336,7 @@
 	0685  Z490 Chipset LPC/eSPI Controller
 	0687  Q470 Chipset LPC/eSPI Controller
 	068d  Comet Lake LPC Controller
+	068e  WM490 Chipset LPC/eSPI Controller
 	06a3  Comet Lake PCH SMBus Controller
 	06a4  Comet Lake PCH SPI Controller
 	06a8  Comet Lake PCH Serial IO UART Host Controller #0
@@ -28395,9 +29345,11 @@
 	06ab  Comet Lake PCH Serial IO SPI Controller #1
 	06ac  Comet Lake PCI Express Root Port #21
 	06b0  Comet Lake PCI Express Root Port #9
+	06b8  Comet Lake PCIe Root Port #1
 	06ba  Comet Lake PCI Express Root Port #1
 	06bb  Comet Lake PCI Express Root Port #4
 	06bd  Comet Lake PCIe Port #6
+	06be  Comet Lake PCIe Root Port #7
 	06bf  Comet Lake PCIe Port #8
 	06c0  Comet Lake PCI Express Root Port #17
 	06c8  Comet Lake PCH cAVS
@@ -28421,6 +29373,7 @@
 		8086 42a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
 	06f9  Comet Lake PCH Thermal Controller
 	06fb  Comet Lake PCH Serial IO SPI Controller #2
+	06fc  Comet Lake PCH Integrated Sensor Solution
 	0700  CE Media Processor A/V Bridge
 	0701  CE Media Processor NAND Flash Controller
 	0703  CE Media Processor Media Control Unit 1
@@ -29459,6 +30412,7 @@
 		8086 10a6  PRO/1000 PF Quad Port Server Adapter
 	10a6  82599EB 10-Gigabit Dummy Function
 	10a7  82575EB Gigabit Network Connection
+		15d9 10a7  X10DRW-i
 		8086 10a8  82575EB Gigabit Riser Card
 	10a9  82575EB Gigabit Backplane Connection
 	10b0  82573L PRO/1000 PL Network Connection
@@ -29621,6 +30575,8 @@
 		1bd4 002f  10G SFP+ DP EP102Fi4A Adapter
 		1bd4 0032  10G SFP+ DP EP102Fi4 Adapter
 		1bd4 0067  F102I82599
+		1f3f 0a00  Dual-port 10-Gigabit SFI/SFP+ Network Connection
+		4c52 1022  LRES1022PF Dual-port 10Gb Ethernet Bypass Network Adapter
 		4c52 1024  LR-LINK LRES9804BF Quad-port 10Gb Ethernet Server Adapter
 		4c52 3002  LRES3002PF Dual-port 10Gb Ethernet Server Adapter for OCP
 		4c52 3012  LRES3012PF Dual-port 10Gb Ethernet Server Adapter for OCP
@@ -29877,7 +30833,9 @@
 	125d  Ethernet Controller I226-IT
 	12d1  Ethernet Controller E830-CC for backplane
 	12d2  Ethernet Controller E830-CC for QSFP
+		8086 0001  Ethernet Network Adapter E830-C-Q2
 		8086 0002  Ethernet Network Adapter E830-C-Q2 for OCP 3.0
+		8086 0003  Ethernet Network Adapter E830-CC-Q1
 		8086 0004  Ethernet Network Adapter E830-CC-Q1 for OCP 3.0
 	12d3  Ethernet Controller E830-CC for SFP
 		8086 0001  Ethernet Network Adapter E830-XXV-2 for OCP 3.0
@@ -29887,14 +30845,17 @@
 	12d5  Ethernet Controller E830-C for backplane
 	12d8  Ethernet Controller E830-C for QSFP
 	12da  Ethernet Controller E830-C for SFP
-	12dc  Ethernet Controller E830-XXV for backplane
-	12dd  Ethernet Controller E830-XXV for QSFP
-	12de  Ethernet Controller E830-XXV for SFP
+	12dc  Ethernet Controller E830-L for backplane
+	12dd  Ethernet Controller E830-L for QSFP
+	12de  Ethernet Controller E830-L for SFP
+		8086 0001  Ethernet Network Adapter E830-XXV-2 for OCP 3.0
+		8086 0003  Ethernet Network Adapter E830-XXV-2
 	1360  82806AA PCI64 Hub PCI Bridge
 	1361  82806AA PCI64 Hub Controller (HRes)
 		8086 1361  82806AA PCI64 Hub Controller (HRes)
 		8086 8000  82806AA PCI64 Hub Controller (HRes)
 	1452  Infrastructure Data Path Function
+	1457  NVMe Data Path Function
 	145c  Infrastructure Data Path Function
 	1460  82870P2 P64H2 Hub PCI Bridge
 	1461  82870P2 P64H2 I/OxAPIC
@@ -29975,6 +30936,7 @@
 		1137 023e  1GigE I350 LOM
 		15d9 0000  AOC-SGP-i4
 		15d9 0652  Dual Port i350 GbE MicroLP [AOC-CGP-i2]
+		15d9 1521  X10DRW-i
 		17aa 1074  ThinkServer I350-T4 AnyFabric
 		17aa 4005  I350 Gigabit Network Connection
 		18d4 0c07  I350 1Gb 2-port RJ45 OCP Mezz Card MOP41-I-1GT2
@@ -30000,7 +30962,8 @@
 		4c52 3023  LRES3023PT Quad-port 1Gb Ethernet Server Adapter for OCP
 		4c52 3041  LRES3041PT Dual-port 1Gb Ethernet Server Adapter for OCP
 		4c52 4006  LRES4006MT Quad-port 1Gb Ethernet Netwaork Adapter
-		4c52 9712  LREC9712HT Dual-port 10Gb Ethernet Network Adapter
+		4c52 8001  LRES8001PT Quad-port 1Gb Ethernet Bypass Network Adapter
+		4c52 9712  LREC9712HT Dual-port 1Gb Ethernet Bypass Network Adapter
 		8086 0001  Ethernet Server Adapter I350-T4
 		8086 0002  Ethernet Server Adapter I350-T2
 		8086 0003  Ethernet Network Adapter I350-T4 for OCP NIC 3.0
@@ -30017,6 +30980,7 @@
 		108e 7b19  Dual Port GbE PCIe 2.0 Low Profile Adapter, MMF
 		4c52 1006  LRES1006PF Six-port 1Gb Ethernet Network Adapter
 		4c52 2203  LRES2203PF Dual-port 1Gb Ethernet Network Adapter
+		4c52 8030  LRES8030PF Dual-port 1Gb Ethernet Bypass Network Adapter
 		4c52 9710  LREC9710HF Single-port 1Gb Ethernet Network Adapter
 		4c52 9712  LREC9712HF Dual-port 1Gb Ethernet Network Adapter
 		4c52 9714  LREC9714HF Quad-port 1Gb Ethernet Network Adapter
@@ -30075,6 +31039,8 @@
 	1530  X540 Virtual Function
 	1531  I210 Gigabit Unprogrammed
 	1533  I210 Gigabit Network Connection
+		1028 0758  I210 PCIe 1Gb 1-Port RJ45 LOM
+		1028 0759  I210 PCIe 1Gb 1-Port RJ45 LOM
 		1028 0b35  I210 Gigabit Network Connection
 		103c 0003  Ethernet I210-T1 GbE NIC
 		1059 0180  RD10019 1GbE interface
@@ -30111,6 +31077,7 @@
 		1059 0150  RD-01068 1GbE interface
 		1059 0170  RD-01213 10GbE interface
 	1538  I210 Gigabit Network Connection
+		1059 0190  RD20057 M.2 Dual 1GbE-T1 15m
 	1539  I211 Gigabit Network Connection
 	153a  Ethernet Connection I217-LM
 		103c 1909  ZBook 15
@@ -30212,6 +31179,7 @@
 		4c52 3003  LRES3003PF Quad-port 10Gb Ethernet Server Adapter for OCP
 		4c52 3007  LRES3007PF Quad-port 10Gb Ethernet Server Adapter for OCP
 		4c52 3039  LRES3039PF Dual-port 10Gb Ethernet Server Adapter for OCP
+		4c52 8003  LRES8003PT Quad-port 10Gb Ethernet Bypass Network Adapter
 		4c52 9804  LREC9804BF Quad-port 10Gb Ethernet Server Adapter
 		4c52 9812  LREC9812BF Dual-port 10Gb Ethernet Server Adapter
 		8086 0000  Ethernet Converged Network Adapter X710
@@ -30333,6 +31301,7 @@
 		1590 0000  Ethernet Network Adapter XXV710-2
 		1590 0253  Ethernet 10/25/Gb 2-port 661SFP28 Adapter
 		4c52 3017  LRES3017PF Dual-port 25Gb Ethernet Server Adapter for OCP
+		4c52 8004  LRES8004PT Quad-port 25Gb Ethernet Bypass Network Adapter
 		8086 0000  Ethernet Network Adapter XXV710
 		8086 0001  Ethernet Network Adapter XXV710-2
 		8086 0002  Ethernet Network Adapter XXV710-2
@@ -30389,6 +31358,7 @@
 		8086 000e  Ethernet Network Adapter E810-XXV-4T
 		8086 000f  Ethernet 25G 4P E810-XXV-stg Adapter
 		8086 0010  Ethernet 25G 4P E810-XXV-st Adapter
+		8086 0012  Ethernet 25G 4P E810-XXV Adapter
 		8086 4010  Ethernet Network Adapter E810-XXV-4
 		8086 4013  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
 		8086 401c  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
@@ -30494,8 +31464,8 @@
 		1028 09be  Latitude 7410
 	15ec  JHL7540 Thunderbolt 3 USB Controller [Titan Ridge 4C 2018]
 		1028 09be  Latitude 7410
-	15ef  JHL7540 Thunderbolt 3 Bridge [Titan Ridge DD 2018]
-	15f0  JHL7540 Thunderbolt 3 USB Controller [Titan Ridge DD 2018]
+	15ef  JHL7440 Thunderbolt 3 Bridge [Titan Ridge DD 2018]
+	15f0  JHL7440 Thunderbolt 3 USB Controller [Titan Ridge DD 2018]
 	15f2  Ethernet Controller I225-LM
 		4c52 2031  LRES2031PT Single-port 2.5Gb Ethernet Network Adapter
 		8086 0001  Ethernet Network Adapter I225-T1
@@ -30512,6 +31482,7 @@
 	15fc  Ethernet Connection (13) I219-V
 	15ff  Ethernet Controller X710 for 10GBASE-T
 		1014 0000  PCIe3 4-port 10GbE Base-T Adapter
+		108e 0000  Quad Port 10GBase-T Adapter - CP
 		108e 7b1f  Quad Port 10GBase-T Adapter - CP
 		1137 0000  X710TLG GbE RJ45 PCIe NIC
 		1137 02c1  X710T2LG 2x10 GbE RJ45 PCIe NIC
@@ -30744,6 +31715,7 @@
 	19d5  Atom Processor C3000 Series ME KT Controller
 	19d6  Atom Processor C3000 Series ME HECI 3
 	19d8  Atom Processor C3000 Series HSUART Controller
+	19db  Atom Processor C3000 Series SD Host Controller
 	19dc  Atom Processor C3000 Series LPC or eSPI
 	19dd  Atom Processor C3000 Series Primary to Side Band (P2SB) Bridge
 	19de  Atom Processor C3000 Series Power Management Controller
@@ -30751,6 +31723,7 @@
 	19e0  Atom Processor C3000 Series SPI Controller
 	19e2  Atom Processor C3000 Series QuickAssist Technology
 	19e3  Atom Processor C3000 Series QuickAssist Technology Virtual Function
+	1a12  Timna CPU Graphics
 	1a1c  Ethernet Connection (17) I219-LM
 	1a1d  Ethernet Connection (17) I219-V
 	1a1e  Ethernet Connection (16) I219-LM
@@ -33914,6 +34887,7 @@
 	2e95  4 Series Chipset HECI Controller
 	2e96  4 Series Chipset PT IDER Controller
 	2f00  Xeon E7 v3/Xeon E5 v3/Core i7 DMI2
+		15d9 0821  X10DRW-i
 	2f01  Xeon E7 v3/Xeon E5 v3/Core i7 PCI Express Root Port 0
 	2f02  Xeon E7 v3/Xeon E5 v3/Core i7 PCI Express Root Port 1
 	2f03  Xeon E7 v3/Xeon E5 v3/Core i7 PCI Express Root Port 1
@@ -33942,28 +34916,48 @@
 	2f1b  Xeon E7 v3/Xeon E5 v3/Core i7 IIO Debug
 	2f1c  Xeon E7 v3/Xeon E5 v3/Core i7 IIO Debug
 	2f1d  Xeon E7 v3/Xeon E5 v3/Core i7 PCIe Ring Interface
+		15d9 0821  X10DRW-i
 	2f1e  Xeon E7 v3/Xeon E5 v3/Core i7 Scratchpad & Semaphore Registers
+		15d9 0821  X10DRW-i
 	2f1f  Xeon E7 v3/Xeon E5 v3/Core i7 Scratchpad & Semaphore Registers
+		15d9 0821  X10DRW-i
 	2f20  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 0
+		15d9 0821  X10DRW-i
 	2f21  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 1
+		15d9 0821  X10DRW-i
 	2f22  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 2
+		15d9 0821  X10DRW-i
 	2f23  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 3
+		15d9 0821  X10DRW-i
 	2f24  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 4
+		15d9 0821  X10DRW-i
 	2f25  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 5
+		15d9 0821  X10DRW-i
 	2f26  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 6
+		15d9 0821  X10DRW-i
 	2f27  Xeon E7 v3/Xeon E5 v3/Core i7 DMA Channel 7
+		15d9 0821  X10DRW-i
 	2f28  Xeon E7 v3/Xeon E5 v3/Core i7 Address Map, VTd_Misc, System Management
+		15d9 0821  X10DRW-i
 	2f29  Xeon E7 v3/Xeon E5 v3/Core i7 Hot Plug
+		15d9 0821  X10DRW-i
 	2f2a  Xeon E7 v3/Xeon E5 v3/Core i7 RAS, Control Status and Global Errors
+		15d9 0821  X10DRW-i
 	2f2c  Xeon E7 v3/Xeon E5 v3/Core i7 I/O APIC
+		15d9 0821  X10DRW-i
 	2f2e  Xeon E7 v3/Xeon E5 v3/Core i7 RAID 5/6
 	2f2f  Xeon E7 v3/Xeon E5 v3/Core i7 RAID 5/6
 	2f30  Xeon E7 v3/Xeon E5 v3/Core i7 Home Agent 0
+		15d9 0821  X10DRW-i
 	2f32  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 0
+		15d9 0821  X10DRW-i
 	2f33  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 1
 	2f34  Xeon E7 v3/Xeon E5 v3/Core i7 PCIe Ring Interface
+		15d9 0821  X10DRW-i
 	2f36  Xeon E7 v3/Xeon E5 v3/Core i7 R3 QPI Link 0 & 1 Monitoring
+		15d9 0821  X10DRW-i
 	2f37  Xeon E7 v3/Xeon E5 v3/Core i7 R3 QPI Link 0 & 1 Monitoring
+		15d9 0821  X10DRW-i
 	2f38  Xeon E7 v3/Xeon E5 v3/Core i7 Home Agent 1
 	2f39  Xeon E7 v3/Xeon E5 v3/Core i7 I/O Performance Monitoring
 	2f3a  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 2
@@ -33989,10 +34983,14 @@
 	2f78  Xeon E7 v3/Xeon E5 v3/Core i7 Home Agent 1 Debug
 	2f79  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 1 Target Address, Thermal & RAS Registers
 	2f7d  Xeon E7 v3/Xeon E5 v3/Core i7 Scratchpad & Semaphore Registers
+		15d9 0821  X10DRW-i
 	2f7e  Xeon E7 v3/Xeon E5 v3/Core i7 E3 QPI Link Debug
 	2f80  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 0
+		15d9 0821  X10DRW-i
 	2f81  Xeon E7 v3/Xeon E5 v3/Core i7 R3 QPI Link 0 & 1 Monitoring
+		15d9 0821  X10DRW-i
 	2f83  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 0
+		15d9 0821  X10DRW-i
 	2f85  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 0 Debug
 	2f86  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 0 Debug
 	2f87  Xeon E7 v3/Xeon E5 v3/Core i7 QPI Link 0 Debug
@@ -34007,11 +35005,16 @@
 	2f9a  Xeon E7 v3/Xeon E5 v3/Core i7 Power Control Unit
 	2f9c  Xeon E7 v3/Xeon E5 v3/Core i7 Power Control Unit
 	2fa0  Xeon E7 v3/Xeon E5 v3/Core i7 Home Agent 0
+		15d9 0821  X10DRW-i
 	2fa8  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 0 Target Address, Thermal & RAS Registers
 	2faa  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 0 Channel Target Address Decoder
+		15d9 0821  X10DRW-i
 	2fab  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 0 Channel Target Address Decoder
+		15d9 0821  X10DRW-i
 	2fac  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 0 Channel Target Address Decoder
+		15d9 0821  X10DRW-i
 	2fad  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 0 Channel Target Address Decoder
+		15d9 0821  X10DRW-i
 	2fae  Xeon E7 v3/Xeon E5 v3/Core i7 DDRIO Channel 0/1 Broadcast
 	2faf  Xeon E7 v3/Xeon E5 v3/Core i7 DDRIO Global Broadcast
 	2fb0  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 0 Channel 0 Thermal Control
@@ -34045,13 +35048,21 @@
 	2fd6  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 1 Channel 2 ERROR Registers
 	2fd7  Xeon E7 v3/Xeon E5 v3/Core i7 Integrated Memory Controller 1 Channel 3 ERROR Registers
 	2fe0  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe1  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe2  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe3  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe4  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe5  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe6  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe7  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
+		15d9 0821  X10DRW-i
 	2fe8  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
 	2fe9  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
 	2fea  Xeon E7 v3/Xeon E5 v3/Core i7 Unicast Registers
@@ -34073,8 +35084,11 @@
 	2ffa  Xeon E7 v3/Xeon E5 v3/Core i7 Buffered Ring Agent
 	2ffb  Xeon E7 v3/Xeon E5 v3/Core i7 Buffered Ring Agent
 	2ffc  Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
+		15d9 0821  X10DRW-i
 	2ffd  Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
+		15d9 0821  X10DRW-i
 	2ffe  Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
+		15d9 0821  X10DRW-i
 	3101  Killer E3100X 2.5 Gigabit Ethernet Controller
 	3140  Easel/Monette Hill Image Processor [Pixel Visual Core]
 	3165  Wireless 3165
@@ -34088,6 +35102,7 @@
 	318e  Celeron/Pentium Silver Processor NorthPeak
 	3190  Celeron/Pentium Silver Processor Gaussian Mixture Model
 	3192  Gemini Lake P2SB
+	3196  Unknown P2SB serial controller
 	3197  Celeron/Pentium Silver Processor PCI-default ISA-bridge
 	3198  Celeron/Pentium Silver Processor High Definition Audio
 		17aa 380b  V130-15IGM Laptop (Lenovo) - Type 81HL
@@ -35034,11 +36049,13 @@
 	43ba  Tiger Lake-H PCIe Root Port #3
 	43bb  Tiger Lake-H PCIe Root Port #4
 	43bc  Tiger Lake-H PCI Express Root Port #5
+	43be  11th Gen Core Processor PCIe Root Port #7
 	43c0  Tiger Lake-H PCIe Root Port #17
 	43c7  Tiger Lake-H PCIe Root Port #24
 	43c8  Tiger Lake-H HD Audio Controller
 	43d3  Tiger Lake SATA AHCI Controller
 	43e0  Tiger Lake-H Management Engine Interface
+	43e3  Tiger Lake AMT SOL Redirection
 	43e8  Tiger Lake-H Serial IO I2C Controller #0
 	43e9  Tiger Lake-H Serial IO I2C Controller #1
 	43ed  Tiger Lake-H USB 3.2 Gen 2x1 xHCI Host Controller
@@ -35058,6 +36075,9 @@
 	4601  Alder Lake-U15 Host and DRAM Controller
 	4602  Alder Lake Host and DRAM Controller
 	460d  12th Gen Core Processor PCI Express x16 Controller #1
+	4619  Core i9/i7/i5/i3 Host Bridge/DRAM Registers
+	461b  Alder Lake-N Processor Host Bridge/DRAM Registers
+	461c  Alder Lake-N Processor Host Bridge/DRAM Registers
 	461d  Alder Lake Innovation Platform Framework Processor Participant
 		1028 0b10  Precision 3571
 	461e  Alder Lake-P Thunderbolt 4 USB Controller
@@ -35088,6 +36108,7 @@
 	466d  Alder Lake-P Thunderbolt 4 NHI #1
 	466e  Alder Lake-P Thunderbolt 4 PCI Express Root Port #0
 	467d  Platform Monitoring Technology
+	467e  GNA Scoring Accelerator
 	467f  Volume Management Device NVMe RAID Controller
 	4680  AlderLake-S GT1
 	4682  Alder Lake-S GT1 [UHD Graphics 730]
@@ -35172,10 +36193,13 @@
 	4deb  Jasper Lake Serial IO I2C Host Controller #3
 	4ded  Jasper Lake USB 3.1 xHCI Host Controller
 	4def  Jasper Lake Shared SRAM
-	4df0  Wi-Fi 6 AX201 160MHz
+	4df0  Jasper Lake PCH CNVi WiFi
+		8086 4030  Wireless-AC 9560 160MHz
 	4df8  Jasper Lake SD Controller
 	4e03  Dynamic Tuning service
+	4e11  Gaussian Mixture Model and Neural Network Accelerator (GNA)
 	4e19  JasperLake IPU
+	4e22  Processor Transaction Router SKU 2 Core
 	4e55  JasperLake [UHD Graphics]
 	4e61  JasperLake [UHD Graphics]
 	4e71  JasperLake [UHD Graphics]
@@ -35258,7 +36282,10 @@
 	51ab  Alder Lake SPI Controller
 	51b0  Alder Lake PCI Express Root Port #9
 	51b1  Alder Lake PCI Express x1 Root Port #10
+	51b2  Alder Lake PCI Express x1 Root Port #11
+	51b3  Alder Lake PCI Express Root Port #12
 	51bb  Alder Lake-P PCH PCIe Root Port #4
+	51bc  Alder Lake PCI Express x4 Root Port #5
 	51bd  Alder Lake-P PCH PCIe Root Port #6
 	51bf  Alder Lake PCH-P PCI Express Root Port #9
 	51c5  Alder Lake-P Serial IO I2C Controller #0
@@ -35326,6 +36353,11 @@
 	54b1  Alder Lake-N PCI Express Root Port #10
 	54b2  Alder Lake-N PCI Express Root Port #11
 	54b3  Alder Lake-N PCI Express Root Port #12
+	54b8  Alder Lake-N PCI Express Root Port #1
+	54b9  Alder Lake-N PCI Express Root Port #2
+	54ba  Alder Lake-N PCI Express Root Port #3
+	54bb  Alder Lake-N PCI Express Root Port #4
+	54be  Alder Lake-N PCI Express Root Port #7
 	54c8  Alder Lake-N PCH High Definition Audio Controller
 	54d3  Alder Lake-N SATA AHCI Controller
 	54e0  Alder Lake-N PCH HECI Controller
@@ -35334,6 +36366,8 @@
 	54f0  CNVi: Wi-Fi
 		8086 0244  Wi-Fi 6 AX101NGW
 	5502  Ethernet Controller (2) I225-LMvP
+		103c 87b9  Thunderbolt Dock G4 PCIe NIC
+		17aa 2303  ThinkPad Universal Thunderbolt 4 Dock PCIe NIC
 		1ab6 0225  TS4 On-Board 2.5GbE Ethernet Adaptor
 	5690  DG2 [Arc A770M]
 	5691  DG2 [Arc A730M]
@@ -35358,12 +36392,12 @@
 	56b1  DG2 [Arc Pro A40/A50]
 	56b2  DG2 [Arc Pro A60M]
 	56b3  DG2 [Arc Pro A60]
-	56ba  DG2 [Intel Graphics]
-	56bb  DG2 [Intel Graphics]
-	56bc  DG2 [Intel Graphics]
-	56bd  DG2 [Intel Graphics]
-	56be  DG2 [Arc Graphics A750E]
-	56bf  DG2 [Arc Graphics A580E]
+	56ba  DG2 [Arc A380E]
+	56bb  DG2 [Arc A310E]
+	56bc  DG2 [Arc A370E]
+	56bd  DG2 [Arc A350E]
+	56be  DG2 [Arc A750E]
+	56bf  DG2 [Arc A580E]
 	56c0  ATS-M [Data Center GPU Flex 170]
 	56c1  ATS-M [Data Center GPU Flex 140]
 	56c2  ATS-M [Data Center GPU Flex 170V]
@@ -35375,16 +36409,25 @@
 	5785  Thunderbolt USB Controller [Barlow Ridge Host 40G 2023]
 	5786  Thunderbolt 80/120G Bridge [Barlow Ridge Hub 80G 2023]
 	5787  Thunderbolt 80/120G USB Controller [Barlow Ridge Hub 80G 2023]
+	5795  Granite Rapids Chipset LPC Controller
 	579c  Ethernet Connection E825-C for backplane
 	579d  Ethernet Connection E825-C for QSFP
 	579e  Ethernet Connection E825-C for SFP
+	579f  Ethernet Connection E825-C 10GbE
 	57a4  Thunderbolt Bridge [Barlow Ridge Hub 40G 2023]
 	57a5  Thunderbolt USB Controller [Barlow Ridge Hub 40G 2023]
+	57ad  E610 Virtual Function
 	57ae  Ethernet Controller E610 Backplane
 	57af  Ethernet Controller E610 SFP
 	57b0  Ethernet Controller E610 10GBASE T
+		8086 0001  Ethernet Network Adapter E610-XT4
+		8086 0002  Ethernet Network Adapter E610-XT2
+		8086 0003  Ethernet Network Adapter E610-XT4 for OCP 3.0
+		8086 0004  Ethernet Network Adapter E610-XT2 for OCP 3.0
 	57b1  Ethernet Controller E610 2.5GBASE T
 		8086 0000  Ethernet Converged Network Adapter E610
+		8086 0002  Ethernet Network Adapter E610-IT4
+		8086 0003  Ethernet Network Adapter E610-IT4 for OCP 3.0
 	57b2  Ethernet Controller E610 SGMII
 	5845  QEMU NVM Express Controller
 		1af4 1100  QEMU Virtual Machine
@@ -35418,6 +36461,7 @@
 		17aa 2248  ThinkPad T570
 		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	5917  UHD Graphics 620
+		17aa 225d  ThinkPad T480 (20L5)
 		17aa 225e  ThinkPad T480
 	5918  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 	591b  HD Graphics 630
@@ -35467,7 +36511,7 @@
 	5af0  Celeron N3350/Pentium N4200/Atom E3900 Series Host Bridge
 	6420  Lunar Lake [Intel Graphics]
 	643e  Lunar Lake NPU
-	64a0  Lunar Lake [Intel Graphics]
+	64a0  Lunar Lake [Intel Arc Graphics 130V / 140V]
 	64b0  Lunar Lake [Intel Graphics]
 	65c0  5100 Chipset Memory Controller Hub
 	65e2  5100 Chipset PCI Express x4 Port 2
@@ -35750,6 +36794,18 @@
 	7601  82372FB PIIX5 IDE
 	7602  82372FB PIIX5 USB
 	7603  82372FB PIIX5 SMBus
+	7725  Arrow Lake-H [PCH Serial IO UART Host Controller]
+	7726  Arrow Lake-H PCH Serial IO UART Host Controller]
+	7727  Arrow Lake-H [LPC/eSPI Controller]
+	7730  Arrow Lake-H [LPC/eSPI Controller]
+	7746  Arrow Lake-H [LPC/eSPI Controller]
+	7750  Arrow Lake-H [Serial IO I2C Host Controller]
+	7751  Arrow Lake-H [Serial IO I2C Host Controller]
+	7752  Arrow Lake-H [PCH Serial IO UART Host Controller]
+	7778  Arrow Lake-H [Serial IO I2C Host Controller]
+	7779  Arrow Lake-H [Serial IO I2C Host Controller]
+	777a  Arrow Lake-H [Serial IO I2C Host Controller]
+	777b  Arrow Lake-H [Serial IO I2C Host Controller]
 	7800  82740 (i740) AGP Graphics Accelerator
 		003d 0008  Starfighter AGP
 		003d 000b  Starfighter AGP
@@ -35781,7 +36837,7 @@
 		8086 0090  WiFi 6E AX211 160MHz
 # Unlike other PCH components. The eSPI controller is specific to each chipset model
 	7a84  Z690 Chipset LPC/eSPI Controller
-	7a85  Alder Lake-S PCH PCI Express Root Port #?????
+	7a85  LPC Controller/eSPI Controller (H670)
 	7aa3  Alder Lake-S PCH SMBus Controller
 	7aa4  Alder Lake-S PCH SPI Controller
 	7aa7  Alder Lake-S PCH Shared SRAM
@@ -35803,12 +36859,15 @@
 	7acf  Alder Lake-S PCH Serial IO I2C Controller #3
 	7ad0  Alder Lake-S HD Audio Controller
 	7ae0  Alder Lake-S PCH USB 3.2 Gen 2x2 XHCI Controller
+	7ae1  Alder Lake-S PCH USB 3.2 Gen 1x1 xDCI Controller
 	7ae2  Alder Lake-S PCH SATA Controller [AHCI Mode]
 	7ae8  Alder Lake-S PCH HECI Controller #1
+	7aeb  Alder Lake-S Keyboard and Text (KT) Redirection
 	7af0  Alder Lake-S PCH CNVi WiFi
 		8086 0034  Wireless-AC 9560
 		8086 0070  Wi-Fi 6 AX201 160MHz
 		8086 0094  Wi-Fi 6 AX201 160MHz
+	7af8  Alder Lake-S Integrated Sensor Hub
 	7afc  Alder Lake-S PCH Serial IO I2C Controller #4
 	7afd  Alder Lake-S PCH Serial IO I2C Controller #5
 	7d03  Meteor Lake-P Dynamic Tuning Technology
@@ -35822,7 +36881,7 @@
 	7d51  Arrow Lake-P [Intel Graphics]
 	7d55  Meteor Lake-P [Intel Arc Graphics]
 	7d60  Meteor Lake-M [Intel Graphics]
-	7d67  Arrow Lake-U [Intel Graphics]
+	7d67  Arrow Lake-S [Intel Graphics]
 	7dd1  Arrow Lake-P [Intel Graphics]
 	7dd5  Meteor Lake-P [Intel Graphics]
 	7e01  Meteor Lake-P LPC/eSPI Controller
@@ -35858,6 +36917,8 @@
 	7ec5  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #1
 	7ec6  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #2
 	7ec7  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #3
+	7f70  Arrow Lake-S PCH CNVi WiFi
+		8086 0094  WiFi 6E AX211 160MHz
 	8002  Trusted Execution Technology Registers
 	8003  Trusted Execution Technology Registers
 	8100  US15W/US15X SCH [Poulsbo] Host Bridge
@@ -36117,6 +37178,7 @@
 	8cc6  H97 Chipset LPC Controller
 	8d00  C610/X99 series chipset 4-port SATA Controller [IDE mode]
 	8d02  C610/X99 series chipset 6-Port SATA Controller [AHCI mode]
+		15d9 0821  X10DRW-i
 	8d04  C610/X99 series chipset SATA Controller [RAID mode]
 	8d06  C610/X99 series chipset SATA Controller [RAID mode]
 		17aa 1031  ThinkServer RAID 110i
@@ -36141,19 +37203,26 @@
 	8d20  C610/X99 series chipset HD Audio Controller
 	8d21  C610/X99 series chipset HD Audio Controller
 	8d22  C610/X99 series chipset SMBus Controller
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d24  C610/X99 series chipset Thermal Subsystem
+		15d9 0821  X10DRW-i
 	8d26  C610/X99 series chipset USB Enhanced Host Controller #1
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d2d  C610/X99 series chipset USB Enhanced Host Controller #2
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d31  C610/X99 series chipset USB xHCI Host Controller
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d33  C610/X99 series chipset LAN Controller
 	8d34  C610/X99 series chipset NAND Controller
 	8d3a  C610/X99 series chipset MEI Controller #1
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d3b  C610/X99 series chipset MEI Controller #2
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d3c  C610/X99 series chipset IDE-r Controller
 	8d3d  C610/X99 series chipset KT Controller
@@ -36162,6 +37231,7 @@
 	8d42  C610/X99 series chipset LPC Controller
 	8d43  C610/X99 series chipset LPC Controller
 	8d44  C610/X99 series chipset LPC Controller
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d45  C610/X99 series chipset LPC Controller
 	8d46  C610/X99 series chipset LPC Controller
@@ -36176,11 +37246,13 @@
 	8d4f  C610/X99 series chipset LPC Controller
 	8d60  C610/X99 series chipset sSATA Controller [IDE mode]
 	8d62  C610/X99 series chipset sSATA Controller [AHCI mode]
+		15d9 0821  X10DRW-i
 	8d64  C610/X99 series chipset sSATA Controller [RAID mode]
 	8d66  C610/X99 series chipset sSATA Controller [RAID mode]
 	8d68  C610/X99 series chipset sSATA Controller [IDE mode]
 	8d6e  C610/X99 series chipset sSATA Controller [RAID mode]
 	8d7c  C610/X99 series chipset SPSR
+		15d9 0821  X10DRW-i
 		15d9 0832  X10SRL-F
 	8d7d  C610/X99 series chipset MS SMBus 0
 	8d7e  C610/X99 series chipset MS SMBus 1
@@ -36196,22 +37268,29 @@
 	9840  Lakefield GT2 [UHD Graphics]
 	9841  Lakefield GT1.5 [UHD Graphics]
 	9a01  11th Gen Core Processor PCIe Controller #1
+	9a02  Tiger Lake-UP4 2 cores Host Bridge/DRAM Registers
 	9a03  TigerLake-LP Dynamic Tuning Processor Participant
+	9a04  Tiger Lake-UP3 2 cores Host Bridge/DRAM Registers
+	9a05  11th Gen Core Processor PCIe Controller #2
+	9a07  11th Gen Core Processor PCIe Controller #3
 	9a09  11th Gen Core Processor PCIe Controller
 	9a0b  Volume Management Device NVMe RAID Controller
 	9a0d  Tigerlake Telemetry Aggregator Driver
 	9a0f  11th Gen Core Processor PCIe Controller #0
 	9a11  GNA Scoring Accelerator module
+	9a12  Tiger Lake-UP4 4 cores Host Bridge/DRAM Registers
 	9a13  Tiger Lake-LP Thunderbolt 4 USB Controller
-	9a14  11th Gen Core Processor Host Bridge/DRAM Registers
+	9a14  Tiger Lake-UP3/H35 4 cores Host Bridge/DRAM Registers
+	9a15  Tiger Lake xDCI Controller
 	9a17  Tiger Lake-H Thunderbolt 4 USB Controller
+	9a19  Tiger Lake IPU6
 	9a1b  Tiger Lake-LP Thunderbolt 4 NHI #0
 	9a1d  Tiger Lake-LP Thunderbolt 4 NHI #1
 	9a1f  Tiger Lake-H Thunderbolt 4 NHI #0
 	9a21  Tiger Lake-H Thunderbolt 4 NHI #1
 	9a23  Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #0
 	9a25  Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #1
-	9a26  11th Gen Core Processor Host Bridge/DRAM Registers
+	9a26  Tiger Lake-H 6 cores Host Bridge/DRAM Registers
 	9a27  Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #2
 	9a29  Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #3
 	9a2b  Tiger Lake-H Thunderbolt 4 PCI Express Root Port #0
@@ -36219,7 +37298,8 @@
 	9a2f  Tiger Lake-H Thunderbolt 4 PCI Express Root Port #2
 	9a31  Tiger Lake-H Thunderbolt 4 PCI Express Root Port #3
 	9a33  Tiger Lake Trace Hub
-	9a36  11th Gen Core Processor Host Bridge/DRAM Registers
+	9a36  Tiger Lake-H 8 cores Host Bridge/DRAM Registers
+	9a39  Tiger Lake H IPU6-Slim
 	9a40  Tiger Lake-UP4 GT2 [Iris Xe Graphics]
 	9a49  TigerLake-LP GT2 [Iris Xe Graphics]
 	9a60  TigerLake-H GT1 [UHD Graphics]
@@ -36926,6 +38006,7 @@
 		1028 0c06  Precision 3580
 	a71e  Raptor Lake-P Thunderbolt 4 USB Controller
 		1028 0c06  Precision 3580
+	a71f  Raptor Lake-P Thunderbolt 4 PCI Express Root Port #1
 	a720  Raptor Lake-P [UHD Graphics]
 	a721  Raptor Lake-P [UHD Graphics]
 	a72f  Raptor Lake-P Thunderbolt 4 PCI Express Root Port #2
@@ -36935,6 +38016,7 @@
 	a74d  Raptor Lake PCIe 4.0 Graphics Port
 	a74f  GNA Scoring Accelerator module
 		1028 0c06  Precision 3580
+	a75d  Raptor Lake IPU
 	a76d  Raptor Lake-P Thunderbolt 4 NHI #1
 	a76e  Raptor Lake-P Thunderbolt 4 PCI Express Root Port #0
 	a77d  Raptor Lake Crashlog and Telemetry
@@ -36975,6 +38057,7 @@
 	a83b  Lunar Lake-M PCI Express Root Port #4
 	a83c  Lunar Lake-M PCI Express Root Port #5
 	a83d  Lunar Lake-M PCI Express Root Port #6
+	a840  BE201 320MHz
 	a845  Lunar Lake-M Integrated Sensor Hub
 	a847  Lunar Lake-M UFS Controller
 	a84e  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #0
@@ -36989,6 +38072,14 @@
 	ad0b  Volume Management Device NVMe RAID Controller Intel Corporation
 	ad1d  Arrow Lake NPU
 	b03e  Panther Lake NPU
+	b080  Panther Lake [Intel Graphics]
+	b081  Panther Lake [Intel Graphics]
+	b082  Panther Lake [Intel Graphics]
+	b083  Panther Lake [Intel Graphics]
+	b08f  Panther Lake [Intel Graphics]
+	b090  Panther Lake [Intel Graphics]
+	b0a0  Panther Lake [Intel Graphics]
+	b0b0  Panther Lake [Intel Graphics]
 	b152  21152 PCI-to-PCI Bridge
 		8086 b152  21152 PCI-to-PCI Bridge
 # observed, and documented in Intel revision note; new mask of 1011:0026
@@ -37000,6 +38091,7 @@
 		4c53 1050  CT7 mainboard
 		4c53 1051  CE7 mainboard
 		e4bf 1000  CC8-1-BLUES
+	b640  Arrow Lake-H [Intel Graphics]
 	d130  Core Processor DMI
 		15d9 0605  X8SIL
 	d131  Core Processor DMI
@@ -37026,10 +38118,13 @@
 	d157  Core Processor System Control and Status Registers
 	d158  Core Processor Miscellaneous Registers
 	e202  Battlemage G21 [Intel Graphics]
-	e20b  Battlemage G21 [Intel Graphics]
-	e20c  Battlemage G21 [Intel Graphics]
+	e20b  Battlemage G21 [Arc B580]
+	e20c  Battlemage G21 [Arc B570]
 	e20d  Battlemage G21 [Intel Graphics]
+	e210  Battlemage G21 [Intel Graphics]
 	e212  Battlemage G21 [Intel Graphics]
+	e215  Battlemage G21 [Intel Graphics]
+	e216  Battlemage G21 [Intel Graphics]
 	f1a5  SSD 600P Series
 		8086 390a  SSDPEKKW256G7 256GB
 	f1a6  SSD DC P4101/Pro 7600p/760p/E 6100p Series
@@ -37107,6 +38202,7 @@
 		4c52 1002  LRES1002PF Dual-port 10Gb Ethernet Server Adapter
 		4c52 1003  LRES1003PF Single-port 10Gb Ethernet Server Adapter
 		4c52 3001  LRES3001PF Dual-port 10Gb Ethernet Server Adapter for OCP
+		4c52 8005  LRES8005PF Dual-port 10Gb Ethernet Bypass Network Adapter
 		8088 0000  Ethernet Network Adaptor RP1000 for 10GbE SFP+
 		8088 0300  Ethernet Network Adaptor RP1000-A03 for 10GbE SFP+
 		8088 0400  Ethernet Network Adaptor RP1000-A04 for 10GbE SFP+
@@ -37115,6 +38211,10 @@
 		8088 2000  Ethernet Network Adaptor RP2000 for 10GbE SFP+
 		8088 2300  Ethernet Network Adaptor RP2000-A03 for 10GbE SFP+
 		8088 2400  Ethernet Network Adaptor RP2000-A04 for 10GbE SFP+
+	5025  Ethernet Controller WX5025 for 25GbE SFP28
+		8088 1000  Dual-Port Ethernet Network Adapter FF5025-DDATACXX
+	5125  Ethernet Controller WX5025AL for 25GbE SFP28
+		8088 3000  Dual-Port Ethernet Network Adapter FF5025-DDATAIXX
 80ee  InnoTek Systemberatung GmbH
 	beef  VirtualBox Graphics Adapter
 	cafe  VirtualBox Guest Service
@@ -37131,6 +38231,7 @@
 		8510 0007  GB2062-PCIe-C40
 		8510 0008  CQ2040-MXM-M60
 		8510 0009  GB2062-PCIe-C20
+		8510 000b  GB2062-PCIe-HIEILP42
 		8510 000c  CQ2040-PUB
 		8510 0201  GB2062-PUB-DDR
 # nee ScaleMP
@@ -37181,6 +38282,7 @@
 8e0e  Computone Corporation
 8e2e  KTI
 	3000  ET32P2
+9000  C*Core Technology Co., Ltd.
 9004  Adaptec
 	0078  AHA-2940U_CN
 	1078  AIC-7810
@@ -37565,6 +38667,9 @@
 		1d49 0621  ThinkSystem RAID 9350-8i 2GB Flash PCIe 12Gb Internal Adapter
 		1d49 0622  ThinkSystem RAID 9350-16i 4GB Flash PCIe 12Gb Adapter
 		1d49 0623  ThinkSystem RAID 9350-16i 4GB Flash PCIe 12Gb Internal Adapter
+		1f3f 0610  3S610-8i, SAS/SATA 12Gb HBA
+		207d 4140  TrustRAID D3152s-8i
+		207d 4240  TrustRAID D3154s-8i
 		9005 0608  SmartRAID 3162-8i /e
 		9005 0800  SmartRAID 3154-8i
 		9005 0801  SmartRAID 3152-8i
@@ -37750,6 +38855,8 @@
 	1501  STAR1500C NVMe SSD
 	1502  STAR1500E NVMe SSD
 	1504  STAR1500L NVMe SSD
+# NVMe Gen5 Controller 16ch
+	1516  STAR1516 PCIe NVMe SSD Controller
 	2000  STAR2000 NVMe Controller
 	2001  STAR2000E NVMe SSD
 	2002  STAR2000C NVMe SSD
@@ -37806,6 +38913,7 @@ b100  OpenVox Communication Co. Ltd.
 b10b  Uakron PCI Project
 b1b3  Shiva Europe Limited
 b1d9  ATCOM Technology co., LTD.
+b390  TD3-X3+
 # Pinnacle should be 11bd, but they got it wrong several times --mj
 bd11  Pinnacle Systems, Inc. (Wrong ID)
 bdbd  Blackmagic Design
@@ -37854,7 +38962,10 @@ c0a9  Micron/Crucial Technology
 	5412  P5 NVMe PCIe SSD[SlashP5]
 	5415  T500 NVMe PCIe SSD
 	5419  T700 NVMe PCIe SSD
+	5420  P3 NVMe PCIe SSD (DRAM-less)
 	5421  P3 Plus NVMe PCIe SSD (DRAM-less)
+	5426  P310 NVMe PCIe SSD (DRAM-less)
+	542b  T705 NVMe PCIe SSD
 c0de  Motorola
 c0fe  Motion Engineering, Inc.
 ca01  I-TEK OptoElectronics Co., LTD.
@@ -37868,7 +38979,8 @@ cace  CACE Technologies, Inc.
 	0002  TurboCap Port B
 	0023  AirPcap N
 caed  Canny Edge
-cafe  Chrysalis-ITS
+# nee Chrysalis-ITS
+cafe  Thales
 	0003  Luna K3 Hardware Security Module
 	0006  Luna PCI-e 3000 Hardware Security Module
 	0007  Luna K6 Hardware Security Module
@@ -37929,25 +39041,19 @@ d209  Ultimarc
 	15a2  SpinTrak
 	1601  AimTrak
 d20c  Chengdu BeiZhongWangXin Technology Co., Ltd.
-	5010  NE5000 Ethernet Controller
 	5011  NE5000 Ethernet Controller
+		d20c e120  N5 Series 2-port 10GbE Network Adapter
+		d20c e140  N5 Series 4-port 10GbE Network Adapter
 		d20c e220  N5 Series 2-port 25GbE Network Adapter
 		d20c e221  N5S Series 2-port 25GbE Network Adapter
 		d20c e22c  N5 Series 2-port 25GbE Network Adapter for OCP
-		d20c e22d  N5S Series 2-port 25GbE Network Adapter for OCP
-	6010  NE6000 Ethernet Controller
 	6011  NE6000 Ethernet Controller
-		d20c a141  N6S Series 4-port 10GbE Network Adapter
-		d20c a221  N6S Series 2-port 25GbE Network Adapter
-		d20c a241  N6S Series 4-port 25GbE Network Adapter
-		d20c a421  N6S Series 2-port 40GbE Network Adapter
-		d20c aa21  N6S Series 2-port 100GbE Network Adapter
-		d20c d221  N6S Series 2-port 25GbE Network Adapter with DPI
-		d20c da21  N6S Series 2-port 100GbE Network Adapter with DPI
-		d20c ea20  N6 Series 2-port 100GbE Network Adapter
+		d20c a001  N6S Series Network Adapter
+		d20c e221  N6S Series 2-port 25GbE Network Adapter
+		d20c e281  N6S Series 8-port 25GbE Network Adapter
+		d20c e421  N6S Series 2-port 40GbE Network Adapter
 		d20c ea21  N6S Series 2-port 100GbE Network Adapter
-		d20c ea2c  N6 Series 2-port 100GbE Network Adapter for OCP
-		d20c ea2d  N6S Series 2-port 100GbE Network Adapter for OCP
+d405  LeapIO
 d4d4  Dy4 Systems Inc
 	0601  PCI Mezzanine Card
 d531  I+ME ACTIA GmbH
@@ -37998,6 +39104,7 @@ dd01  Digital Devices GmbH
 	0011  Octopus CI DVB Adapter
 		dd01 0040  Octopus CI
 		dd01 0041  Octopus CI Single
+	0012  Octopus Duo CI
 	0201  Resi DVB-C Modulator
 		dd01 0001  Resi DVB-C Modulator
 dead  Indigita Corporation
@@ -38165,6 +39272,9 @@ f1d0  AJA Video
 	eb25  Corvid 44 12g
 	eb26  T-Tap Pro
 	eb27  IoX3
+	eb28  Kona XM
+	eb29  Kona X
+	eb30  Kona IP 25G
 	efac  Xena SD-MM/SD-22-MM
 	facd  Xena HD-MM
 f5f5  F5 Networks, Inc.

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/pciids/pciids.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/pciids/pciids.go
@@ -396,7 +396,7 @@ func (p *parser) parse() Interface {
 			hkClass = db.classes[uint32(id)]
 
 			hkFullID = uint32(id) << 16
-			hkFullID = hkFullID & 0xFFFF0000
+			hkFullID &= 0xFFFF0000
 			hkFullName[0] = fmt.Sprintf("%s (%02x)", lit.name, id)
 		}
 
@@ -408,11 +408,11 @@ func (p *parser) parse() Interface {
 			}
 			hkSubClass = hkClass.subClasses[uint32(id)]
 
-			// Clear the last detected sub class.
-			hkFullID = hkFullID & 0xFFFF0000
-			hkFullID = hkFullID | uint32(id)<<8
+			// Clear the last detected subclass.
+			hkFullID &= 0xFFFF0000
+			hkFullID |= uint32(id) << 8
 			// Clear the last detected prog iface.
-			hkFullID = hkFullID & 0xFFFFFF00
+			hkFullID &= 0xFFFFFF00
 			hkFullName[1] = fmt.Sprintf("%s (%02x)", lit.name, id)
 
 			db.classes[uint32(hkFullID)] = class{

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare.go
@@ -7,10 +7,13 @@ import (
 	"time"
 )
 
-type CompareType int
+// Deprecated: CompareType has only ever been for internal use and has accidentally been published since v1.6.0. Do not use it.
+type CompareType = compareResult
+
+type compareResult int
 
 const (
-	compareLess CompareType = iota - 1
+	compareLess compareResult = iota - 1
 	compareEqual
 	compareGreater
 )
@@ -39,7 +42,7 @@ var (
 	bytesType = reflect.TypeOf([]byte{})
 )
 
-func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
+func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
 	obj1Value := reflect.ValueOf(obj1)
 	obj2Value := reflect.ValueOf(obj2)
 
@@ -325,7 +328,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 				timeObj2 = obj2Value.Convert(timeType).Interface().(time.Time)
 			}
 
-			return compare(timeObj1.UnixNano(), timeObj2.UnixNano(), reflect.Int64)
+			if timeObj1.Before(timeObj2) {
+				return compareLess, true
+			}
+			if timeObj1.Equal(timeObj2) {
+				return compareEqual, true
+			}
+			return compareGreater, true
 		}
 	case reflect.Slice:
 		{
@@ -345,7 +354,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 				bytesObj2 = obj2Value.Convert(bytesType).Interface().([]byte)
 			}
 
-			return CompareType(bytes.Compare(bytesObj1, bytesObj2)), true
+			return compareResult(bytes.Compare(bytesObj1, bytesObj2)), true
 		}
 	case reflect.Uintptr:
 		{
@@ -381,7 +390,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -394,7 +403,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Less asserts that the first element is less than the second
@@ -406,7 +415,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -419,7 +428,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Positive asserts that the specified element is positive
@@ -431,7 +440,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
+	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
 }
 
 // Negative asserts that the specified element is negative
@@ -443,10 +452,10 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
+	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
-func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -469,7 +478,7 @@ func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedCompare
 	return true
 }
 
-func containsValue(values []CompareType, value CompareType) bool {
+func containsValue(values []compareResult, value compareResult) bool {
 	for _, v := range values {
 		if v == value {
 			return true

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go
@@ -104,8 +104,8 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 	return EqualExportedValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
-// EqualValuesf asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
 //	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
@@ -186,7 +186,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 //	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -568,6 +568,23 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 	return NotContains(t, s, contains, append([]interface{}{msg}, args...)...)
 }
 
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// assert.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotElementsMatch(t, listA, listB, append([]interface{}{msg}, args...)...)
+}
+
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
@@ -604,7 +621,16 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 	return NotEqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -186,8 +186,8 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 	return EqualExportedValuesf(a.t, expected, actual, msg, args...)
 }
 
-// EqualValues asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
 //	a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
@@ -197,8 +197,8 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-// EqualValuesf asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
 //	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
@@ -336,7 +336,7 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 //	a.EventuallyWithT(func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -361,7 +361,7 @@ func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor 
 //	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1128,6 +1128,40 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 	return NotContainsf(a.t, s, contains, msg, args...)
 }
 
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
+func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
@@ -1200,7 +1234,25 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	return NotEqualf(a.t, expected, actual, msg, args...)
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAsf(a.t, err, target, msg, args...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
@@ -1209,7 +1261,7 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 	return NotErrorIs(a.t, err, target, msgAndArgs...)
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {

--- a/vendor/github.com/stretchr/testify/assert/assertion_order.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_order.go
@@ -6,7 +6,7 @@ import (
 )
 
 // isOrdered checks that collection contains orderable elements.
-func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+func isOrdered(t TestingT, object interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
 	objKind := reflect.TypeOf(object).Kind()
 	if objKind != reflect.Slice && objKind != reflect.Array {
 		return false
@@ -50,7 +50,7 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 //	assert.IsIncreasing(t, []float{1, 2})
 //	assert.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // IsNonIncreasing asserts that the collection is not increasing
@@ -59,7 +59,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonIncreasing(t, []float{2, 1})
 //	assert.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // IsDecreasing asserts that the collection is decreasing
@@ -68,7 +68,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	assert.IsDecreasing(t, []float{2, 1})
 //	assert.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // IsNonDecreasing asserts that the collection is not decreasing
@@ -77,5 +77,5 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonDecreasing(t, []float{1, 2})
 //	assert.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pmezard/go-difflib/difflib"
-	"gopkg.in/yaml.v3"
+
+	// Wrapper around gopkg.in/yaml.v3
+	"github.com/stretchr/testify/assert/yaml"
 )
 
 //go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_format.go.tmpl"
@@ -44,6 +46,10 @@ type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
 // ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
+
+// PanicAssertionFunc is a common function prototype when validating a panic value.  Can be useful
+// for table driven tests.
+type PanicAssertionFunc = func(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool
 
 // Comparison is a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
@@ -496,7 +502,13 @@ func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) b
 		h.Helper()
 	}
 
-	if !samePointers(expected, actual) {
+	same, ok := samePointers(expected, actual)
+	if !ok {
+		return Fail(t, "Both arguments must be pointers", msgAndArgs...)
+	}
+
+	if !same {
+		// both are pointers but not the same type & pointing to the same address
 		return Fail(t, fmt.Sprintf("Not same: \n"+
 			"expected: %p %#v\n"+
 			"actual  : %p %#v", expected, expected, actual, actual), msgAndArgs...)
@@ -516,7 +528,13 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 		h.Helper()
 	}
 
-	if samePointers(expected, actual) {
+	same, ok := samePointers(expected, actual)
+	if !ok {
+		//fails when the arguments are not pointers
+		return !(Fail(t, "Both arguments must be pointers", msgAndArgs...))
+	}
+
+	if same {
 		return Fail(t, fmt.Sprintf(
 			"Expected and actual point to the same object: %p %#v",
 			expected, expected), msgAndArgs...)
@@ -524,21 +542,23 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	return true
 }
 
-// samePointers compares two generic interface objects and returns whether
-// they point to the same object
-func samePointers(first, second interface{}) bool {
+// samePointers checks if two generic interface objects are pointers of the same
+// type pointing to the same object. It returns two values: same indicating if
+// they are the same type and point to the same object, and ok indicating that
+// both inputs are pointers.
+func samePointers(first, second interface{}) (same bool, ok bool) {
 	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
 	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {
-		return false
+		return false, false //not both are pointers
 	}
 
 	firstType, secondType := reflect.TypeOf(first), reflect.TypeOf(second)
 	if firstType != secondType {
-		return false
+		return false, true // both are pointers, but of different types
 	}
 
 	// compare pointer addresses
-	return first == second
+	return first == second, true
 }
 
 // formatUnequalValues takes two values of arbitrary types and returns string
@@ -572,8 +592,8 @@ func truncatingFormat(data interface{}) string {
 	return value
 }
 
-// EqualValues asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
 //	assert.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
@@ -613,21 +633,6 @@ func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ..
 
 	if aType != bType {
 		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
-	}
-
-	if aType.Kind() == reflect.Ptr {
-		aType = aType.Elem()
-	}
-	if bType.Kind() == reflect.Ptr {
-		bType = bType.Elem()
-	}
-
-	if aType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct or pointer to struct \n\t%v != %v", aType.Kind(), reflect.Struct), msgAndArgs...)
-	}
-
-	if bType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct or pointer to struct \n\t%v != %v", bType.Kind(), reflect.Struct), msgAndArgs...)
 	}
 
 	expected = copyExportedFields(expected)
@@ -1170,6 +1175,39 @@ func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) stri
 	return msg.String()
 }
 
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// assert.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+func NotElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if isEmpty(listA) && isEmpty(listB) {
+		return Fail(t, "listA and listB contain the same elements", msgAndArgs)
+	}
+
+	if !isList(t, listA, msgAndArgs...) {
+		return Fail(t, "listA is not a list type", msgAndArgs...)
+	}
+	if !isList(t, listB, msgAndArgs...) {
+		return Fail(t, "listB is not a list type", msgAndArgs...)
+	}
+
+	extraA, extraB := diffLists(listA, listB)
+	if len(extraA) == 0 && len(extraB) == 0 {
+		return Fail(t, "listA and listB contain the same elements", msgAndArgs)
+	}
+
+	return true
+}
+
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
@@ -1488,6 +1526,9 @@ func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAnd
 	if err != nil {
 		return Fail(t, err.Error(), msgAndArgs...)
 	}
+	if math.IsNaN(actualEpsilon) {
+		return Fail(t, "relative error is NaN", msgAndArgs...)
+	}
 	if actualEpsilon > epsilon {
 		return Fail(t, fmt.Sprintf("Relative error is too high: %#v (expected)\n"+
 			"        < %#v (actual)", epsilon, actualEpsilon), msgAndArgs...)
@@ -1611,7 +1652,6 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 
 // matchRegexp return true if a specified regexp matches a string.
 func matchRegexp(rx interface{}, str interface{}) bool {
-
 	var r *regexp.Regexp
 	if rr, ok := rx.(*regexp.Regexp); ok {
 		r = rr
@@ -1619,7 +1659,14 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 		r = regexp.MustCompile(fmt.Sprint(rx))
 	}
 
-	return (r.FindStringIndex(fmt.Sprint(str)) != nil)
+	switch v := str.(type) {
+	case []byte:
+		return r.Match(v)
+	case string:
+		return r.MatchString(v)
+	default:
+		return r.MatchString(fmt.Sprint(v))
+	}
 
 }
 
@@ -1872,7 +1919,7 @@ var spewConfigStringerEnabled = spew.ConfigState{
 	MaxDepth:                10,
 }
 
-type tHelper interface {
+type tHelper = interface {
 	Helper()
 }
 
@@ -1911,6 +1958,9 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 
 // CollectT implements the TestingT interface and collects all errors.
 type CollectT struct {
+	// A slice of errors. Non-nil slice denotes a failure.
+	// If it's non-nil but len(c.errors) == 0, this is also a failure
+	// obtained by direct c.FailNow() call.
 	errors []error
 }
 
@@ -1919,9 +1969,10 @@ func (c *CollectT) Errorf(format string, args ...interface{}) {
 	c.errors = append(c.errors, fmt.Errorf(format, args...))
 }
 
-// FailNow panics.
-func (*CollectT) FailNow() {
-	panic("Assertion failed")
+// FailNow stops execution by calling runtime.Goexit.
+func (c *CollectT) FailNow() {
+	c.fail()
+	runtime.Goexit()
 }
 
 // Deprecated: That was a method for internal usage that should not have been published. Now just panics.
@@ -1932,6 +1983,16 @@ func (*CollectT) Reset() {
 // Deprecated: That was a method for internal usage that should not have been published. Now just panics.
 func (*CollectT) Copy(TestingT) {
 	panic("Copy() is deprecated")
+}
+
+func (c *CollectT) fail() {
+	if !c.failed() {
+		c.errors = []error{} // Make it non-nil to mark a failure.
+	}
+}
+
+func (c *CollectT) failed() bool {
+	return c.errors != nil
 }
 
 // EventuallyWithT asserts that given condition will be met in waitFor time,
@@ -1951,14 +2012,14 @@ func (*CollectT) Copy(TestingT) {
 //	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 
 	var lastFinishedTickErrs []error
-	ch := make(chan []error, 1)
+	ch := make(chan *CollectT, 1)
 
 	timer := time.NewTimer(waitFor)
 	defer timer.Stop()
@@ -1978,16 +2039,16 @@ func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time
 			go func() {
 				collect := new(CollectT)
 				defer func() {
-					ch <- collect.errors
+					ch <- collect
 				}()
 				condition(collect)
 			}()
-		case errs := <-ch:
-			if len(errs) == 0 {
+		case collect := <-ch:
+			if !collect.failed() {
 				return true
 			}
 			// Keep the errors from the last ended condition, so that they can be copied to t if timeout is reached.
-			lastFinishedTickErrs = errs
+			lastFinishedTickErrs = collect.errors
 			tick = ticker.C
 		}
 	}
@@ -2049,7 +2110,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 	), msgAndArgs...)
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
@@ -2086,6 +2147,24 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
 		"expected: %q\n"+
+		"in chain: %s", target, chain,
+	), msgAndArgs...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !errors.As(err, target) {
+		return true
+	}
+
+	chain := buildErrorChainString(err)
+
+	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
+		"found: %q\n"+
 		"in chain: %s", target, chain,
 	), msgAndArgs...)
 }

--- a/vendor/github.com/stretchr/testify/assert/yaml/yaml_custom.go
+++ b/vendor/github.com/stretchr/testify/assert/yaml/yaml_custom.go
@@ -1,0 +1,25 @@
+//go:build testify_yaml_custom && !testify_yaml_fail && !testify_yaml_default
+// +build testify_yaml_custom,!testify_yaml_fail,!testify_yaml_default
+
+// Package yaml is an implementation of YAML functions that calls a pluggable implementation.
+//
+// This implementation is selected with the testify_yaml_custom build tag.
+//
+//	go test -tags testify_yaml_custom
+//
+// This implementation can be used at build time to replace the default implementation
+// to avoid linking with [gopkg.in/yaml.v3].
+//
+// In your test package:
+//
+//		import assertYaml "github.com/stretchr/testify/assert/yaml"
+//
+//		func init() {
+//			assertYaml.Unmarshal = func (in []byte, out interface{}) error {
+//				// ...
+//	     			return nil
+//			}
+//		}
+package yaml
+
+var Unmarshal func(in []byte, out interface{}) error

--- a/vendor/github.com/stretchr/testify/assert/yaml/yaml_default.go
+++ b/vendor/github.com/stretchr/testify/assert/yaml/yaml_default.go
@@ -1,0 +1,37 @@
+//go:build !testify_yaml_fail && !testify_yaml_custom
+// +build !testify_yaml_fail,!testify_yaml_custom
+
+// Package yaml is just an indirection to handle YAML deserialization.
+//
+// This package is just an indirection that allows the builder to override the
+// indirection with an alternative implementation of this package that uses
+// another implementation of YAML deserialization. This allows to not either not
+// use YAML deserialization at all, or to use another implementation than
+// [gopkg.in/yaml.v3] (for example for license compatibility reasons, see [PR #1120]).
+//
+// Alternative implementations are selected using build tags:
+//
+//   - testify_yaml_fail: [Unmarshal] always fails with an error
+//   - testify_yaml_custom: [Unmarshal] is a variable. Caller must initialize it
+//     before calling any of [github.com/stretchr/testify/assert.YAMLEq] or
+//     [github.com/stretchr/testify/assert.YAMLEqf].
+//
+// Usage:
+//
+//	go test -tags testify_yaml_fail
+//
+// You can check with "go list" which implementation is linked:
+//
+//	go list -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//	go list -tags testify_yaml_fail -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//	go list -tags testify_yaml_custom -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//
+// [PR #1120]: https://github.com/stretchr/testify/pull/1120
+package yaml
+
+import goyaml "gopkg.in/yaml.v3"
+
+// Unmarshal is just a wrapper of [gopkg.in/yaml.v3.Unmarshal].
+func Unmarshal(in []byte, out interface{}) error {
+	return goyaml.Unmarshal(in, out)
+}

--- a/vendor/github.com/stretchr/testify/assert/yaml/yaml_fail.go
+++ b/vendor/github.com/stretchr/testify/assert/yaml/yaml_fail.go
@@ -1,0 +1,18 @@
+//go:build testify_yaml_fail && !testify_yaml_custom && !testify_yaml_default
+// +build testify_yaml_fail,!testify_yaml_custom,!testify_yaml_default
+
+// Package yaml is an implementation of YAML functions that always fail.
+//
+// This implementation can be used at build time to replace the default implementation
+// to avoid linking with [gopkg.in/yaml.v3]:
+//
+//	go test -tags testify_yaml_fail
+package yaml
+
+import "errors"
+
+var errNotImplemented = errors.New("YAML functions are not available (see https://pkg.go.dev/github.com/stretchr/testify/assert/yaml)")
+
+func Unmarshal([]byte, interface{}) error {
+	return errNotImplemented
+}

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -34,9 +34,9 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Contains(t, "Hello World", "World")
-//	assert.Contains(t, ["Hello", "World"], "World")
-//	assert.Contains(t, {"Hello": "World"}, "Hello")
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -50,9 +50,9 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -91,7 +91,7 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
 // the number of appearances of each of them in both lists should match.
 //
-// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+// require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -106,7 +106,7 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
 // the number of appearances of each of them in both lists should match.
 //
-// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+// require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -120,7 +120,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	assert.Empty(t, obj)
+//	require.Empty(t, obj)
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -134,7 +134,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	assert.Emptyf(t, obj, "error message %s", "formatted")
+//	require.Emptyf(t, obj, "error message %s", "formatted")
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -147,7 +147,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // Equal asserts that two objects are equal.
 //
-//	assert.Equal(t, 123, 123)
+//	require.Equal(t, 123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -166,7 +166,7 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 // and that it is equal to the provided error.
 //
 //	actualObj, err := SomeFunction()
-//	assert.EqualError(t, err,  expectedErrorString)
+//	require.EqualError(t, err,  expectedErrorString)
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -181,7 +181,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 // and that it is equal to the provided error.
 //
 //	actualObj, err := SomeFunction()
-//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -200,8 +200,8 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //		Exported     	int
 //		notExported   	int
 //	 }
-//	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
-//	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -220,8 +220,8 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 //		Exported     	int
 //		notExported   	int
 //	 }
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -232,10 +232,10 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 	t.FailNow()
 }
 
-// EqualValues asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
-//	assert.EqualValues(t, uint32(123), int32(123))
+//	require.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -246,10 +246,10 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 	t.FailNow()
 }
 
-// EqualValuesf asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
-//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -262,7 +262,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Equalf asserts that two objects are equal.
 //
-//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//	require.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -280,8 +280,8 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.Error(t, err) {
-//		   assert.Equal(t, expectedError, err)
+//	  if require.Error(t, err) {
+//		   require.Equal(t, expectedError, err)
 //	  }
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -321,7 +321,7 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // and that the error contains the specified substring.
 //
 //	actualObj, err := SomeFunction()
-//	assert.ErrorContains(t, err,  expectedErrorSubString)
+//	require.ErrorContains(t, err,  expectedErrorSubString)
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -336,7 +336,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 // and that the error contains the specified substring.
 //
 //	actualObj, err := SomeFunction()
-//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -374,8 +374,8 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.Errorf(t, err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedErrorf, err)
+//	  if require.Errorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedErrorf, err)
 //	  }
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -390,7 +390,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -415,10 +415,10 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//	require.EventuallyWithT(t, func(c *require.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -443,10 +443,10 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -460,7 +460,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -473,7 +473,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 
 // Exactly asserts that two objects are equal in value and type.
 //
-//	assert.Exactly(t, int32(123), int64(123))
+//	require.Exactly(t, int32(123), int64(123))
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -486,7 +486,7 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -543,7 +543,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 
 // False asserts that the specified value is false.
 //
-//	assert.False(t, myBool)
+//	require.False(t, myBool)
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -556,7 +556,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-//	assert.Falsef(t, myBool, "error message %s", "formatted")
+//	require.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -593,9 +593,9 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-//	assert.Greater(t, 2, 1)
-//	assert.Greater(t, float64(2), float64(1))
-//	assert.Greater(t, "b", "a")
+//	require.Greater(t, 2, 1)
+//	require.Greater(t, float64(2), float64(1))
+//	require.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -608,10 +608,10 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqual(t, 2, 1)
-//	assert.GreaterOrEqual(t, 2, 2)
-//	assert.GreaterOrEqual(t, "b", "a")
-//	assert.GreaterOrEqual(t, "b", "b")
+//	require.GreaterOrEqual(t, 2, 1)
+//	require.GreaterOrEqual(t, 2, 2)
+//	require.GreaterOrEqual(t, "b", "a")
+//	require.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -624,10 +624,10 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -640,9 +640,9 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
-//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -656,7 +656,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -672,7 +672,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -688,7 +688,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -704,7 +704,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -719,7 +719,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -734,7 +734,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -749,7 +749,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -764,7 +764,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -779,7 +779,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
@@ -794,7 +794,7 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
@@ -809,7 +809,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -824,7 +824,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -839,7 +839,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-//	assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -852,7 +852,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -865,7 +865,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-//	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
+//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -922,7 +922,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -979,9 +979,9 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 
 // IsDecreasing asserts that the collection is decreasing
 //
-//	assert.IsDecreasing(t, []int{2, 1, 0})
-//	assert.IsDecreasing(t, []float{2, 1})
-//	assert.IsDecreasing(t, []string{"b", "a"})
+//	require.IsDecreasing(t, []int{2, 1, 0})
+//	require.IsDecreasing(t, []float{2, 1})
+//	require.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -994,9 +994,9 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1009,9 +1009,9 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasing asserts that the collection is increasing
 //
-//	assert.IsIncreasing(t, []int{1, 2, 3})
-//	assert.IsIncreasing(t, []float{1, 2})
-//	assert.IsIncreasing(t, []string{"a", "b"})
+//	require.IsIncreasing(t, []int{1, 2, 3})
+//	require.IsIncreasing(t, []float{1, 2})
+//	require.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1024,9 +1024,9 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1039,9 +1039,9 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasing(t, []int{1, 1, 2})
-//	assert.IsNonDecreasing(t, []float{1, 2})
-//	assert.IsNonDecreasing(t, []string{"a", "b"})
+//	require.IsNonDecreasing(t, []int{1, 1, 2})
+//	require.IsNonDecreasing(t, []float{1, 2})
+//	require.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1054,9 +1054,9 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1069,9 +1069,9 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasing(t, []int{2, 1, 1})
-//	assert.IsNonIncreasing(t, []float{2, 1})
-//	assert.IsNonIncreasing(t, []string{"b", "a"})
+//	require.IsNonIncreasing(t, []int{2, 1, 1})
+//	require.IsNonIncreasing(t, []float{2, 1})
+//	require.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1084,9 +1084,9 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1121,7 +1121,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1134,7 +1134,7 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1148,7 +1148,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-//	assert.Len(t, mySlice, 3)
+//	require.Len(t, mySlice, 3)
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1162,7 +1162,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1175,9 +1175,9 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Less asserts that the first element is less than the second
 //
-//	assert.Less(t, 1, 2)
-//	assert.Less(t, float64(1), float64(2))
-//	assert.Less(t, "a", "b")
+//	require.Less(t, 1, 2)
+//	require.Less(t, float64(1), float64(2))
+//	require.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1190,10 +1190,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqual(t, 1, 2)
-//	assert.LessOrEqual(t, 2, 2)
-//	assert.LessOrEqual(t, "a", "b")
-//	assert.LessOrEqual(t, "b", "b")
+//	require.LessOrEqual(t, 1, 2)
+//	require.LessOrEqual(t, 2, 2)
+//	require.LessOrEqual(t, "a", "b")
+//	require.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1206,10 +1206,10 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1222,9 +1222,9 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Lessf asserts that the first element is less than the second
 //
-//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
-//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+//	require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	require.Lessf(t, "a", "b", "error message %s", "formatted")
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1237,8 +1237,8 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // Negative asserts that the specified element is negative
 //
-//	assert.Negative(t, -1)
-//	assert.Negative(t, -1.23)
+//	require.Negative(t, -1)
+//	require.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1251,8 +1251,8 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-//	assert.Negativef(t, -1, "error message %s", "formatted")
-//	assert.Negativef(t, -1.23, "error message %s", "formatted")
+//	require.Negativef(t, -1, "error message %s", "formatted")
+//	require.Negativef(t, -1.23, "error message %s", "formatted")
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1266,7 +1266,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1280,7 +1280,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1293,7 +1293,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nil asserts that the specified object is nil.
 //
-//	assert.Nil(t, err)
+//	require.Nil(t, err)
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1306,7 +1306,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-//	assert.Nilf(t, err, "error message %s", "formatted")
+//	require.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1344,8 +1344,8 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NoError asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.NoError(t, err) {
-//		   assert.Equal(t, expectedObj, actualObj)
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
 //	  }
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1360,8 +1360,8 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 // NoErrorf asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedObj, actualObj)
+//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedObj, actualObj)
 //	  }
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1400,9 +1400,9 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContains(t, "Hello World", "Earth")
-//	assert.NotContains(t, ["Hello", "World"], "Earth")
-//	assert.NotContains(t, {"Hello": "World"}, "Earth")
+//	require.NotContains(t, "Hello World", "Earth")
+//	require.NotContains(t, ["Hello", "World"], "Earth")
+//	require.NotContains(t, {"Hello": "World"}, "Earth")
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1416,9 +1416,9 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1429,11 +1429,51 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 	t.FailNow()
 }
 
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	if assert.NotEmpty(t, obj) {
-//	  assert.Equal(t, "two", obj[1])
+//	if require.NotEmpty(t, obj) {
+//	  require.Equal(t, "two", obj[1])
 //	}
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1448,8 +1488,8 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
-//	  assert.Equal(t, "two", obj[1])
+//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  require.Equal(t, "two", obj[1])
 //	}
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1463,7 +1503,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-//	assert.NotEqual(t, obj1, obj2)
+//	require.NotEqual(t, obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1479,7 +1519,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValues(t, obj1, obj2)
+//	require.NotEqualValues(t, obj1, obj2)
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1492,7 +1532,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1505,7 +1545,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1519,7 +1559,31 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 	t.FailNow()
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1531,7 +1595,7 @@ func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) 
 	t.FailNow()
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1545,7 +1609,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1558,7 +1622,7 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1571,7 +1635,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNil asserts that the specified object is not nil.
 //
-//	assert.NotNil(t, err)
+//	require.NotNil(t, err)
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1584,7 +1648,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	assert.NotNilf(t, err, "error message %s", "formatted")
+//	require.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1597,7 +1661,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanics(t, func(){ RemainCalm() })
+//	require.NotPanics(t, func(){ RemainCalm() })
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1610,7 +1674,7 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1623,8 +1687,8 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
-//	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-//	assert.NotRegexp(t, "^start", "it's not starting")
+//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	require.NotRegexp(t, "^start", "it's not starting")
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1637,8 +1701,8 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
-//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1651,7 +1715,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-//	assert.NotSame(t, ptr1, ptr2)
+//	require.NotSame(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1667,7 +1731,7 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1685,8 +1749,8 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // contain all elements given in the specified subset list(array, slice...) or
 // map.
 //
-//	assert.NotSubset(t, [1, 3, 4], [1, 2])
-//	assert.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	require.NotSubset(t, [1, 3, 4], [1, 2])
+//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1701,8 +1765,8 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 // contain all elements given in the specified subset list(array, slice...) or
 // map.
 //
-//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1737,7 +1801,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panics(t, func(){ GoCrazy() })
+//	require.Panics(t, func(){ GoCrazy() })
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1752,7 +1816,7 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1767,7 +1831,7 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1781,7 +1845,7 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1795,7 +1859,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1808,7 +1872,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1821,8 +1885,8 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 
 // Positive asserts that the specified element is positive
 //
-//	assert.Positive(t, 1)
-//	assert.Positive(t, 1.23)
+//	require.Positive(t, 1)
+//	require.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1835,8 +1899,8 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-//	assert.Positivef(t, 1, "error message %s", "formatted")
-//	assert.Positivef(t, 1.23, "error message %s", "formatted")
+//	require.Positivef(t, 1, "error message %s", "formatted")
+//	require.Positivef(t, 1.23, "error message %s", "formatted")
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1849,8 +1913,8 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 
 // Regexp asserts that a specified regexp matches a string.
 //
-//	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
-//	assert.Regexp(t, "start...$", "it's not starting")
+//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	require.Regexp(t, "start...$", "it's not starting")
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1863,8 +1927,8 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 
 // Regexpf asserts that a specified regexp matches a string.
 //
-//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1877,7 +1941,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Same asserts that two pointers reference the same object.
 //
-//	assert.Same(t, ptr1, ptr2)
+//	require.Same(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1893,7 +1957,7 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1910,8 +1974,8 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Subset asserts that the specified list(array, slice...) or map contains all
 // elements given in the specified subset list(array, slice...) or map.
 //
-//	assert.Subset(t, [1, 2, 3], [1, 2])
-//	assert.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	require.Subset(t, [1, 2, 3], [1, 2])
+//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1925,8 +1989,8 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 // Subsetf asserts that the specified list(array, slice...) or map contains all
 // elements given in the specified subset list(array, slice...) or map.
 //
-//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1939,7 +2003,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // True asserts that the specified value is true.
 //
-//	assert.True(t, myBool)
+//	require.True(t, myBool)
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1952,7 +2016,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-//	assert.Truef(t, myBool, "error message %s", "formatted")
+//	require.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1965,7 +2029,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1978,7 +2042,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1991,7 +2055,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2004,7 +2068,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,4 +1,4 @@
-{{.Comment}}
+{{ replace .Comment "assert." "require."}}
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
 	if h, ok := t.(tHelper); ok { h.Helper() }
 	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -187,8 +187,8 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 	EqualExportedValuesf(a.t, expected, actual, msg, args...)
 }
 
-// EqualValues asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
 //	a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
@@ -198,8 +198,8 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 	EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-// EqualValuesf asserts that two objects are equal or convertible to the same types
-// and equal.
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
 //
 //	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
@@ -337,7 +337,7 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 //	a.EventuallyWithT(func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -362,7 +362,7 @@ func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), w
 //	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1129,6 +1129,40 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 	NotContainsf(a.t, s, contains, msg, args...)
 }
 
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
+func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
@@ -1201,7 +1235,25 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	NotEqualf(a.t, expected, actual, msg, args...)
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAsf(a.t, err, target, msg, args...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
@@ -1210,7 +1262,7 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 	NotErrorIs(a.t, err, target, msgAndArgs...)
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -6,7 +6,7 @@ type TestingT interface {
 	FailNow()
 }
 
-type tHelper interface {
+type tHelper = interface {
 	Helper()
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/NVIDIA/go-nvlib v0.6.1
+# github.com/NVIDIA/go-nvlib v0.7.2
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvlib/pkg/nvlib/device
 github.com/NVIDIA/go-nvlib/pkg/nvlib/info
@@ -61,9 +61,10 @@ github.com/russross/blackfriday/v2
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/test
-# github.com/stretchr/testify v1.9.0
+# github.com/stretchr/testify v1.10.0
 ## explicit; go 1.17
 github.com/stretchr/testify/assert
+github.com/stretchr/testify/assert/yaml
 github.com/stretchr/testify/require
 # github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 ## explicit


### PR DESCRIPTION
This change updates github.com/NVIDIA/go-nvlib from v0.7.1 to v0.7.2 to allow Thor systems to be detected as Tegra-based. This allows fixes automatic mode detection to work on these systems.

Backport of https://github.com/NVIDIA/nvidia-container-toolkit/pull/1078

It also includes an update of testing dependencies.