### PR TITLE
[no-relnote] fix(systemd): Support alternative nvidia-smi path in refresh service

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -14,7 +14,8 @@
 
 [Unit]
 Description=Refresh NVIDIA CDI specification file
-ConditionPathExists=/usr/bin/nvidia-smi
+ConditionPathExists=|/usr/bin/nvidia-smi
+ConditionPathExists=|/usr/sbin/nvidia-smi
 ConditionPathExists=/usr/bin/nvidia-ctk
 
 [Service]


### PR DESCRIPTION
The nvidia-cdi-refresh.service unit hardcodes the path to nvidia-smi as /usr/bin/nvidia-smi. On RPM-based distributions, this binary is often located at /usr/sbin/nvidia-smi.

This change modifies the systemd service file to check for the existence of nvidia-smi in both /usr/bin and /usr/sbin. By using the '|' prefix on the ConditionPathExists directives, we ensure that the condition is met if either path exists, making the service compatible across both DEB and RPM-based systems.

Ref: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Conditions%20and%20Asserts 