### PR TITLE
[no-relnote] Switch to public runners

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   packages:
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -49,7 +49,7 @@ jobs:
           - ispr: true
             target: centos8-ppc64le
       fail-fast: false
-      
+
     steps:
       - uses: actions/checkout@v4
         name: Check out code
@@ -76,7 +76,7 @@ jobs:
           path: ${{ github.workspace }}/dist/*
 
   image:
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         dist:


### PR DESCRIPTION
Since we now use pr-copy-bot, we are not running image builds from forks and as such the required secrets for pushing to the ghcr are present.