### PR TITLE
[no-relnote] Add e2e test for firmware path traversal

### DIFF
--- a/tests/e2e/runner.go
+++ b/tests/e2e/runner.go
@@ -124,7 +124,7 @@ func (r remoteRunner) Run(script string) (string, string, error) {
 	// Run the script
 	err = session.Run(script)
 	if err != nil {
-		return "", "", fmt.Errorf("script execution failed: %v\nSTDOUT: %s\nSTDERR: %s", err, stdout.String(), stderr.String())
+		return "", stderr.String(), fmt.Errorf("script execution failed: %v\nSTDOUT: %s\nSTDERR: %s", err, stdout.String(), stderr.String())
 	}
 
 	// Return stdout as string if no errors


### PR DESCRIPTION
A container image could be crafted with a symbolic link in
/lib/firmware/nvidia/ that points to a location outside of the
container's root filesystem. When running such a container with the
NVIDIA Container Toolkit, this could potentially lead to files being
created on the host filesystem.

This change adds an end-to-end test to ensure that the toolkit is not
vulnerable to this kind of path traversal attack.

The test case covers two scenarios:
- When using CDI, which is the default, the test ensures that the
  container runs without error and no files are created on the host.
- When using the legacy nvidia-container-runtime-hook, the test
  ensures that the operation fails with a specific path error,
  preventing any file creation on the host.