### PR TITLE
[no-relnote] Setup envfile for systemd services

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.env
+++ b/deployments/systemd/nvidia-cdi-refresh.env
@@ -1,0 +1,20 @@
+# This file can be used to override the configuration of the
+#   nvidia-ctk cdi generate
+# command invoked by the nvidia-cdi-refresh.service.
+#
+# This is done by specifying the name and value of the environment variables in
+# this file as follows:
+#
+# ENVVAR=value
+#
+# For a list of envvars that can be set set the output of:
+#
+#   nvidia-ctk --help
+#
+# and
+#
+#   nvidia-ctk cdi generate --help
+#
+# For example, to change the for the generated CDI specification update and
+# uncomment the following line:
+# NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml

--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -20,9 +20,11 @@ ConditionPathExists=/usr/bin/nvidia-ctk
 
 [Service]
 Type=oneshot
-EnvironmentFile=-/etc/nvidia-container-toolkit/cdi-refresh.env
+# Values from Environment will be replaced if defined in EnvironmentFile
+Environment=NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml
+EnvironmentFile=-/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
 ExecCondition=/usr/bin/grep -qE '/nvidia.ko' /lib/modules/%v/modules.dep
-ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
+ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
 
 [Install]

--- a/packaging/debian/nvidia-container-toolkit-base.install
+++ b/packaging/debian/nvidia-container-toolkit-base.install
@@ -3,3 +3,4 @@ nvidia-ctk /usr/bin
 nvidia-cdi-hook /usr/bin
 nvidia-cdi-refresh.service /etc/systemd/system/
 nvidia-cdi-refresh.path /etc/systemd/system/
+nvidia-cdi-refresh.env /etc/nvidia-container-toolkit/

--- a/packaging/rpm/SPECS/nvidia-container-toolkit.spec
+++ b/packaging/rpm/SPECS/nvidia-container-toolkit.spec
@@ -19,6 +19,7 @@ Source5: nvidia-container-runtime.legacy
 Source6: nvidia-cdi-hook
 Source7: nvidia-cdi-refresh.service
 Source8: nvidia-cdi-refresh.path
+Source9: nvidia-cdi-refresh.env
 
 Obsoletes: nvidia-container-runtime <= 3.5.0-1, nvidia-container-runtime-hook <= 1.4.0-2
 Provides: nvidia-container-runtime
@@ -35,6 +36,7 @@ cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} 
 %install
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sysconfdir}/systemd/system/
+mkdir -p %{buildroot}%{_sysconfdir}/nvidia-container-toolkit
 
 install -m 755 -t %{buildroot}%{_bindir} nvidia-container-runtime-hook
 install -m 755 -t %{buildroot}%{_bindir} nvidia-container-runtime
@@ -44,6 +46,7 @@ install -m 755 -t %{buildroot}%{_bindir} nvidia-ctk
 install -m 755 -t %{buildroot}%{_bindir} nvidia-cdi-hook
 install -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system nvidia-cdi-refresh.service
 install -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system nvidia-cdi-refresh.path
+install -m 644 -t %{buildroot}%{_sysconfdir}/nvidia-container-toolkit nvidia-cdi-refresh.env
 
 %post
 if [ $1 -gt 1 ]; then  # only on package upgrade
@@ -105,6 +108,7 @@ Provides tools such as the NVIDIA Container Runtime and NVIDIA Container Toolkit
 %{_bindir}/nvidia-cdi-hook
 %{_sysconfdir}/systemd/system/nvidia-cdi-refresh.service
 %{_sysconfdir}/systemd/system/nvidia-cdi-refresh.path
+%config(noreplace) %{_sysconfdir}/nvidia-container-toolkit/nvidia-cdi-refresh.env
 
 # The OPERATOR EXTENSIONS package consists of components that are required to enable GPU support in Kubernetes.
 # This package is not distributed as part of the NVIDIA Container Toolkit RPMs.


### PR DESCRIPTION
This updates the packages to include the referenced environment file for the systemd unit files.  Additionally it switches the exec to then use a referenced variable for the cdi output.