### PR TITLE
Minor cleanup of WSL2 CDI spec generation

### DIFF
--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -40,13 +40,12 @@ var requiredDriverStoreFiles = []string{
 
 // newWSLDriverDiscoverer returns a Discoverer for WSL2 drivers.
 func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator, ldconfigPath string) (discover.Discover, error) {
-	err := dxcore.Init()
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize dxcore: %v", err)
+	if err := dxcore.Init(); err != nil {
+		return nil, fmt.Errorf("failed to initialize dxcore: %w", err)
 	}
 	defer func() {
 		if err := dxcore.Shutdown(); err != nil {
-			logger.Warningf("failed to shutdown dxcore: %v", err)
+			logger.Warningf("failed to shutdown dxcore: %w", err)
 		}
 	}()
 
@@ -61,7 +60,7 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCrea
 
 	driverStorePaths = append(driverStorePaths, "/usr/lib/wsl/lib")
 
-	libraries := discover.NewMounts(
+	driverStoreMounts := discover.NewMounts(
 		logger,
 		lookup.NewFileLocator(
 			lookup.WithLogger(logger),
@@ -76,14 +75,14 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCrea
 
 	symlinkHook := nvidiaSMISimlinkHook{
 		logger:      logger,
-		mountsFrom:  libraries,
+		mountsFrom:  driverStoreMounts,
 		hookCreator: hookCreator,
 	}
 
-	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, libraries, hookCreator, ldconfigPath)
+	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, driverStoreMounts, hookCreator, ldconfigPath)
 
 	d := discover.Merge(
-		libraries,
+		driverStoreMounts,
 		symlinkHook,
 		ldcacheHook,
 	)

--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -59,19 +59,14 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCrea
 	}
 	logger.Infof("Using WSL driver store paths: %v", driverStorePaths)
 
-	return newWSLDriverStoreDiscoverer(logger, driverRoot, hookCreator, ldconfigPath, driverStorePaths)
-}
-
-// newWSLDriverStoreDiscoverer returns a Discoverer for WSL2 drivers in the driver store associated with a dxcore adapter.
-func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator, ldconfigPath string, searchPaths []string) (discover.Discover, error) {
-	searchPaths = append(searchPaths, "/usr/lib/wsl/lib")
+	driverStorePaths = append(driverStorePaths, "/usr/lib/wsl/lib")
 
 	libraries := discover.NewMounts(
 		logger,
 		lookup.NewFileLocator(
 			lookup.WithLogger(logger),
 			lookup.WithSearchPaths(
-				searchPaths...,
+				driverStorePaths...,
 			),
 			lookup.WithCount(1),
 		),

--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -54,24 +54,16 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCrea
 	if len(driverStorePaths) == 0 {
 		return nil, fmt.Errorf("no driver store paths found")
 	}
+	if len(driverStorePaths) > 1 {
+		logger.Warningf("Found multiple driver store paths: %v", driverStorePaths)
+	}
 	logger.Infof("Using WSL driver store paths: %v", driverStorePaths)
 
 	return newWSLDriverStoreDiscoverer(logger, driverRoot, hookCreator, ldconfigPath, driverStorePaths)
 }
 
 // newWSLDriverStoreDiscoverer returns a Discoverer for WSL2 drivers in the driver store associated with a dxcore adapter.
-func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator, ldconfigPath string, driverStorePaths []string) (discover.Discover, error) {
-	var searchPaths []string
-	seen := make(map[string]bool)
-	for _, path := range driverStorePaths {
-		if seen[path] {
-			continue
-		}
-		searchPaths = append(searchPaths, path)
-	}
-	if len(searchPaths) > 1 {
-		logger.Warningf("Found multiple driver store paths: %v", searchPaths)
-	}
+func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator, ldconfigPath string, searchPaths []string) (discover.Discover, error) {
 	searchPaths = append(searchPaths, "/usr/lib/wsl/lib")
 
 	libraries := discover.NewMounts(


### PR DESCRIPTION
While auditing the use of maps for deduplication of mounts, it was noticed that the driver store discoverer use for generating CDI specifications on WSL2-based systems was not properly deduplicating the input. This was not a bug as such, since the input value was already de-duplicated at another point.

This change simplifies the function to remove the buggy code.