### PR TITLE
Remove docker-run as default runtime candidate

### DIFF
--- a/cmd/nvidia-container-runtime/README.md
+++ b/cmd/nvidia-container-runtime/README.md
@@ -21,8 +21,8 @@ The `runtimes` config option allows for the low-level runtime to be specified. T
 The default value for this setting is:
 ```toml
 runtimes = [
-    "docker-runc",
     "runc",
+    "crun",
 ]
 ```
 

--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -27,7 +27,7 @@ const (
 )
 
 var availableRuntimes = map[string]struct{}{"docker": {}, "crio": {}, "containerd": {}}
-var defaultLowLevelRuntimes = []string{"docker-runc", "runc", "crun"}
+var defaultLowLevelRuntimes = []string{"runc", "crun"}
 
 var waitingForSignal = make(chan bool, 1)
 var signalReceived = make(chan bool, 1)

--- a/cmd/nvidia-ctk-installer/main_test.go
+++ b/cmd/nvidia-ctk-installer/main_test.go
@@ -67,7 +67,7 @@ swarm-resource = ""
   debug = "/dev/null"
   log-level = "info"
   mode = "auto"
-  runtimes = ["docker-runc", "runc", "crun"]
+  runtimes = ["runc", "crun"]
 
   [nvidia-container-runtime.modes]
 
@@ -131,7 +131,7 @@ swarm-resource = ""
   debug = "/dev/null"
   log-level = "info"
   mode = "auto"
-  runtimes = ["docker-runc", "runc", "crun"]
+  runtimes = ["runc", "crun"]
 
   [nvidia-container-runtime.modes]
 
@@ -198,7 +198,7 @@ swarm-resource = ""
   debug = "/dev/null"
   log-level = "info"
   mode = "auto"
-  runtimes = ["docker-runc", "runc", "crun"]
+  runtimes = ["runc", "crun"]
 
   [nvidia-container-runtime.modes]
 
@@ -262,7 +262,7 @@ swarm-resource = ""
   debug = "/dev/null"
   log-level = "info"
   mode = "auto"
-  runtimes = ["docker-runc", "runc", "crun"]
+  runtimes = ["runc", "crun"]
 
   [nvidia-container-runtime.modes]
 
@@ -348,7 +348,7 @@ swarm-resource = ""
   debug = "/dev/null"
   log-level = "info"
   mode = "auto"
-  runtimes = ["docker-runc", "runc", "crun"]
+  runtimes = ["runc", "crun"]
 
   [nvidia-container-runtime.modes]
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,7 @@ func GetDefault() (*Config, error) {
 		NVIDIAContainerRuntimeConfig: RuntimeConfig{
 			DebugFilePath: "/dev/null",
 			LogLevel:      "info",
-			Runtimes:      []string{"docker-runc", "runc", "crun"},
+			Runtimes:      []string{"runc", "crun"},
 			Mode:          "auto",
 			Modes: modesConfig{
 				CSV: csvModeConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,7 +63,7 @@ func TestGetConfig(t *testing.T) {
 				NVIDIAContainerRuntimeConfig: RuntimeConfig{
 					DebugFilePath: "/dev/null",
 					LogLevel:      "info",
-					Runtimes:      []string{"docker-runc", "runc", "crun"},
+					Runtimes:      []string{"runc", "crun"},
 					Mode:          "auto",
 					Modes: modesConfig{
 						CSV: csvModeConfig{
@@ -170,7 +170,7 @@ func TestGetConfig(t *testing.T) {
 				NVIDIAContainerRuntimeConfig: RuntimeConfig{
 					DebugFilePath: "/dev/null",
 					LogLevel:      "info",
-					Runtimes:      []string{"docker-runc", "runc", "crun"},
+					Runtimes:      []string{"runc", "crun"},
 					Mode:          "auto",
 					Modes: modesConfig{
 						CSV: csvModeConfig{
@@ -289,7 +289,7 @@ func TestGetConfig(t *testing.T) {
 				NVIDIAContainerRuntimeConfig: RuntimeConfig{
 					DebugFilePath: "/dev/null",
 					LogLevel:      "info",
-					Runtimes:      []string{"docker-runc", "runc", "crun"},
+					Runtimes:      []string{"runc", "crun"},
 					Mode:          "auto",
 					Modes: modesConfig{
 						CSV: csvModeConfig{
@@ -331,7 +331,7 @@ func TestGetConfig(t *testing.T) {
 				NVIDIAContainerRuntimeConfig: RuntimeConfig{
 					DebugFilePath: "/dev/null",
 					LogLevel:      "info",
-					Runtimes:      []string{"docker-runc", "runc", "crun"},
+					Runtimes:      []string{"runc", "crun"},
 					Mode:          "auto",
 					Modes: modesConfig{
 						CSV: csvModeConfig{

--- a/internal/config/toml_test.go
+++ b/internal/config/toml_test.go
@@ -62,7 +62,7 @@ load-kmods = true
 #debug = "/var/log/nvidia-container-runtime.log"
 log-level = "info"
 mode = "auto"
-runtimes = ["docker-runc", "runc", "crun"]
+runtimes = ["runc", "crun"]
 
 [nvidia-container-runtime.modes]
 


### PR DESCRIPTION
This change removes docker-runc as the highest priority default candidate for the low-level runtimes supported by the nvidia-container-runtime.