### PR TITLE
[no-relnote] Fix rpm package definition

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -50,7 +50,7 @@ jobs:
         skip-cache: true
 
     - name: Check golang modules
-      run: | 
+      run: |
         make check-vendor
         make -C deployments/devel check-modules
 
@@ -71,11 +71,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-      
+
       - name: Run unit tests and generate coverage report
         run: make coverage
 
       - name: Upload to Coveralls
+        continue-on-error: true
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/packaging/rpm/SPECS/nvidia-container-toolkit.spec
+++ b/packaging/rpm/SPECS/nvidia-container-toolkit.spec
@@ -31,7 +31,7 @@ Requires: nvidia-container-toolkit-base == %{version}-%{release}
 Provides tools and utilities to enable GPU support in containers.
 
 %prep
-cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} .
+cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} %{SOURCE9} .
 
 %install
 mkdir -p %{buildroot}%{_bindir}


### PR DESCRIPTION
The change from c4a9bbe6afa77998232d5fe5b8388a15121f6538 did not add the envfile to the rpm sources.