### PR TITLE
Bump third_party/libnvidia-container from d26524a to caf057b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NVIDIA Container Toolkit Changelog
 
+### Changes in libnvidia-container
+
+- Fixed bug in setting default for `--cuda-compat-mode` flag. This caused failures in use cases invoking the `nvidia-container-cli` directly.
+
 ## v1.17.7
 
 - Fix mode detection on Thor-based systems. This correctly resolves `auto` mode to `csv`.


### PR DESCRIPTION
This includes:
* https://github.com/NVIDIA/libnvidia-container/pull/310
* https://github.com/NVIDIA/libnvidia-container/pull/311