### PR TITLE
BUGFIX: modifier: respect GPU volume-mount device requests

### DIFF
--- a/internal/config/image/cuda_image.go
+++ b/internal/config/image/cuda_image.go
@@ -144,8 +144,8 @@ func (i CUDA) HasDisableRequire() bool {
 	return false
 }
 
-// DevicesFromEnvvars returns the devices requested by the image through environment variables
-func (i CUDA) DevicesFromEnvvars(envVars ...string) VisibleDevices {
+// devicesFromEnvvars returns the devices requested by the image through environment variables
+func (i CUDA) devicesFromEnvvars(envVars ...string) []string {
 	// We concantenate all the devices from the specified env.
 	var isSet bool
 	var devices []string
@@ -166,15 +166,15 @@ func (i CUDA) DevicesFromEnvvars(envVars ...string) VisibleDevices {
 
 	// Environment variable unset with legacy image: default to "all".
 	if !isSet && len(devices) == 0 && i.IsLegacy() {
-		return NewVisibleDevices("all")
+		devices = []string{"all"}
 	}
 
 	// Environment variable unset or empty or "void": return nil
 	if len(devices) == 0 || requested["void"] {
-		return NewVisibleDevices("void")
+		devices = []string{"void"}
 	}
 
-	return NewVisibleDevices(devices...)
+	return NewVisibleDevices(devices...).List()
 }
 
 // GetDriverCapabilities returns the requested driver capabilities.
@@ -328,7 +328,7 @@ func (i CUDA) cdiDeviceRequestsFromAnnotations() []string {
 // NVIDIA_VISIBLE_DEVICES environment variable is used.
 func (i CUDA) visibleDevicesFromEnvVar() []string {
 	envVars := i.visibleEnvVars()
-	return i.DevicesFromEnvvars(envVars...).List()
+	return i.devicesFromEnvvars(envVars...)
 }
 
 // visibleDevicesFromMounts returns the set of visible devices requested as mounts.
@@ -414,7 +414,7 @@ func (m cdiDeviceMountRequest) qualifiedName() (string, error) {
 
 // ImexChannelsFromEnvVar returns the list of IMEX channels requested for the image.
 func (i CUDA) ImexChannelsFromEnvVar() []string {
-	imexChannels := i.DevicesFromEnvvars(EnvVarNvidiaImexChannels).List()
+	imexChannels := i.devicesFromEnvvars(EnvVarNvidiaImexChannels)
 	if len(imexChannels) == 1 && imexChannels[0] == "all" {
 		return nil
 	}

--- a/internal/config/image/cuda_image.go
+++ b/internal/config/image/cuda_image.go
@@ -270,7 +270,7 @@ func (i CUDA) VisibleDevices() []string {
 	}
 
 	// Get the Fallback to reading from the environment variable if privileges are correct
-	envVarDeviceRequests := i.VisibleDevicesFromEnvVar()
+	envVarDeviceRequests := i.visibleDevicesFromEnvVar()
 	if len(envVarDeviceRequests) == 0 {
 		return nil
 	}
@@ -322,11 +322,11 @@ func (i CUDA) cdiDeviceRequestsFromAnnotations() []string {
 	return devices
 }
 
-// VisibleDevicesFromEnvVar returns the set of visible devices requested through environment variables.
+// visibleDevicesFromEnvVar returns the set of visible devices requested through environment variables.
 // If any of the preferredVisibleDeviceEnvVars are present in the image, they
 // are used to determine the visible devices. If this is not the case, the
 // NVIDIA_VISIBLE_DEVICES environment variable is used.
-func (i CUDA) VisibleDevicesFromEnvVar() []string {
+func (i CUDA) visibleDevicesFromEnvVar() []string {
 	envVars := i.visibleEnvVars()
 	return i.DevicesFromEnvvars(envVars...).List()
 }

--- a/internal/config/image/cuda_image.go
+++ b/internal/config/image/cuda_image.go
@@ -19,6 +19,7 @@ package image
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -300,16 +301,23 @@ func (i CUDA) cdiDeviceRequestsFromAnnotations() []string {
 		return nil
 	}
 
-	var devices []string
-	for key, value := range i.annotations {
+	var annotationKeys []string
+	for key := range i.annotations {
 		for _, prefix := range i.annotationsPrefixes {
 			if strings.HasPrefix(key, prefix) {
-				devices = append(devices, strings.Split(value, ",")...)
+				annotationKeys = append(annotationKeys, key)
 				// There is no need to check additional prefixes since we
 				// typically deduplicate devices in any case.
 				break
 			}
 		}
+	}
+	// We sort the annotationKeys for consistent results.
+	slices.Sort(annotationKeys)
+
+	var devices []string
+	for _, key := range annotationKeys {
+		devices = append(devices, strings.Split(i.annotations[key], ",")...)
 	}
 	return devices
 }

--- a/internal/modifier/cdi_test.go
+++ b/internal/modifier/cdi_test.go
@@ -98,7 +98,7 @@ func TestDeviceRequests(t *testing.T) {
 					"another-prefix/bar": "example.com/device=baz",
 				},
 			},
-			expectedDevices: []string{"example.com/device=bar", "example.com/device=baz"},
+			expectedDevices: []string{"example.com/device=baz", "example.com/device=bar"},
 		},
 		{
 			description: "multiple matching annotations with duplicate devices",

--- a/internal/modifier/csv.go
+++ b/internal/modifier/csv.go
@@ -33,7 +33,7 @@ import (
 // NewCSVModifier creates a modifier that applies modications to an OCI spec if required by the runtime wrapper.
 // The modifications are defined by CSV MountSpecs.
 func NewCSVModifier(logger logger.Interface, cfg *config.Config, container image.CUDA) (oci.SpecModifier, error) {
-	if devices := container.VisibleDevicesFromEnvVar(); len(devices) == 0 {
+	if devices := container.VisibleDevices(); len(devices) == 0 {
 		logger.Infof("No modification required; no devices requested")
 		return nil, nil
 	}

--- a/internal/modifier/gated.go
+++ b/internal/modifier/gated.go
@@ -37,7 +37,7 @@ import (
 //
 // If not devices are selected, no changes are made.
 func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image image.CUDA, driver *root.Driver, hookCreator discover.HookCreator) (oci.SpecModifier, error) {
-	if devices := image.VisibleDevicesFromEnvVar(); len(devices) == 0 {
+	if devices := image.VisibleDevices(); len(devices) == 0 {
 		logger.Infof("No modification required; no devices requested")
 		return nil, nil
 	}

--- a/internal/modifier/graphics_test.go
+++ b/internal/modifier/graphics_test.go
@@ -26,9 +26,9 @@ import (
 
 func TestGraphicsModifier(t *testing.T) {
 	testCases := []struct {
-		description      string
-		envmap           map[string]string
-		expectedRequired bool
+		description     string
+		envmap          map[string]string
+		expectedDevices []string
 	}{
 		{
 			description: "empty image does not create modifier",
@@ -52,7 +52,7 @@ func TestGraphicsModifier(t *testing.T) {
 				"NVIDIA_VISIBLE_DEVICES":     "all",
 				"NVIDIA_DRIVER_CAPABILITIES": "all",
 			},
-			expectedRequired: true,
+			expectedDevices: []string{"all"},
 		},
 		{
 			description: "devices with graphics capability creates modifier",
@@ -60,7 +60,7 @@ func TestGraphicsModifier(t *testing.T) {
 				"NVIDIA_VISIBLE_DEVICES":     "all",
 				"NVIDIA_DRIVER_CAPABILITIES": "graphics",
 			},
-			expectedRequired: true,
+			expectedDevices: []string{"all"},
 		},
 		{
 			description: "devices with compute,graphics capability creates modifier",
@@ -68,7 +68,7 @@ func TestGraphicsModifier(t *testing.T) {
 				"NVIDIA_VISIBLE_DEVICES":     "all",
 				"NVIDIA_DRIVER_CAPABILITIES": "compute,graphics",
 			},
-			expectedRequired: true,
+			expectedDevices: []string{"all"},
 		},
 		{
 			description: "devices with display capability creates modifier",
@@ -76,7 +76,7 @@ func TestGraphicsModifier(t *testing.T) {
 				"NVIDIA_VISIBLE_DEVICES":     "all",
 				"NVIDIA_DRIVER_CAPABILITIES": "display",
 			},
-			expectedRequired: true,
+			expectedDevices: []string{"all"},
 		},
 		{
 			description: "devices with display,graphics capability creates modifier",
@@ -84,7 +84,7 @@ func TestGraphicsModifier(t *testing.T) {
 				"NVIDIA_VISIBLE_DEVICES":     "all",
 				"NVIDIA_DRIVER_CAPABILITIES": "display,graphics",
 			},
-			expectedRequired: true,
+			expectedDevices: []string{"all"},
 		},
 	}
 
@@ -94,7 +94,7 @@ func TestGraphicsModifier(t *testing.T) {
 				image.WithEnvMap(tc.envmap),
 			)
 			required, _ := requiresGraphicsModifier(image)
-			require.EqualValues(t, tc.expectedRequired, required)
+			require.EqualValues(t, tc.expectedDevices, required)
 		})
 	}
 }


### PR DESCRIPTION
The gated modifiers used to add support for GDS, Mofed, and CUDA Forward Comatibility only check the NVIDIA_VISIBLE_DEVICES envvar to determine whether GPUs are requested and modifications should be made. This means that use cases where volume mounts are used to request devices (e.g. when using the GPU Device Plugin) are not supported.

These changes make the extraction of devices for gated and graphics modifiers consistent with other methods.

Fixes: #1049