### PR TITLE
Fix:Local yum repo not enabled by default in centos8 and fedora35 entrypoints

### DIFF
--- a/tests/release/docker/centos8/entrypoint.sh
+++ b/tests/release/docker/centos8/entrypoint.sh
@@ -22,17 +22,17 @@
 : ${LOCAL_REPO_DIRECTORY:=/local-repository}
 if [[ -d ${LOCAL_REPO_DIRECTORY} ]]; then
     echo "Setting up local-repository"
-    createrepo /local-repository
+    createrepo "${LOCAL_REPO_DIRECTORY}"
 
     cat >/etc/yum.repos.d/local.repo <<EOL
 [local-repository]
 name=NVIDIA Container Toolkit Local Packages
-baseurl=file:///local-repository
-enabled=0
+baseurl=file://${LOCAL_REPO_DIRECTORY}
+enabled=1
 gpgcheck=0
 protect=1
 EOL
-    yum-config-manager --enable local-repository
+    
 elif [[ -n ${TEST_REPO} ]]; then
     ./install_repo.sh ${TEST_REPO}
 else

--- a/tests/release/docker/fedora35/entrypoint.sh
+++ b/tests/release/docker/fedora35/entrypoint.sh
@@ -22,17 +22,16 @@
 : ${LOCAL_REPO_DIRECTORY:=/local-repository}
 if [[ -d ${LOCAL_REPO_DIRECTORY} ]]; then
     echo "Setting up local-repository"
-    createrepo /local-repository
+    createrepo "${LOCAL_REPO_DIRECTORY}"
 
     cat >/etc/yum.repos.d/local.repo <<EOL
 [local-repository]
 name=NVIDIA Container Toolkit Local Packages
-baseurl=file:///local-repository
-enabled=0
+baseurl=file://${LOCAL_REPO_DIRECTORY}
+enabled=1
 gpgcheck=0
 protect=1
 EOL
-    yum-config-manager --enable local-repository
 elif [[ -n ${TEST_REPO} ]]; then
     ./install_repo.sh ${TEST_REPO}
 else


### PR DESCRIPTION
Summary
This patch fixes an issue in the entrypoint.sh scripts for both CentOS 8 and Fedora 35 where the local YUM repository was not being used by default during test runs.

Issue
Even though the script creates a local YUM repository file (local.repo), it was configured with enabled=0, which means it is disabled by default. While yum-config-manager --enable local-repository was called, this is not always reliable in automated or minimal environments (e.g. CI containers) and may fail silently or be skipped.

As a result, any locally built RPM packages are not actually used during testing, making the local-repository setup ineffective.

Fix
Changed enabled=0 to enabled=1 directly in the .repo file to ensure it's active by default.
Set the correct baseurl using the ${LOCAL_REPO_DIRECTORY} environment variable.
Removed the redundant call to yum-config-manager --enable local-repository.
Impact
Ensures local RPMs are tested properly in CI.
Fixes misleading behavior where the script pretended to use the local repo but didn’t.
Helps catch packaging or integration issues earlier in the CI pipeline.

IMP NOTE: Previous PR (https://github.com/NVIDIA/nvidia-container-toolkit/pull/1196) had issues during squash/sign-off process due to local setup constraints. This PR is the corrected version and replaces the old one. Thank you for your understanding and patience!

