### PR TITLE
Add cuda-compat-mode config option

### DIFF
--- a/cmd/nvidia-container-runtime-hook/hook_config.go
+++ b/cmd/nvidia-container-runtime-hook/hook_config.go
@@ -104,3 +104,26 @@ func (c *hookConfig) getSwarmResourceEnvvars() []string {
 
 	return envvars
 }
+
+// nvidiaContainerCliCUDACompatModeFlags returns required --cuda-compat-mode
+// flag(s) depending on the hook and runtime configurations.
+func (c *hookConfig) nvidiaContainerCliCUDACompatModeFlags() []string {
+	var flag string
+	switch c.NVIDIAContainerRuntimeConfig.Modes.Legacy.CUDACompatMode {
+	case config.CUDACompatModeLdconfig:
+		flag = "--cuda-compat-mode=ldconfig"
+	case config.CUDACompatModeMount:
+		flag = "--cuda-compat-mode=mount"
+	case config.CUDACompatModeDisabled, config.CUDACompatModeHook:
+		flag = "--cuda-compat-mode=disabled"
+	default:
+		if !c.Features.AllowCUDACompatLibsFromContainer.IsEnabled() {
+			flag = "--cuda-compat-mode=disabled"
+		}
+	}
+
+	if flag == "" {
+		return nil
+	}
+	return []string{flag}
+}

--- a/cmd/nvidia-container-runtime-hook/main.go
+++ b/cmd/nvidia-container-runtime-hook/main.go
@@ -114,9 +114,8 @@ func doPrestart() {
 	}
 	args = append(args, "configure")
 
-	if !hook.Features.AllowCUDACompatLibsFromContainer.IsEnabled() {
-		args = append(args, "--no-cntlibs")
-	}
+	args = append(args, hook.nvidiaContainerCliCUDACompatModeFlags()...)
+
 	if ldconfigPath := cli.NormalizeLDConfigPath(); ldconfigPath != "" {
 		args = append(args, fmt.Sprintf("--ldconfig=%s", ldconfigPath))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,9 @@ func GetDefault() (*Config, error) {
 					AnnotationPrefixes: []string{cdi.AnnotationPrefix},
 					SpecDirs:           cdi.DefaultSpecDirs,
 				},
+				Legacy: legacyModeConfig{
+					CUDACompatMode: defaultCUDACompatMode,
+				},
 			},
 		},
 		NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,9 @@ func TestGetConfig(t *testing.T) {
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
 						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
+						},
 					},
 				},
 				NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{
@@ -93,6 +96,7 @@ func TestGetConfig(t *testing.T) {
 				"nvidia-container-cli.load-kmods = false",
 				"nvidia-container-cli.ldconfig = \"@/foo/bar/ldconfig\"",
 				"nvidia-container-cli.user = \"foo:bar\"",
+				"nvidia-container-cli.cuda-compat-mode = \"mount\"",
 				"nvidia-container-runtime.debug = \"/foo/bar\"",
 				"nvidia-container-runtime.discover-mode = \"not-legacy\"",
 				"nvidia-container-runtime.log-level = \"debug\"",
@@ -102,6 +106,7 @@ func TestGetConfig(t *testing.T) {
 				"nvidia-container-runtime.modes.cdi.annotation-prefixes = [\"cdi.k8s.io/\", \"example.vendor.com/\",]",
 				"nvidia-container-runtime.modes.cdi.spec-dirs = [\"/except/etc/cdi\", \"/not/var/run/cdi\",]",
 				"nvidia-container-runtime.modes.csv.mount-spec-path = \"/not/etc/nvidia-container-runtime/host-files-for-container.d\"",
+				"nvidia-container-runtime.modes.legacy.cuda-compat-mode = \"mount\"",
 				"nvidia-container-runtime-hook.path = \"/foo/bar/nvidia-container-runtime-hook\"",
 				"nvidia-ctk.path = \"/foo/bar/nvidia-ctk\"",
 			},
@@ -133,6 +138,9 @@ func TestGetConfig(t *testing.T) {
 								"/except/etc/cdi",
 								"/not/var/run/cdi",
 							},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "mount",
 						},
 					},
 				},
@@ -178,6 +186,9 @@ func TestGetConfig(t *testing.T) {
 								"/var/run/cdi",
 							},
 						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
+						},
 					},
 				},
 				NVIDIAContainerRuntimeHookConfig: RuntimeHookConfig{
@@ -200,6 +211,7 @@ func TestGetConfig(t *testing.T) {
 				"root = \"/bar/baz\"",
 				"load-kmods = false",
 				"ldconfig = \"@/foo/bar/ldconfig\"",
+				"cuda-compat-mode = \"mount\"",
 				"user = \"foo:bar\"",
 				"[nvidia-container-runtime]",
 				"debug = \"/foo/bar\"",
@@ -213,6 +225,8 @@ func TestGetConfig(t *testing.T) {
 				"spec-dirs = [\"/except/etc/cdi\", \"/not/var/run/cdi\",]",
 				"[nvidia-container-runtime.modes.csv]",
 				"mount-spec-path = \"/not/etc/nvidia-container-runtime/host-files-for-container.d\"",
+				"[nvidia-container-runtime.modes.legacy]",
+				"cuda-compat-mode = \"mount\"",
 				"[nvidia-container-runtime-hook]",
 				"path = \"/foo/bar/nvidia-container-runtime-hook\"",
 				"[nvidia-ctk]",
@@ -246,6 +260,9 @@ func TestGetConfig(t *testing.T) {
 								"/except/etc/cdi",
 								"/not/var/run/cdi",
 							},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "mount",
 						},
 					},
 				},
@@ -282,6 +299,9 @@ func TestGetConfig(t *testing.T) {
 							DefaultKind:        "nvidia.com/gpu",
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
 						},
 					},
 				},
@@ -321,6 +341,9 @@ func TestGetConfig(t *testing.T) {
 							DefaultKind:        "nvidia.com/gpu",
 							AnnotationPrefixes: []string{"cdi.k8s.io/"},
 							SpecDirs:           []string{"/etc/cdi", "/var/run/cdi"},
+						},
+						Legacy: legacyModeConfig{
+							CUDACompatMode: "ldconfig",
 						},
 					},
 				},

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -29,8 +29,9 @@ type RuntimeConfig struct {
 
 // modesConfig defines (optional) per-mode configs
 type modesConfig struct {
-	CSV csvModeConfig `toml:"csv"`
-	CDI cdiModeConfig `toml:"cdi"`
+	CSV    csvModeConfig    `toml:"csv"`
+	CDI    cdiModeConfig    `toml:"cdi"`
+	Legacy legacyModeConfig `toml:"legacy"`
 }
 
 type cdiModeConfig struct {
@@ -45,3 +46,31 @@ type cdiModeConfig struct {
 type csvModeConfig struct {
 	MountSpecPath string `toml:"mount-spec-path"`
 }
+
+type legacyModeConfig struct {
+	// CUDACompatMode sets the mode to be used to make CUDA Forward Compat
+	// libraries discoverable in the container.
+	CUDACompatMode cudaCompatMode `toml:"cuda-compat-mode,omitempty"`
+}
+
+type cudaCompatMode string
+
+const (
+	defaultCUDACompatMode = CUDACompatModeLdconfig
+	// CUDACompatModeDisabled explicitly disables the handling of CUDA Forward
+	// Compatibility in the NVIDIA Container Runtime and NVIDIA Container
+	// Runtime Hook.
+	CUDACompatModeDisabled = cudaCompatMode("disabled")
+	// CUDACompatModeHook uses a container lifecycle hook to implement CUDA
+	// Forward Compatibility support. This requires the use of the NVIDIA
+	// Container Runtime and is not compatible with use cases where only the
+	// NVIDIA Container Runtime Hook is used (e.g. the Docker --gpus flag).
+	CUDACompatModeHook = cudaCompatMode("hook")
+	// CUDACompatModeLdconfig adds the folders containing CUDA Forward Compat
+	// libraries to the ldconfig command invoked from the NVIDIA Container
+	// Runtime Hook.
+	CUDACompatModeLdconfig = cudaCompatMode("ldconfig")
+	// CUDACompatModeMount mounts CUDA Forward Compat folders from the container
+	// to the container when using the NVIDIA Container Runtime Hook.
+	CUDACompatModeMount = cudaCompatMode("mount")
+)

--- a/internal/config/toml_test.go
+++ b/internal/config/toml_test.go
@@ -74,6 +74,9 @@ spec-dirs = ["/etc/cdi", "/var/run/cdi"]
 [nvidia-container-runtime.modes.csv]
 mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
 
+[nvidia-container-runtime.modes.legacy]
+cuda-compat-mode = "ldconfig"
+
 [nvidia-container-runtime-hook]
 path = "nvidia-container-runtime-hook"
 skip-mode-detection = false


### PR DESCRIPTION
This change adds an nvidia-container-runtime.modes.legacy.cuda-compat-modeconfig option. This can be set to one of four values:

* ldconfig (default): the --cuda-compat-mode=ldconfig flag is passed to the nvidia-container-cli
* mount: the --cuda-compat-mode=mount flag is passed to the nvidia-conainer-cli
* disabled: the --cuda-compat-mode=disabled flag is passed to the nvidia-container-cli
* hook: the --cuda-compat-mode=disabled flag is passed to the nvidia-container-cli AND the
      enable-cuda-compat hook is used to provide forward compatibility.

Note that the disable-cuda-compat-lib-hook feature flag will prevent the enable-cuda-compat
hook from being used. This change also means that the allow-cuda-compat-libs-from-container
feature flag no longer has any effect.

Backport of #1055 