### PR TITLE
Make CDI device requests consistent with other methods

### DIFF
--- a/internal/config/image/builder.go
+++ b/internal/config/image/builder.go
@@ -50,7 +50,6 @@ func New(opt ...Option) (CUDA, error) {
 	if b.logger == nil {
 		b.logger = logger.New()
 	}
-
 	if b.env == nil {
 		b.env = make(map[string]string)
 	}
@@ -77,6 +76,20 @@ func WithAcceptDeviceListAsVolumeMounts(acceptDeviceListAsVolumeMounts bool) Opt
 func WithAcceptEnvvarUnprivileged(acceptEnvvarUnprivileged bool) Option {
 	return func(b *builder) error {
 		b.acceptEnvvarUnprivileged = acceptEnvvarUnprivileged
+		return nil
+	}
+}
+
+func WithAnnotations(annotations map[string]string) Option {
+	return func(b *builder) error {
+		b.annotations = annotations
+		return nil
+	}
+}
+
+func WithAnnotationsPrefixes(annotationsPrefixes []string) Option {
+	return func(b *builder) error {
+		b.annotationsPrefixes = annotationsPrefixes
 		return nil
 	}
 }

--- a/internal/config/image/cuda_image.go
+++ b/internal/config/image/cuda_image.go
@@ -95,6 +95,10 @@ func (i CUDA) IsLegacy() bool {
 	return len(legacyCudaVersion) > 0 && len(cudaRequire) == 0
 }
 
+func (i CUDA) IsPrivileged() bool {
+	return i.isPrivileged
+}
+
 // GetRequirements returns the requirements from all NVIDIA_REQUIRE_ environment
 // variables.
 func (i CUDA) GetRequirements() ([]string, error) {

--- a/internal/config/image/cuda_image_test.go
+++ b/internal/config/image/cuda_image_test.go
@@ -710,7 +710,7 @@ func TestCDIDeviceRequestsFromAnnotations(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			devices := image.CDIDeviceRequestsFromAnnotations()
+			devices := image.cdiDeviceRequestsFromAnnotations()
 			require.ElementsMatch(t, tc.expectedDevices, devices)
 		})
 	}

--- a/internal/config/image/cuda_image_test.go
+++ b/internal/config/image/cuda_image_test.go
@@ -487,9 +487,9 @@ func TestGetVisibleDevicesFromMounts(t *testing.T) {
 			expectedDevices: []string{"GPU0-MIG0/0/1", "GPU1-MIG0/0/1"},
 		},
 		{
-			description:     "cdi devices are ignored",
-			mounts:          makeTestMounts("GPU0", "cdi/nvidia.com/gpu=all", "GPU1"),
-			expectedDevices: []string{"GPU0", "GPU1"},
+			description:     "cdi devices are included",
+			mounts:          makeTestMounts("GPU0", "nvidia.com/gpu=all", "GPU1"),
+			expectedDevices: []string{"GPU0", "nvidia.com/gpu=all", "GPU1"},
 		},
 		{
 			description:     "imex devices are ignored",

--- a/internal/modifier/cdi_test.go
+++ b/internal/modifier/cdi_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/config/image"
 )
 
 func TestGetAnnotationDevices(t *testing.T) {
@@ -79,7 +81,13 @@ func TestGetAnnotationDevices(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			devices, err := getAnnotationDevices(tc.prefixes, tc.annotations)
+			image, err := image.New(
+				image.WithAnnotations(tc.annotations),
+				image.WithAnnotationsPrefixes(tc.prefixes),
+			)
+			require.NoError(t, err)
+
+			devices, err := getAnnotationDevices(image)
 			if tc.expectedError != nil {
 				require.Error(t, err)
 				return

--- a/internal/modifier/cdi_test.go
+++ b/internal/modifier/cdi_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config/image"
@@ -67,7 +69,7 @@ func TestGetAnnotationDevices(t *testing.T) {
 				"prefix/foo":         "example.com/device=bar",
 				"another-prefix/bar": "example.com/device=bar",
 			},
-			expectedDevices: []string{"example.com/device=bar"},
+			expectedDevices: []string{"example.com/device=bar", "example.com/device=bar"},
 		},
 		{
 			description: "invalid devices",
@@ -95,6 +97,70 @@ func TestGetAnnotationDevices(t *testing.T) {
 
 			require.NoError(t, err)
 			require.ElementsMatch(t, tc.expectedDevices, devices)
+		})
+	}
+}
+
+func TestDeviceRequests(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+
+	testCases := []struct {
+		description     string
+		input           cdiDeviceRequestor
+		spec            *specs.Spec
+		expectedDevices []string
+	}{
+		{
+			description: "empty spec yields no devices",
+		},
+		{
+			description: "cdi devices from mounts",
+			input: cdiDeviceRequestor{
+				defaultKind: "nvidia.com/gpu",
+			},
+			spec: &specs.Spec{
+				Mounts: []specs.Mount{
+					{
+						Destination: "/var/run/nvidia-container-devices/cdi/nvidia.com/gpu/0",
+						Source:      "/dev/null",
+					},
+					{
+						Destination: "/var/run/nvidia-container-devices/cdi/nvidia.com/gpu/1",
+						Source:      "/dev/null",
+					},
+				},
+			},
+			expectedDevices: []string{"nvidia.com/gpu=0", "nvidia.com/gpu=1"},
+		},
+		{
+			description: "cdi devices from envvar",
+			input: cdiDeviceRequestor{
+				defaultKind: "nvidia.com/gpu",
+			},
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Env: []string{"NVIDIA_VISIBLE_DEVICES=0,example.com/class=device"},
+				},
+			},
+			expectedDevices: []string{"nvidia.com/gpu=0", "example.com/class=device"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.input.logger = logger
+
+		image, err := image.NewCUDAImageFromSpec(
+			tc.spec,
+			image.WithAcceptDeviceListAsVolumeMounts(true),
+			image.WithAcceptEnvvarUnprivileged(true),
+		)
+		require.NoError(t, err)
+		tc.input.image = image
+
+		t.Run(tc.description, func(t *testing.T) {
+			devices := tc.input.DeviceRequests()
+			require.NoError(t, err)
+			require.EqualValues(t, tc.expectedDevices, devices)
 		})
 	}
 }

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -81,8 +81,6 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 		return nil, err
 	}
 
-	hookCreator := discover.NewHookCreator(discover.WithNVIDIACDIHookPath(cfg.NVIDIACTKConfig.Path))
-
 	mode := info.ResolveAutoMode(logger, cfg.NVIDIAContainerRuntimeConfig.Mode, image)
 	// We update the mode here so that we can continue passing just the config to other functions.
 	cfg.NVIDIAContainerRuntimeConfig.Mode = mode
@@ -91,6 +89,7 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 		return nil, err
 	}
 
+	hookCreator := discover.NewHookCreator(discover.WithNVIDIACDIHookPath(cfg.NVIDIACTKConfig.Path))
 	var modifiers modifier.List
 	for _, modifierType := range supportedModifierTypes(mode) {
 		switch modifierType {

--- a/internal/runtime/runtime_factory.go
+++ b/internal/runtime/runtime_factory.go
@@ -65,26 +65,12 @@ func newNVIDIAContainerRuntime(logger logger.Interface, cfg *config.Config, argv
 
 // newSpecModifier is a factory method that creates constructs an OCI spec modifer based on the provided config.
 func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Spec, driver *root.Driver) (oci.SpecModifier, error) {
-	rawSpec, err := ociSpec.Load()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load OCI spec: %v", err)
-	}
-
-	image, err := image.NewCUDAImageFromSpec(
-		rawSpec,
-		image.WithLogger(logger),
-		image.WithAcceptDeviceListAsVolumeMounts(cfg.AcceptDeviceListAsVolumeMounts),
-		image.WithAcceptEnvvarUnprivileged(cfg.AcceptEnvvarUnprivileged),
-		image.WithAnnotationsPrefixes(cfg.NVIDIAContainerRuntimeConfig.Modes.CDI.AnnotationPrefixes),
-	)
+	mode, image, err := initRuntimeModeAndImage(logger, cfg, ociSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	mode := info.ResolveAutoMode(logger, cfg.NVIDIAContainerRuntimeConfig.Mode, image)
-	// We update the mode here so that we can continue passing just the config to other functions.
-	cfg.NVIDIAContainerRuntimeConfig.Mode = mode
-	modeModifier, err := newModeModifier(logger, mode, cfg, image)
+	modeModifier, err := newModeModifier(logger, mode, cfg, *image)
 	if err != nil {
 		return nil, err
 	}
@@ -98,13 +84,13 @@ func newSpecModifier(logger logger.Interface, cfg *config.Config, ociSpec oci.Sp
 		case "nvidia-hook-remover":
 			modifiers = append(modifiers, modifier.NewNvidiaContainerRuntimeHookRemover(logger))
 		case "graphics":
-			graphicsModifier, err := modifier.NewGraphicsModifier(logger, cfg, image, driver, hookCreator)
+			graphicsModifier, err := modifier.NewGraphicsModifier(logger, cfg, *image, driver, hookCreator)
 			if err != nil {
 				return nil, err
 			}
 			modifiers = append(modifiers, graphicsModifier)
 		case "feature-gated":
-			featureGatedModifier, err := modifier.NewFeatureGatedModifier(logger, cfg, image, driver, hookCreator)
+			featureGatedModifier, err := modifier.NewFeatureGatedModifier(logger, cfg, *image, driver, hookCreator)
 			if err != nil {
 				return nil, err
 			}
@@ -126,6 +112,45 @@ func newModeModifier(logger logger.Interface, mode string, cfg *config.Config, i
 	}
 
 	return nil, fmt.Errorf("invalid runtime mode: %v", cfg.NVIDIAContainerRuntimeConfig.Mode)
+}
+
+// initRuntimeModeAndImage constructs an image from the specified OCI runtime
+// specification and runtime config.
+// The image is also used to determine the runtime mode to apply.
+// If a non-CDI mode is detected we ensure that the image does not process
+// annotation devices.
+func initRuntimeModeAndImage(logger logger.Interface, cfg *config.Config, ociSpec oci.Spec) (string, *image.CUDA, error) {
+	rawSpec, err := ociSpec.Load()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to load OCI spec: %v", err)
+	}
+
+	image, err := image.NewCUDAImageFromSpec(
+		rawSpec,
+		image.WithLogger(logger),
+		image.WithAcceptDeviceListAsVolumeMounts(cfg.AcceptDeviceListAsVolumeMounts),
+		image.WithAcceptEnvvarUnprivileged(cfg.AcceptEnvvarUnprivileged),
+		image.WithAnnotationsPrefixes(cfg.NVIDIAContainerRuntimeConfig.Modes.CDI.AnnotationPrefixes),
+	)
+	if err != nil {
+		return "", nil, err
+	}
+
+	mode := info.ResolveAutoMode(logger, cfg.NVIDIAContainerRuntimeConfig.Mode, image)
+	// We update the mode here so that we can continue passing just the config to other functions.
+	cfg.NVIDIAContainerRuntimeConfig.Mode = mode
+
+	if mode == "cdi" || len(cfg.NVIDIAContainerRuntimeConfig.Modes.CDI.AnnotationPrefixes) == 0 {
+		return mode, &image, nil
+	}
+
+	// For non-cdi modes we explicitly set the annotation prefixes to nil and
+	// call this function again to force a reconstruction of the image.
+	// Note that since the mode is now explicitly set, we will effectively skip
+	// the mode resolution.
+	cfg.NVIDIAContainerRuntimeConfig.Modes.CDI.AnnotationPrefixes = nil
+
+	return initRuntimeModeAndImage(logger, cfg, ociSpec)
 }
 
 // supportedModifierTypes returns the modifiers supported for a specific runtime mode.


### PR DESCRIPTION
Following the refactoring of device request extraction, we can now make CDI device requests consistent with other methods.

This change moves to using image.VisibleDevices instead of separate calls to CDIDevicesFromMounts and VisibleDevicesFromEnvVar. This also changes the way in which annotation requests are handled to be consistent with other mechanisms by including annotation devices in the list of VisibleDevices.

See:
* #1110 for the device request refactoring
* #1130 for making other requests consistent