### PR TITLE
Refactor the way we handle Hook Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,8 @@
 *.swo
 /coverage.out*
 /tests/output/
-/nvidia-container-runtime
-/nvidia-container-runtime.*
-/nvidia-container-runtime-hook
-/nvidia-container-toolkit
-/nvidia-ctk
+/nvidia-*
 /shared-*
 /release-*
 /bin
+/toolkit-test

--- a/internal/discover/compat_libs.go
+++ b/internal/discover/compat_libs.go
@@ -9,16 +9,12 @@ import (
 
 // NewCUDACompatHookDiscoverer creates a discoverer for a enable-cuda-compat hook.
 // This hook is responsible for setting up CUDA compatibility in the container and depends on the host driver version.
-func NewCUDACompatHookDiscoverer(logger logger.Interface, nvidiaCDIHookPath string, driver *root.Driver) Discover {
+func NewCUDACompatHookDiscoverer(logger logger.Interface, hookCreator HookCreator, driver *root.Driver) Discover {
 	_, cudaVersionPattern := getCUDALibRootAndVersionPattern(logger, driver)
 	var args []string
 	if !strings.Contains(cudaVersionPattern, "*") {
 		args = append(args, "--host-driver-version="+cudaVersionPattern)
 	}
 
-	return CreateNvidiaCDIHook(
-		nvidiaCDIHookPath,
-		"enable-cuda-compat",
-		args...,
-	)
+	return hookCreator.Create("enable-cuda-compat", args...)
 }

--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -36,21 +36,21 @@ import (
 // TODO: The logic for creating DRM devices should be consolidated between this
 // and the logic for generating CDI specs for a single device. This is only used
 // when applying OCI spec modifications to an incoming spec in "legacy" mode.
-func NewDRMNodesDiscoverer(logger logger.Interface, devices image.VisibleDevices, devRoot string, nvidiaCDIHookPath string) (Discover, error) {
+func NewDRMNodesDiscoverer(logger logger.Interface, devices image.VisibleDevices, devRoot string, hookCreator HookCreator) (Discover, error) {
 	drmDeviceNodes, err := newDRMDeviceDiscoverer(logger, devices, devRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DRM device discoverer: %v", err)
 	}
 
-	drmByPathSymlinks := newCreateDRMByPathSymlinks(logger, drmDeviceNodes, devRoot, nvidiaCDIHookPath)
+	drmByPathSymlinks := newCreateDRMByPathSymlinks(logger, drmDeviceNodes, devRoot, hookCreator)
 
 	discover := Merge(drmDeviceNodes, drmByPathSymlinks)
 	return discover, nil
 }
 
 // NewGraphicsMountsDiscoverer creates a discoverer for the mounts required by graphics tools such as vulkan.
-func NewGraphicsMountsDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCDIHookPath string) (Discover, error) {
-	libraries := newGraphicsLibrariesDiscoverer(logger, driver, nvidiaCDIHookPath)
+func NewGraphicsMountsDiscoverer(logger logger.Interface, driver *root.Driver, hookCreator HookCreator) (Discover, error) {
+	libraries := newGraphicsLibrariesDiscoverer(logger, driver, hookCreator)
 
 	configs := NewMounts(
 		logger,
@@ -95,13 +95,13 @@ func newVulkanConfigsDiscover(logger logger.Interface, driver *root.Driver) Disc
 
 type graphicsDriverLibraries struct {
 	Discover
-	logger            logger.Interface
-	nvidiaCDIHookPath string
+	logger      logger.Interface
+	hookCreator HookCreator
 }
 
 var _ Discover = (*graphicsDriverLibraries)(nil)
 
-func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCDIHookPath string) Discover {
+func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver, hookCreator HookCreator) Discover {
 	cudaLibRoot, cudaVersionPattern := getCUDALibRootAndVersionPattern(logger, driver)
 
 	libraries := NewMounts(
@@ -140,9 +140,9 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 	)
 
 	return &graphicsDriverLibraries{
-		Discover:          Merge(libraries, xorgLibraries),
-		logger:            logger,
-		nvidiaCDIHookPath: nvidiaCDIHookPath,
+		Discover:    Merge(libraries, xorgLibraries),
+		logger:      logger,
+		hookCreator: hookCreator,
 	}
 }
 
@@ -203,9 +203,9 @@ func (d graphicsDriverLibraries) Hooks() ([]Hook, error) {
 		return nil, nil
 	}
 
-	hooks := CreateCreateSymlinkHook(d.nvidiaCDIHookPath, links)
+	hook := d.hookCreator.Create("create-symlinks", links...)
 
-	return hooks.Hooks()
+	return hook.Hooks()
 }
 
 // isDriverLibrary checks whether the specified filename is a specific driver library.
@@ -275,19 +275,19 @@ func buildXOrgSearchPaths(libRoot string) []string {
 
 type drmDevicesByPath struct {
 	None
-	logger            logger.Interface
-	nvidiaCDIHookPath string
-	devRoot           string
-	devicesFrom       Discover
+	logger      logger.Interface
+	hookCreator HookCreator
+	devRoot     string
+	devicesFrom Discover
 }
 
 // newCreateDRMByPathSymlinks creates a discoverer for a hook to create the by-path symlinks for DRM devices discovered by the specified devices discoverer
-func newCreateDRMByPathSymlinks(logger logger.Interface, devices Discover, devRoot string, nvidiaCDIHookPath string) Discover {
+func newCreateDRMByPathSymlinks(logger logger.Interface, devices Discover, devRoot string, hookCreator HookCreator) Discover {
 	d := drmDevicesByPath{
-		logger:            logger,
-		nvidiaCDIHookPath: nvidiaCDIHookPath,
-		devRoot:           devRoot,
-		devicesFrom:       devices,
+		logger:      logger,
+		hookCreator: hookCreator,
+		devRoot:     devRoot,
+		devicesFrom: devices,
 	}
 
 	return &d
@@ -315,13 +315,9 @@ func (d drmDevicesByPath) Hooks() ([]Hook, error) {
 		args = append(args, "--link", l)
 	}
 
-	hook := CreateNvidiaCDIHook(
-		d.nvidiaCDIHookPath,
-		"create-symlinks",
-		args...,
-	)
+	hook := d.hookCreator.Create("create-symlinks", args...)
 
-	return []Hook{hook}, nil
+	return hook.Hooks()
 }
 
 // getSpecificLinkArgs returns the required specific links that need to be created

--- a/internal/discover/graphics_test.go
+++ b/internal/discover/graphics_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 	logger, _ := testlog.NewNullLogger()
+	hookCreator := NewHookCreator("/usr/bin/nvidia-cdi-hook")
 
 	testCases := []struct {
 		description    string
@@ -136,9 +137,9 @@ func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			d := &graphicsDriverLibraries{
-				Discover:          tc.libraries,
-				logger:            logger,
-				nvidiaCDIHookPath: "/usr/bin/nvidia-cdi-hook",
+				Discover:    tc.libraries,
+				logger:      logger,
+				hookCreator: hookCreator,
 			}
 
 			devices, err := d.Devices()

--- a/internal/discover/ldconfig.go
+++ b/internal/discover/ldconfig.go
@@ -25,12 +25,12 @@ import (
 )
 
 // NewLDCacheUpdateHook creates a discoverer that updates the ldcache for the specified mounts. A logger can also be specified
-func NewLDCacheUpdateHook(logger logger.Interface, mounts Discover, nvidiaCDIHookPath, ldconfigPath string) (Discover, error) {
+func NewLDCacheUpdateHook(logger logger.Interface, mounts Discover, hookCreator HookCreator, ldconfigPath string) (Discover, error) {
 	d := ldconfig{
-		logger:            logger,
-		nvidiaCDIHookPath: nvidiaCDIHookPath,
-		ldconfigPath:      ldconfigPath,
-		mountsFrom:        mounts,
+		logger:       logger,
+		hookCreator:  hookCreator,
+		ldconfigPath: ldconfigPath,
+		mountsFrom:   mounts,
 	}
 
 	return &d, nil
@@ -38,10 +38,10 @@ func NewLDCacheUpdateHook(logger logger.Interface, mounts Discover, nvidiaCDIHoo
 
 type ldconfig struct {
 	None
-	logger            logger.Interface
-	nvidiaCDIHookPath string
-	ldconfigPath      string
-	mountsFrom        Discover
+	logger       logger.Interface
+	hookCreator  HookCreator
+	ldconfigPath string
+	mountsFrom   Discover
 }
 
 // Hooks checks the required mounts for libraries and returns a hook to update the LDcache for the discovered paths.
@@ -50,16 +50,18 @@ func (d ldconfig) Hooks() ([]Hook, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover mounts for ldcache update: %v", err)
 	}
-	h := CreateLDCacheUpdateHook(
-		d.nvidiaCDIHookPath,
+
+	h := createLDCacheUpdateHook(
+		d.hookCreator,
 		d.ldconfigPath,
 		getLibraryPaths(mounts),
 	)
-	return []Hook{h}, nil
+
+	return h.Hooks()
 }
 
-// CreateLDCacheUpdateHook locates the NVIDIA Container Toolkit CLI and creates a hook for updating the LD Cache
-func CreateLDCacheUpdateHook(executable string, ldconfig string, libraries []string) Hook {
+// createLDCacheUpdateHook locates the NVIDIA Container Toolkit CLI and creates a hook for updating the LD Cache
+func createLDCacheUpdateHook(hookCreator HookCreator, ldconfig string, libraries []string) *Hook {
 	var args []string
 
 	if ldconfig != "" {
@@ -70,13 +72,7 @@ func CreateLDCacheUpdateHook(executable string, ldconfig string, libraries []str
 		args = append(args, "--folder", f)
 	}
 
-	hook := CreateNvidiaCDIHook(
-		executable,
-		"update-ldcache",
-		args...,
-	)
-
-	return hook
+	return hookCreator.Create("update-ldcache", args...)
 }
 
 // getLibraryPaths extracts the library dirs from the specified mounts

--- a/internal/discover/ldconfig_test.go
+++ b/internal/discover/ldconfig_test.go
@@ -31,6 +31,7 @@ const (
 
 func TestLDCacheUpdateHook(t *testing.T) {
 	logger, _ := testlog.NewNullLogger()
+	hookCreator := NewHookCreator(testNvidiaCDIHookPath)
 
 	testCases := []struct {
 		description   string
@@ -97,7 +98,7 @@ func TestLDCacheUpdateHook(t *testing.T) {
 				Lifecycle: "createContainer",
 			}
 
-			d, err := NewLDCacheUpdateHook(logger, mountMock, testNvidiaCDIHookPath, tc.ldconfigPath)
+			d, err := NewLDCacheUpdateHook(logger, mountMock, hookCreator, tc.ldconfigPath)
 			require.NoError(t, err)
 
 			hooks, err := d.Hooks()

--- a/internal/discover/symlinks_test.go
+++ b/internal/discover/symlinks_test.go
@@ -306,12 +306,13 @@ func TestWithWithDriverDotSoSymlinks(t *testing.T) {
 		},
 	}
 
+	hookCreator := NewHookCreator("/path/to/nvidia-cdi-hook")
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			d := WithDriverDotSoSymlinks(
 				tc.discover,
 				tc.version,
-				"/path/to/nvidia-cdi-hook",
+				hookCreator,
 			)
 
 			devices, err := d.Devices()

--- a/internal/platform-support/dgpu/by-path-hooks.go
+++ b/internal/platform-support/dgpu/by-path-hooks.go
@@ -27,11 +27,11 @@ import (
 
 // byPathHookDiscoverer discovers the entities required for injecting by-path DRM device links
 type byPathHookDiscoverer struct {
-	logger            logger.Interface
-	devRoot           string
-	nvidiaCDIHookPath string
-	pciBusID          string
-	deviceNodes       discover.Discover
+	logger      logger.Interface
+	devRoot     string
+	hookCreator discover.HookCreator
+	pciBusID    string
+	deviceNodes discover.Discover
 }
 
 var _ discover.Discover = (*byPathHookDiscoverer)(nil)
@@ -53,18 +53,9 @@ func (d *byPathHookDiscoverer) Hooks() ([]discover.Hook, error) {
 		return nil, nil
 	}
 
-	var args []string
-	for _, l := range links {
-		args = append(args, "--link", l)
-	}
+	hook := d.hookCreator.Create("create-symlinks", links...)
 
-	hook := discover.CreateNvidiaCDIHook(
-		d.nvidiaCDIHookPath,
-		"create-symlinks",
-		args...,
-	)
-
-	return []discover.Hook{hook}, nil
+	return hook.Hooks()
 }
 
 // Mounts returns an empty slice for a full GPU

--- a/internal/platform-support/dgpu/nvml.go
+++ b/internal/platform-support/dgpu/nvml.go
@@ -58,11 +58,11 @@ func (o *options) newNvmlDGPUDiscoverer(d requiredInfo) (discover.Discover, erro
 	)
 
 	byPathHooks := &byPathHookDiscoverer{
-		logger:            o.logger,
-		devRoot:           o.devRoot,
-		nvidiaCDIHookPath: o.nvidiaCDIHookPath,
-		pciBusID:          pciBusID,
-		deviceNodes:       deviceNodes,
+		logger:      o.logger,
+		devRoot:     o.devRoot,
+		hookCreator: o.hookCreator,
+		pciBusID:    pciBusID,
+		deviceNodes: deviceNodes,
 	}
 
 	dd := discover.Merge(

--- a/internal/platform-support/dgpu/options.go
+++ b/internal/platform-support/dgpu/options.go
@@ -17,15 +17,16 @@
 package dgpu
 
 import (
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvcaps"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvsandboxutils"
 )
 
 type options struct {
-	logger            logger.Interface
-	devRoot           string
-	nvidiaCDIHookPath string
+	logger      logger.Interface
+	devRoot     string
+	hookCreator discover.HookCreator
 
 	isMigDevice bool
 	// migCaps stores the MIG capabilities for the system.
@@ -52,10 +53,10 @@ func WithLogger(logger logger.Interface) Option {
 	}
 }
 
-// WithNVIDIACDIHookPath sets the path to the NVIDIA Container Toolkit CLI path for the library
-func WithNVIDIACDIHookPath(path string) Option {
+// WithHookCreator sets the hook creator for the library
+func WithHookCreator(hookCreator discover.HookCreator) Option {
 	return func(l *options) {
-		l.nvidiaCDIHookPath = path
+		l.hookCreator = hookCreator
 	}
 }
 

--- a/internal/platform-support/tegra/csv.go
+++ b/internal/platform-support/tegra/csv.go
@@ -59,7 +59,7 @@ func (o tegraOptions) newDiscovererFromCSVFiles() (discover.Discover, error) {
 			targetsByType[csv.MountSpecLib],
 		),
 		"",
-		o.nvidiaCDIHookPath,
+		o.hookCreator,
 	)
 
 	// We process the explicitly requested symlinks.

--- a/internal/platform-support/tegra/csv_test.go
+++ b/internal/platform-support/tegra/csv_test.go
@@ -181,13 +181,14 @@ func TestDiscovererFromCSVFiles(t *testing.T) {
 		},
 	}
 
+	hookCreator := discover.NewHookCreator("/usr/bin/nvidia-cdi-hook")
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			defer setGetTargetsFromCSVFiles(tc.moutSpecs)()
 
 			o := tegraOptions{
 				logger:              logger,
-				nvidiaCDIHookPath:   "/usr/bin/nvidia-cdi-hook",
+				hookCreator:         hookCreator,
 				csvFiles:            []string{"dummy"},
 				ignorePatterns:      tc.ignorePatterns,
 				symlinkLocator:      tc.symlinkLocator,

--- a/internal/platform-support/tegra/symlinks.go
+++ b/internal/platform-support/tegra/symlinks.go
@@ -26,9 +26,9 @@ import (
 
 type symlinkHook struct {
 	discover.None
-	logger            logger.Interface
-	nvidiaCDIHookPath string
-	targets           []string
+	logger      logger.Interface
+	hookCreator discover.HookCreator
+	targets     []string
 
 	// The following can be overridden for testing
 	symlinkChainLocator lookup.Locator
@@ -39,7 +39,7 @@ type symlinkHook struct {
 func (o tegraOptions) createCSVSymlinkHooks(targets []string) discover.Discover {
 	return symlinkHook{
 		logger:              o.logger,
-		nvidiaCDIHookPath:   o.nvidiaCDIHookPath,
+		hookCreator:         o.hookCreator,
 		targets:             targets,
 		symlinkChainLocator: o.symlinkChainLocator,
 		resolveSymlink:      o.resolveSymlink,
@@ -48,10 +48,7 @@ func (o tegraOptions) createCSVSymlinkHooks(targets []string) discover.Discover 
 
 // Hooks returns a hook to create the symlinks from the required CSV files
 func (d symlinkHook) Hooks() ([]discover.Hook, error) {
-	return discover.CreateCreateSymlinkHook(
-		d.nvidiaCDIHookPath,
-		d.getCSVFileSymlinks(),
-	).Hooks()
+	return d.hookCreator.Create("create-symlinks", d.getCSVFileSymlinks()...).Hooks()
 }
 
 // getSymlinkCandidates returns a list of symlinks that are candidates for being created.

--- a/internal/platform-support/tegra/tegra.go
+++ b/internal/platform-support/tegra/tegra.go
@@ -30,7 +30,7 @@ type tegraOptions struct {
 	csvFiles           []string
 	driverRoot         string
 	devRoot            string
-	nvidiaCDIHookPath  string
+	hookCreator        discover.HookCreator
 	ldconfigPath       string
 	librarySearchPaths []string
 	ignorePatterns     ignoreMountSpecPatterns
@@ -80,7 +80,7 @@ func New(opts ...Option) (discover.Discover, error) {
 		return nil, fmt.Errorf("failed to create CSV discoverer: %v", err)
 	}
 
-	ldcacheUpdateHook, err := discover.NewLDCacheUpdateHook(o.logger, csvDiscoverer, o.nvidiaCDIHookPath, o.ldconfigPath)
+	ldcacheUpdateHook, err := discover.NewLDCacheUpdateHook(o.logger, csvDiscoverer, o.hookCreator, o.ldconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ldcach update hook discoverer: %v", err)
 	}
@@ -133,10 +133,10 @@ func WithCSVFiles(csvFiles []string) Option {
 	}
 }
 
-// WithNVIDIACDIHookPath sets the path to the nvidia-cdi-hook binary.
-func WithNVIDIACDIHookPath(nvidiaCDIHookPath string) Option {
+// WithHookCreator sets the hook creator for the discoverer.
+func WithHookCreator(hookCreator discover.HookCreator) Option {
 	return func(o *tegraOptions) {
-		o.nvidiaCDIHookPath = nvidiaCDIHookPath
+		o.hookCreator = hookCreator
 	}
 }
 

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config/image"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/info"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/root"
@@ -74,6 +75,8 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 		return nil, err
 	}
 
+	hookCreator := discover.NewHookCreator(cfg.NVIDIACTKConfig.Path)
+
 	mode := info.ResolveAutoMode(logger, cfg.NVIDIAContainerRuntimeConfig.Mode, image)
 	// We update the mode here so that we can continue passing just the config to other functions.
 	cfg.NVIDIAContainerRuntimeConfig.Mode = mode
@@ -90,13 +93,13 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 		case "nvidia-hook-remover":
 			modifiers = append(modifiers, modifier.NewNvidiaContainerRuntimeHookRemover(logger))
 		case "graphics":
-			graphicsModifier, err := modifier.NewGraphicsModifier(logger, cfg, image, driver)
+			graphicsModifier, err := modifier.NewGraphicsModifier(logger, cfg, image, driver, hookCreator)
 			if err != nil {
 				return nil, err
 			}
 			modifiers = append(modifiers, graphicsModifier)
 		case "feature-gated":
-			featureGatedModifier, err := modifier.NewFeatureGatedModifier(logger, cfg, image, driver)
+			featureGatedModifier, err := modifier.NewFeatureGatedModifier(logger, cfg, image, driver, hookCreator)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/nvcdi/common-nvml.go
+++ b/pkg/nvcdi/common-nvml.go
@@ -36,7 +36,7 @@ func (l *nvmllib) newCommonNVMLDiscoverer() (discover.Discover, error) {
 		},
 	)
 
-	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(l.logger, l.driver, l.nvidiaCDIHookPath)
+	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(l.logger, l.driver, l.hookCreator)
 	if err != nil {
 		l.logger.Warningf("failed to create discoverer for graphics mounts: %v", err)
 	}

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -102,17 +102,17 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string) (discover.Discover
 	driverDotSoSymlinksDiscoverer := discover.WithDriverDotSoSymlinks(
 		libraries,
 		version,
-		l.nvidiaCDIHookPath,
+		l.hookCreator,
 	)
 	discoverers = append(discoverers, driverDotSoSymlinksDiscoverer)
 
 	if l.HookIsSupported(HookEnableCudaCompat) {
 		// TODO: The following should use the version directly.
-		cudaCompatLibHookDiscoverer := discover.NewCUDACompatHookDiscoverer(l.logger, l.nvidiaCDIHookPath, l.driver)
+		cudaCompatLibHookDiscoverer := discover.NewCUDACompatHookDiscoverer(l.logger, l.hookCreator, l.driver)
 		discoverers = append(discoverers, cudaCompatLibHookDiscoverer)
 	}
 
-	updateLDCache, _ := discover.NewLDCacheUpdateHook(l.logger, libraries, l.nvidiaCDIHookPath, l.ldconfigPath)
+	updateLDCache, _ := discover.NewLDCacheUpdateHook(l.logger, libraries, l.hookCreator, l.ldconfigPath)
 	discoverers = append(discoverers, updateLDCache)
 
 	d := discover.Merge(discoverers...)

--- a/pkg/nvcdi/driver-wsl_test.go
+++ b/pkg/nvcdi/driver-wsl_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestNvidiaSMISymlinkHook(t *testing.T) {
 	logger, _ := testlog.NewNullLogger()
+	hookCreator := discover.NewHookCreator("nvidia-cdi-hook")
 
 	errMounts := errors.New("mounts error")
 
@@ -143,9 +144,9 @@ func TestNvidiaSMISymlinkHook(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			m := nvidiaSMISimlinkHook{
-				logger:            logger,
-				mountsFrom:        tc.mounts,
-				nvidiaCDIHookPath: "nvidia-cdi-hook",
+				logger:      logger,
+				mountsFrom:  tc.mounts,
+				hookCreator: hookCreator,
 			}
 
 			devices, err := m.Devices()

--- a/pkg/nvcdi/full-gpu-nvml.go
+++ b/pkg/nvcdi/full-gpu-nvml.go
@@ -71,7 +71,7 @@ func (l *nvmllib) newFullGPUDiscoverer(d device.Device) (discover.Discover, erro
 	deviceNodes, err := dgpu.NewForDevice(d,
 		dgpu.WithDevRoot(l.devRoot),
 		dgpu.WithLogger(l.logger),
-		dgpu.WithNVIDIACDIHookPath(l.nvidiaCDIHookPath),
+		dgpu.WithHookCreator(l.hookCreator),
 		dgpu.WithNvsandboxuitilsLib(l.nvsandboxutilslib),
 	)
 	if err != nil {
@@ -81,7 +81,7 @@ func (l *nvmllib) newFullGPUDiscoverer(d device.Device) (discover.Discover, erro
 	deviceFolderPermissionHooks := newDeviceFolderPermissionHookDiscoverer(
 		l.logger,
 		l.devRoot,
-		l.nvidiaCDIHookPath,
+		l.hookCreator,
 		deviceNodes,
 	)
 

--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -44,7 +44,7 @@ func (l *csvlib) GetAllDeviceSpecs() ([]specs.Device, error) {
 		tegra.WithLogger(l.logger),
 		tegra.WithDriverRoot(l.driverRoot),
 		tegra.WithDevRoot(l.devRoot),
-		tegra.WithNVIDIACDIHookPath(l.nvidiaCDIHookPath),
+		tegra.WithHookCreator(l.hookCreator),
 		tegra.WithLdconfigPath(l.ldconfigPath),
 		tegra.WithCSVFiles(l.csvFiles),
 		tegra.WithLibrarySearchPaths(l.librarySearchPaths...),

--- a/pkg/nvcdi/lib-wsl.go
+++ b/pkg/nvcdi/lib-wsl.go
@@ -54,7 +54,7 @@ func (l *wsllib) GetAllDeviceSpecs() ([]specs.Device, error) {
 
 // GetCommonEdits generates a CDI specification that can be used for ANY devices
 func (l *wsllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
-	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.nvidiaCDIHookPath, l.ldconfigPath)
+	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.hookCreator, l.ldconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for WSL driver: %v", err)
 	}

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/root"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvsandboxutils"
@@ -56,6 +57,7 @@ type nvcdilib struct {
 	mergedDeviceOptions []transform.MergedDeviceOption
 
 	disabledHooks disabledHooks
+	hookCreator   discover.HookCreator
 }
 
 // New creates a new nvcdi library
@@ -79,6 +81,9 @@ func New(opts ...Option) (Interface, error) {
 	if l.nvidiaCDIHookPath == "" {
 		l.nvidiaCDIHookPath = "/usr/bin/nvidia-cdi-hook"
 	}
+	// create hookCreator
+	l.hookCreator = discover.NewHookCreator(l.nvidiaCDIHookPath)
+
 	if l.driverRoot == "" {
 		l.driverRoot = "/"
 	}

--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -138,7 +138,7 @@ func (m *managementlib) newManagementDeviceDiscoverer() (discover.Discover, erro
 	deviceFolderPermissionHooks := newDeviceFolderPermissionHookDiscoverer(
 		m.logger,
 		m.devRoot,
-		m.nvidiaCDIHookPath,
+		m.hookCreator,
 		deviceNodes,
 	)
 

--- a/pkg/nvcdi/mig-device-nvml.go
+++ b/pkg/nvcdi/mig-device-nvml.go
@@ -54,7 +54,7 @@ func (l *nvmllib) GetMIGDeviceEdits(parent device.Device, mig device.MigDevice) 
 	deviceNodes, err := dgpu.NewForMigDevice(parent, mig,
 		dgpu.WithDevRoot(l.devRoot),
 		dgpu.WithLogger(l.logger),
-		dgpu.WithNVIDIACDIHookPath(l.nvidiaCDIHookPath),
+		dgpu.WithHookCreator(l.hookCreator),
 		dgpu.WithNvsandboxuitilsLib(l.nvsandboxutilslib),
 	)
 	if err != nil {


### PR DESCRIPTION
This pull request refactors the codebase to introduce a new `HookCreator` interface, replacing the previous direct use of `nvidiaCDIHookPath` for creating hooks. This change improves modularity and makes the code more extensible by centralizing hook creation logic. The changes span multiple files and functions, focusing on updating constructors, methods, and tests to use the new `HookCreator` abstraction.

### Refactoring to Use `HookCreator`:

* **Centralized Hook Creation**:
  - Introduced `HookCreator` interface and its implementation (`CDIHook`) to encapsulate hook creation logic. This replaces the direct use of `nvidiaCDIHookPath` for creating hooks. (`internal/discover/hooks.go`, [internal/discover/hooks.goL28-R102](diffhunk://#diff-1796074bfa80616c6f45472f4808636ecd132de87752e9da307fff3a9f427bb5L28-R102))
  - Updated various hook creation methods (e.g., `createLDCacheUpdateHook`, `Create("create-symlinks")`) to use `HookCreator`. (`internal/discover/hooks.go`, [internal/discover/hooks.goL28-R102](diffhunk://#diff-1796074bfa80616c6f45472f4808636ecd132de87752e9da307fff3a9f427bb5L28-R102))

* **Function and Constructor Updates**:
  - Replaced `nvidiaCDIHookPath` parameter with `HookCreator` in constructors and functions such as `NewCUDACompatHookDiscoverer`, `NewGraphicsMountsDiscoverer`, and `NewLDCacheUpdateHook`. (`internal/discover/compat_libs.go`, [[1]](diffhunk://#diff-d21a4981715b0514c9e4e404a278dee574bccf3e72cd8b49b10107bd4f118471L12-R19); `internal/discover/graphics.go`, [[2]](diffhunk://#diff-0f55e7e372471bd00194246b86e17ee2dcc9a004d9adeeed953ab1532d4ec6a2L39-R53) [[3]](diffhunk://#diff-97a44282763baa1a0aa530d7742d58a8333a69c7ef12e56994db65410b228a7dL28-R31)
  - Updated related methods and structs to use `hookCreator` instead of `nvidiaCDIHookPath`. (`internal/discover/graphics.go`, [[1]](diffhunk://#diff-0f55e7e372471bd00194246b86e17ee2dcc9a004d9adeeed953ab1532d4ec6a2L99-R104) [[2]](diffhunk://#diff-97a44282763baa1a0aa530d7742d58a8333a69c7ef12e56994db65410b228a7dL42-R42)

### Code Simplification and Cleanup:

* **Removed Redundant Hook Creation Logic**:
  - Eliminated repetitive hook creation functions like `CreateNvidiaCDIHook` and `CreateCreateSymlinkHook`, consolidating their behavior into the `HookCreator` implementation. (`internal/discover/hooks.go`, [internal/discover/hooks.goL28-R102](diffhunk://#diff-1796074bfa80616c6f45472f4808636ecd132de87752e9da307fff3a9f427bb5L28-R102))

* **Simplified Hook Handling**:
  - Updated `Hooks()` methods across various discoverers to delegate hook creation to `HookCreator`. (`internal/discover/graphics.go`, [[1]](diffhunk://#diff-0f55e7e372471bd00194246b86e17ee2dcc9a004d9adeeed953ab1532d4ec6a2L206-R206); `internal/discover/ldconfig.go`, [[2]](diffhunk://#diff-97a44282763baa1a0aa530d7742d58a8333a69c7ef12e56994db65410b228a7dL53-R60)

### Tests and Validation:

* **Test Updates**:
  - Modified tests to use the new `HookCreator` abstraction, ensuring compatibility with the refactored code. (`internal/discover/graphics_test.go`, [[1]](diffhunk://#diff-fba5e230979f7c0b632bf5d3398b74759dbff60e7ee87dc51461a9f1e52250dcR28); `internal/discover/ldconfig_test.go`, [[2]](diffhunk://#diff-ac5331f9a4252da9825592a454da3ee1835673eb5c7abaa8ff19ab814d07e78eR34)

These changes enhance the maintainability and scalability of the codebase by abstracting hook creation logic, reducing redundancy, and improving testability.