### PR TITLE
Refactor cdi api

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -312,7 +312,7 @@ func (m command) generateSpec(opts *options) (spec.Interface, error) {
 		return nil, fmt.Errorf("failed to create CDI library: %v", err)
 	}
 
-	deviceSpecs, err := cdilib.GetAllDeviceSpecs()
+	deviceSpecs, err := cdilib.GetDeviceSpecsByID("all")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device CDI specs: %v", err)
 	}

--- a/pkg/nvcdi/api.go
+++ b/pkg/nvcdi/api.go
@@ -39,6 +39,11 @@ type SpecGenerator interface {
 	GetSpec(...string) (spec.Interface, error)
 }
 
+// A DeviceSpecGenerator is used to generate the specs for one or more devices.
+type DeviceSpecGenerator interface {
+	GetDeviceSpecs() ([]specs.Device, error)
+}
+
 // A HookName represents one of the predefined NVIDIA CDI hooks.
 type HookName = discover.HookName
 

--- a/pkg/nvcdi/gds.go
+++ b/pkg/nvcdi/gds.go
@@ -28,10 +28,14 @@ import (
 
 type gdslib nvcdilib
 
-var _ wrapped = (*gdslib)(nil)
+var _ deviceSpecGeneratorFactory = (*gdslib)(nil)
 
-// GetDeviceSpecsByID returns the device specs for the specified devices.
-func (l *gdslib) GetDeviceSpecsByID(ids ...string) ([]specs.Device, error) {
+func (l *gdslib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
+	return l, nil
+}
+
+// GetDeviceSpecs returns the CDI device specs for a single all device.
+func (l *gdslib) GetDeviceSpecs() ([]specs.Device, error) {
 	discoverer, err := discover.NewGDSDiscoverer(l.logger, l.driverRoot, l.devRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GPUDirect Storage discoverer: %v", err)

--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -29,10 +29,9 @@ import (
 
 type csvlib nvcdilib
 
-var _ wrapped = (*csvlib)(nil)
+var _ deviceSpecGeneratorFactory = (*csvlib)(nil)
 
-// GetDeviceSpecsByID returns the device specs for the specified devices.
-func (l *csvlib) GetDeviceSpecsByID(ids ...string) ([]specs.Device, error) {
+func (l *csvlib) DeviceSpecGenerators(ids ...string) (DeviceSpecGenerator, error) {
 	for _, id := range ids {
 		switch id {
 		case "all":
@@ -42,6 +41,11 @@ func (l *csvlib) GetDeviceSpecsByID(ids ...string) ([]specs.Device, error) {
 		}
 	}
 
+	return l, nil
+}
+
+// GetDeviceSpecs returns the CDI device specs for a single device.
+func (l *csvlib) GetDeviceSpecs() ([]specs.Device, error) {
 	d, err := tegra.New(
 		tegra.WithLogger(l.logger),
 		tegra.WithDriverRoot(l.driverRoot),

--- a/pkg/nvcdi/lib-nvml.go
+++ b/pkg/nvcdi/lib-nvml.go
@@ -28,58 +28,11 @@ import (
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/edits"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/nvsandboxutils"
-	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec"
 )
 
 type nvmllib nvcdilib
 
-var _ Interface = (*nvmllib)(nil)
-
-// GetSpec should not be called for nvmllib
-func (l *nvmllib) GetSpec(...string) (spec.Interface, error) {
-	return nil, fmt.Errorf("unexpected call to nvmllib.GetSpec()")
-}
-
-// GetAllDeviceSpecs returns the device specs for all available devices.
-func (l *nvmllib) GetAllDeviceSpecs() ([]specs.Device, error) {
-	var deviceSpecs []specs.Device
-
-	if r := l.nvmllib.Init(); r != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to initialize NVML: %v", r)
-	}
-	defer func() {
-		if r := l.nvmllib.Shutdown(); r != nvml.SUCCESS {
-			l.logger.Warningf("failed to shutdown NVML: %v", r)
-		}
-	}()
-
-	if l.nvsandboxutilslib != nil {
-		if r := l.nvsandboxutilslib.Init(l.driverRoot); r != nvsandboxutils.SUCCESS {
-			l.logger.Warningf("Failed to init nvsandboxutils: %v; ignoring", r)
-			l.nvsandboxutilslib = nil
-		}
-		defer func() {
-			if l.nvsandboxutilslib == nil {
-				return
-			}
-			_ = l.nvsandboxutilslib.Shutdown()
-		}()
-	}
-
-	gpuDeviceSpecs, err := l.getGPUDeviceSpecs()
-	if err != nil {
-		return nil, err
-	}
-	deviceSpecs = append(deviceSpecs, gpuDeviceSpecs...)
-
-	migDeviceSpecs, err := l.getMigDeviceSpecs()
-	if err != nil {
-		return nil, err
-	}
-	deviceSpecs = append(deviceSpecs, migDeviceSpecs...)
-
-	return deviceSpecs, nil
-}
+var _ deviceSpecGeneratorFactory = (*nvmllib)(nil)
 
 // GetCommonEdits generates a CDI specification that can be used for ANY devices
 func (l *nvmllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
@@ -91,68 +44,110 @@ func (l *nvmllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
 	return edits.FromDiscoverer(common)
 }
 
-// GetDeviceSpecsByID returns the CDI device specs for the GPU(s) represented by
-// the provided identifiers, where an identifier is an index or UUID of a valid
-// GPU device.
-// Deprecated: Use GetDeviceSpecsBy instead.
-func (l *nvmllib) GetDeviceSpecsByID(ids ...string) ([]specs.Device, error) {
-	var identifiers []device.Identifier
-	for _, id := range ids {
-		identifiers = append(identifiers, device.Identifier(id))
+// DeviceSpecGenerators returns the CDI device spec generators for NVML devices
+// with the specified IDs.
+// Supported IDs are:
+// * an index of a GPU or MIG device
+// * a UUID of a GPU or MIG device
+// * the special ID 'all'
+func (l *nvmllib) DeviceSpecGenerators(ids ...string) (DeviceSpecGenerator, error) {
+	if err := l.init(); err != nil {
+		return nil, err
 	}
-	return l.GetDeviceSpecsBy(identifiers...)
+	defer l.tryShutdown()
+
+	dsgs, err := l.getDeviceSpecGeneratorsForIDs(ids...)
+	if err != nil {
+		return nil, err
+	}
+	return l.withInit(dsgs), nil
 }
 
-// GetDeviceSpecsBy returns the device specs for devices with the specified identifiers.
-func (l *nvmllib) GetDeviceSpecsBy(identifiers ...device.Identifier) ([]specs.Device, error) {
-	for _, id := range identifiers {
+func (l *nvmllib) getDeviceSpecGeneratorsForIDs(ids ...string) (DeviceSpecGenerator, error) {
+	var identifiers []device.Identifier
+	for _, id := range ids {
 		if id == "all" {
-			return l.GetAllDeviceSpecs()
+			return l.getDeviceSpecGeneratorsForAllDevices()
 		}
+		identifiers = append(identifiers, device.Identifier(id))
 	}
 
-	var deviceSpecs []specs.Device
-
-	if r := l.nvmllib.Init(); r != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to initialize NVML: %w", r)
-	}
-	defer func() {
-		if r := l.nvmllib.Shutdown(); r != nvml.SUCCESS {
-			l.logger.Warningf("failed to shutdown NVML: %v", r)
-		}
-	}()
-
-	if l.nvsandboxutilslib != nil {
-		if r := l.nvsandboxutilslib.Init(l.driverRoot); r != nvsandboxutils.SUCCESS {
-			l.logger.Warningf("Failed to init nvsandboxutils: %v; ignoring", r)
-			l.nvsandboxutilslib = nil
-		}
-		defer func() {
-			if l.nvsandboxutilslib == nil {
-				return
-			}
-			_ = l.nvsandboxutilslib.Shutdown()
-		}()
-	}
-
-	nvmlDevices, err := l.getNVMLDevicesByID(identifiers...)
+	devices, err := l.getNVMLDevicesByID(identifiers...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get NVML device handles: %w", err)
+		return nil, err
 	}
 
-	for i, nvmlDevice := range nvmlDevices {
-		deviceEdits, err := l.getEditsForDevice(nvmlDevice)
+	var DeviceSpecGenerators DeviceSpecGenerators
+	for i, device := range devices {
+		editor, err := l.newDeviceSpecGeneratorFromNVMLDevice(ids[i], device)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get CDI device edits for identifier %q: %w", identifiers[i], err)
+			return nil, err
 		}
-		deviceSpec := specs.Device{
-			Name:           string(identifiers[i]),
-			ContainerEdits: *deviceEdits.ContainerEdits,
-		}
-		deviceSpecs = append(deviceSpecs, deviceSpec)
+		DeviceSpecGenerators = append(DeviceSpecGenerators, editor)
 	}
 
-	return deviceSpecs, nil
+	return DeviceSpecGenerators, nil
+}
+
+func (l *nvmllib) newDeviceSpecGeneratorFromNVMLDevice(id string, nvmlDevice nvml.Device) (DeviceSpecGenerator, error) {
+	isMig, ret := nvmlDevice.IsMigDeviceHandle()
+	if ret != nvml.SUCCESS {
+		return nil, ret
+	}
+	if isMig {
+		return l.newMIGDeviceSpecGeneratorFromNVMLDevice(id, nvmlDevice)
+	}
+
+	return l.newFullGPUDeviceSpecGeneratorFromNVMLDevice(id, nvmlDevice)
+}
+
+// getDeviceSpecGeneratorsForAllDevices returns the CDI device spec generators
+// for all NVML devices detected on the system.
+// This includes full GPUs as well as MIG devices.
+func (l *nvmllib) getDeviceSpecGeneratorsForAllDevices() (DeviceSpecGenerator, error) {
+	var DeviceSpecGenerators DeviceSpecGenerators
+	err := l.devicelib.VisitDevices(func(i int, d device.Device) error {
+		isMigEnabled, err := d.IsMigEnabled()
+		if err != nil {
+			return err
+		}
+		if isMigEnabled {
+			return nil
+		}
+		e := &fullGPUDeviceSpecGenerator{
+			nvmllib: l,
+			id:      fmt.Sprintf("%d", i),
+			index:   i,
+			device:  d,
+		}
+
+		DeviceSpecGenerators = append(DeviceSpecGenerators, e)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get full GPU device editors: %w", err)
+	}
+
+	err = l.devicelib.VisitMigDevices(func(i int, d device.Device, j int, mig device.MigDevice) error {
+		parentGenerator := &fullGPUDeviceSpecGenerator{
+			nvmllib: l,
+			index:   i,
+			id:      fmt.Sprintf("%d:%d", i, j),
+			device:  d,
+		}
+		migGenerator := &migDeviceSpecGenerator{
+			fullGPUDeviceSpecGenerator: parentGenerator,
+			migIndex:                   j,
+			migDevice:                  mig,
+		}
+		DeviceSpecGenerators = append(DeviceSpecGenerators, parentGenerator, migGenerator)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get MIG device editors: %w", err)
+	}
+
+	return DeviceSpecGenerators, nil
 }
 
 // TODO: move this to go-nvlib?
@@ -192,8 +187,9 @@ func (l *nvmllib) getNVMLDeviceByID(id device.Identifier) (nvml.Device, error) {
 		if migIdx, err = strconv.Atoi(split[1]); err != nil {
 			return nil, fmt.Errorf("failed to convert device index to an int: %w", err)
 		}
-		if parent, err = l.nvmllib.DeviceGetHandleByIndex(gpuIdx); err != nvml.SUCCESS {
-			return nil, fmt.Errorf("failed to get parent device handle: %w", err)
+		parent, ret := l.nvmllib.DeviceGetHandleByIndex(gpuIdx)
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("failed to get parent device handle: %v", ret)
 		}
 		return parent.GetMigDeviceHandleByIndex(migIdx)
 	}
@@ -201,76 +197,51 @@ func (l *nvmllib) getNVMLDeviceByID(id device.Identifier) (nvml.Device, error) {
 	return nil, fmt.Errorf("identifier is not a valid UUID or index: %q", id)
 }
 
-func (l *nvmllib) getEditsForDevice(nvmlDevice nvml.Device) (*cdi.ContainerEdits, error) {
-	mig, err := nvmlDevice.IsMigDeviceHandle()
-	if err != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to determine if device handle is a MIG device: %w", err)
-	}
-	if mig {
-		return l.getEditsForMIGDevice(nvmlDevice)
-	}
-	return l.getEditsForGPUDevice(nvmlDevice)
-}
-
-func (l *nvmllib) getEditsForGPUDevice(nvmlDevice nvml.Device) (*cdi.ContainerEdits, error) {
-	nvlibDevice, err := l.devicelib.NewDevice(nvmlDevice)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct device: %w", err)
-	}
-	deviceEdits, err := l.GetGPUDeviceEdits(nvlibDevice)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get GPU device edits: %w", err)
+func (l *nvmllib) init() error {
+	if r := l.nvmllib.Init(); r != nvml.SUCCESS {
+		return fmt.Errorf("failed to initialize NVML: %w", r)
 	}
 
-	return deviceEdits, nil
-}
-
-func (l *nvmllib) getEditsForMIGDevice(nvmlDevice nvml.Device) (*cdi.ContainerEdits, error) {
-	nvmlParentDevice, ret := nvmlDevice.GetDeviceHandleFromMigDeviceHandle()
-	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to get parent device handle: %w", ret)
-	}
-	nvlibMigDevice, err := l.devicelib.NewMigDevice(nvmlDevice)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct device: %w", err)
-	}
-	nvlibParentDevice, err := l.devicelib.NewDevice(nvmlParentDevice)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct parent device: %w", err)
-	}
-	return l.GetMIGDeviceEdits(nvlibParentDevice, nvlibMigDevice)
-}
-
-func (l *nvmllib) getGPUDeviceSpecs() ([]specs.Device, error) {
-	var deviceSpecs []specs.Device
-	err := l.devicelib.VisitDevices(func(i int, d device.Device) error {
-		specsForDevice, err := l.GetGPUDeviceSpecs(i, d)
-		if err != nil {
-			return err
-		}
-		deviceSpecs = append(deviceSpecs, specsForDevice...)
-
+	if l.nvsandboxutilslib == nil {
 		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate CDI edits for GPU devices: %v", err)
 	}
-	return deviceSpecs, err
+	if r := l.nvsandboxutilslib.Init(l.driverRoot); r != nvsandboxutils.SUCCESS {
+		l.logger.Warningf("Failed to init nvsandboxutils: %v; ignoring", r)
+		l.nvsandboxutilslib = nil
+	}
+	return nil
 }
 
-func (l *nvmllib) getMigDeviceSpecs() ([]specs.Device, error) {
-	var deviceSpecs []specs.Device
-	err := l.devicelib.VisitMigDevices(func(i int, d device.Device, j int, mig device.MigDevice) error {
-		specsForDevice, err := l.GetMIGDeviceSpecs(i, d, j, mig)
-		if err != nil {
-			return err
+func (l *nvmllib) tryShutdown() {
+	if l.nvsandboxutilslib != nil {
+		if r := l.nvsandboxutilslib.Shutdown(); r != nvsandboxutils.SUCCESS {
+			l.logger.Warningf("failed to shutdown nvsandboxutils: %v", r)
 		}
-		deviceSpecs = append(deviceSpecs, specsForDevice...)
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate CDI edits for GPU devices: %v", err)
 	}
-	return deviceSpecs, err
+	if r := l.nvmllib.Shutdown(); r != nvml.SUCCESS {
+		l.logger.Warningf("failed to shutdown NVML: %v", r)
+	}
+}
+
+type deviceSpecGeneratorsWithAndShutdown struct {
+	*nvmllib
+	DeviceSpecGenerator
+}
+
+func (l *nvmllib) withInit(dsg DeviceSpecGenerator) DeviceSpecGenerator {
+	return &deviceSpecGeneratorsWithAndShutdown{
+		nvmllib:             l,
+		DeviceSpecGenerator: dsg,
+	}
+}
+
+// GetDeviceSpecs ensures that the init and shutdown are called before (and
+// after) generating the required device specs.
+func (d *deviceSpecGeneratorsWithAndShutdown) GetDeviceSpecs() ([]specs.Device, error) {
+	if err := d.init(); err != nil {
+		return nil, err
+	}
+	defer d.tryShutdown()
+
+	return d.DeviceSpecGenerator.GetDeviceSpecs()
 }

--- a/pkg/nvcdi/lib-nvml_test.go
+++ b/pkg/nvcdi/lib-nvml_test.go
@@ -1,0 +1,143 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package nvcdi
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	mocknvml "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+)
+
+func TestNvmllibGetDeviceSpecGeneratorsForIDs(t *testing.T) {
+	testCases := []struct {
+		name               string
+		ids                []string
+		setupMock          func(*dgxa100.Server)
+		expectedError      error
+		expectedLength     int
+		expectedGenerators DeviceSpecGenerators
+	}{
+		{
+			name:           "all devices",
+			ids:            []string{"all"},
+			expectedError:  nil,
+			expectedLength: 8,
+		},
+		{
+			name: "single GPU index",
+			ids:  []string{"0"},
+			setupMock: func(server *dgxa100.Server) {
+				for _, d := range server.Devices {
+					// TODO: This is not implemented in the mock.
+					(d.(*dgxa100.Device)).IsMigDeviceHandleFunc = func() (bool, nvml.Return) {
+						return false, nvml.SUCCESS
+					}
+				}
+			},
+			expectedError:  nil,
+			expectedLength: 1,
+		},
+		{
+			name: "single UUID",
+			ids:  []string{"GPU-12345678-1234-1234-1234-123456789abc"},
+			setupMock: func(server *dgxa100.Server) {
+				for _, d := range server.Devices {
+					// TODO: This is not implemented in the mock.
+					(d.(*dgxa100.Device)).IsMigDeviceHandleFunc = func() (bool, nvml.Return) {
+						return false, nvml.SUCCESS
+					}
+				}
+				server.DeviceGetHandleByUUIDFunc = func(s string) (nvml.Device, nvml.Return) {
+					if s == "GPU-12345678-1234-1234-1234-123456789abc" {
+						return server.Devices[3], nvml.SUCCESS
+					}
+					return nil, nvml.ERROR_INVALID_ARGUMENT
+				}
+			},
+			expectedError:  nil,
+			expectedLength: 1,
+		},
+		{
+			name: "MIG device index",
+			ids:  []string{"0:0"},
+			setupMock: func(server *dgxa100.Server) {
+				server.Devices[0].(*dgxa100.Device).GetMigDeviceHandleByIndexFunc = func(n int) (nvml.Device, nvml.Return) {
+					if n != 0 {
+						return nil, nvml.ERROR_INVALID_ARGUMENT
+					}
+
+					mig := &mocknvml.Device{
+						IsMigDeviceHandleFunc: func() (bool, nvml.Return) {
+							return true, nvml.SUCCESS
+						},
+						GetDeviceHandleFromMigDeviceHandleFunc: func() (nvml.Device, nvml.Return) {
+							return server.Devices[0], nvml.SUCCESS
+						},
+						GetIndexFunc: func() (int, nvml.Return) {
+							return 0, nvml.SUCCESS
+						},
+					}
+					return mig, nvml.SUCCESS
+				}
+			},
+			expectedError:  nil,
+			expectedLength: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up a mock server, using the DGX A100 mock.
+			mockNvml := dgxa100.New()
+			mockOverrides(mockNvml)
+			if tc.setupMock != nil {
+				tc.setupMock(mockNvml)
+			}
+
+			mockDev := device.New(mockNvml)
+
+			l := &nvmllib{
+				nvmllib:   mockNvml,
+				devicelib: mockDev,
+			}
+			// Call the function under test
+			generators, err := l.getDeviceSpecGeneratorsForIDs(tc.ids...)
+
+			require.EqualValues(t, tc.expectedError, err)
+			require.Len(t, generators, tc.expectedLength)
+		})
+	}
+}
+
+// TODO: These need to be implemented in go-nvlib
+func mockOverrides(server *dgxa100.Server) {
+	for i, d := range server.Devices {
+		// TODO: This is not implemented in the mock.
+		(d.(*dgxa100.Device)).GetMaxMigDeviceCountFunc = func() (int, nvml.Return) {
+			return 0, nvml.SUCCESS
+		}
+		(d.(*dgxa100.Device)).GetIndexFunc = func() (int, nvml.Return) {
+			return i, nvml.SUCCESS
+		}
+	}
+}

--- a/pkg/nvcdi/lib-wsl.go
+++ b/pkg/nvcdi/lib-wsl.go
@@ -27,10 +27,14 @@ import (
 
 type wsllib nvcdilib
 
-var _ wrapped = (*wsllib)(nil)
+var _ deviceSpecGeneratorFactory = (*wsllib)(nil)
 
-// GetDeviceSpecsByID returns the device specs for the specified devices.
-func (l *wsllib) GetDeviceSpecsByID(...string) ([]specs.Device, error) {
+func (l *wsllib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
+	return l, nil
+}
+
+// GetDeviceSpecs returns the CDI device specs for a single all device.
+func (l *wsllib) GetDeviceSpecs() ([]specs.Device, error) {
 	device := newDXGDeviceDiscoverer(l.logger, l.devRoot)
 	deviceEdits, err := edits.FromDiscoverer(device)
 	if err != nil {

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -118,39 +118,39 @@ func New(opts ...Option) (Interface, error) {
 		)
 	}
 
-	var lib wrapped
+	var factory deviceSpecGeneratorFactory
 	switch l.resolveMode() {
 	case ModeCSV:
 		if len(l.csvFiles) == 0 {
 			l.csvFiles = csv.DefaultFileList()
 		}
-		lib = (*csvlib)(l)
+		factory = (*csvlib)(l)
 	case ModeManagement:
 		if l.vendor == "" {
 			l.vendor = "management.nvidia.com"
 		}
 		// Management containers in general do not require CUDA Forward compatibility.
 		l.disabledHooks = append(l.disabledHooks, HookEnableCudaCompat, DisableDeviceNodeModificationHook)
-		lib = (*managementlib)(l)
+		factory = (*managementlib)(l)
 	case ModeNvml:
-		lib = (*nvmllib)(l)
+		factory = (*nvmllib)(l)
 	case ModeWsl:
-		lib = (*wsllib)(l)
+		factory = (*wsllib)(l)
 	case ModeGds:
 		if l.class == "" {
 			l.class = "gds"
 		}
-		lib = (*gdslib)(l)
+		factory = (*gdslib)(l)
 	case ModeMofed:
 		if l.class == "" {
 			l.class = "mofed"
 		}
-		lib = (*mofedlib)(l)
+		factory = (*mofedlib)(l)
 	case ModeImex:
 		if l.class == "" {
 			l.class = classImexChannel
 		}
-		lib = (*imexlib)(l)
+		factory = (*imexlib)(l)
 	default:
 		return nil, fmt.Errorf("unknown mode %q", l.mode)
 	}
@@ -162,7 +162,7 @@ func New(opts ...Option) (Interface, error) {
 	)
 
 	w := wrapper{
-		wrapped:             lib,
+		factory:             factory,
 		vendor:              l.vendor,
 		class:               l.class,
 		mergedDeviceOptions: l.mergedDeviceOptions,

--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -32,20 +32,14 @@ import (
 
 type managementlib nvcdilib
 
-var _ wrapped = (*managementlib)(nil)
+var _ deviceSpecGeneratorFactory = (*managementlib)(nil)
 
-// GetAllDeviceSpecs returns all device specs for use in managemnt containers.
-// A single device with the name `all` is returned.
-//
-// Deprecated: Use GetDeviceSpecsByID("all") instead.
-func (m *managementlib) GetAllDeviceSpecs() ([]specs.Device, error) {
-	return m.GetDeviceSpecsByID("all")
+func (l *managementlib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
+	return l, nil
 }
 
-// GetDeviceSpecsByID returns the CDI device specs for the GPU(s) represented by
-// the provided identifiers, where an identifier is an index or UUID of a valid
-// GPU device.
-func (m *managementlib) GetDeviceSpecsByID(...string) ([]specs.Device, error) {
+// GetDeviceSpecs returns the CDI device specs for a single all device.
+func (m *managementlib) GetDeviceSpecs() ([]specs.Device, error) {
 	devices, err := m.newManagementDeviceDiscoverer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device discoverer: %v", err)

--- a/pkg/nvcdi/mofed.go
+++ b/pkg/nvcdi/mofed.go
@@ -28,10 +28,14 @@ import (
 
 type mofedlib nvcdilib
 
-var _ wrapped = (*mofedlib)(nil)
+var _ deviceSpecGeneratorFactory = (*mofedlib)(nil)
 
-// GetDeviceSpecsByID returns the device specs for the specified devices.
-func (l *mofedlib) GetDeviceSpecsByID(...string) ([]specs.Device, error) {
+func (l *mofedlib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
+	return l, nil
+}
+
+// GetDeviceSpecs returns the CDI device specs for a single all device.
+func (l *mofedlib) GetDeviceSpecs() ([]specs.Device, error) {
 	discoverer, err := discover.NewMOFEDDiscoverer(l.logger, l.driverRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MOFED discoverer: %v", err)


### PR DESCRIPTION
The original CDI spec generation API was focussed on NVML device specifically. Since then we have replaced the more specific functions (for GPU and MIG devices) in the API with more generally applicable functions based on mode and device IDs.

This organic growth of APIs also means that for the NVML case specifically we had multiple different implementations of CDI spec generation making keeping things consistent more difficult.

Thes changes remove the redundant functions in the `nvcdi.Interface` allowing devices to be requested by ID across all use cases. It also refactors the CDI spec generation for NVML devices to ensure that the same generation logic is used for all cases.