### PR TITLE
[no-relnote] cleanup /etc/cdi/nvidia.yaml on uninstall

### DIFF
--- a/packaging/debian/nvidia-container-toolkit.postrm
+++ b/packaging/debian/nvidia-container-toolkit.postrm
@@ -6,11 +6,11 @@ NVIDIA_CONTAINER_RUNTIME_HOOK=/usr/bin/nvidia-container-runtime-hook
 NVIDIA_CONTAINER_TOOLKIT=/usr/bin/nvidia-container-toolkit
 
 case "$1" in
-    purge)
+    purge|remove)
         [ -L "${NVIDIA_CONTAINER_TOOLKIT}" ] && rm ${NVIDIA_CONTAINER_TOOLKIT}
     ;;
 
-    upgrade|failed-upgrade|remove|abort-install|abort-upgrade|disappear)
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
 
     *)

--- a/packaging/rpm/SPECS/nvidia-container-toolkit.spec
+++ b/packaging/rpm/SPECS/nvidia-container-toolkit.spec
@@ -78,6 +78,11 @@ if [ "$1" = 0 ]; then  # package is uninstalled, not upgraded
   if [ -L %{_bindir}/nvidia-container-toolkit ]; then rm -f %{_bindir}/nvidia-container-toolkit; fi
 fi
 
+%postun base
+if [ "$1" -eq 0 ]; then
+    rm -f %{_sysconfdir}/cdi/nvidia.yaml
+fi
+
 %files
 %license LICENSE
 %{_bindir}/nvidia-container-runtime-hook
@@ -109,6 +114,7 @@ Provides tools such as the NVIDIA Container Runtime and NVIDIA Container Toolkit
 %{_sysconfdir}/systemd/system/nvidia-cdi-refresh.service
 %{_sysconfdir}/systemd/system/nvidia-cdi-refresh.path
 %config(noreplace) %{_sysconfdir}/nvidia-container-toolkit/nvidia-cdi-refresh.env
+%ghost %{_sysconfdir}/cdi/nvidia.yaml
 
 # The OPERATOR EXTENSIONS package consists of components that are required to enable GPU support in Kubernetes.
 # This package is not distributed as part of the NVIDIA Container Toolkit RPMs.


### PR DESCRIPTION
This PR adds a cleanup of `/etc/cdi/nvidia.yaml` upon uninstallation (not upgrade) of the `nvidia-container-toolkit-base` package.

When things are truly screwed up on my system, uninstall and reinstall of the nvidia components is a quick way to get back to a known state.  However, since the current packages don't track the CDI config, a broken nvidia.yaml can persist on the system.  If I don't remember I generated this file, I wont remember to remake it.  My existing config management notices when the file is missing and builds it automatically.