### PR TITLE
[no-relnote] Don't let scan failures block pipeline

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -165,10 +165,7 @@ scan-images:
   variables:
     IMAGE: "${CI_REGISTRY_IMAGE}/container-toolkit:${CI_COMMIT_SHORT_SHA}"
     IMAGE_ARCHIVE: "container-toolkit-${CI_JOB_ID}.tar"
-  rules:
-    - if: $IGNORE_SCANS == "yes"
-      allow_failure: true
-    - when: on_success
+  allow_failure: true
   script:
     - |
       docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
@@ -292,4 +289,3 @@ publish-images-dummy:
     OUT_IMAGE_TAG: "publish-${CI_COMMIT_SHORT_SHA}"
   rules:
     - if: $CI_COMMIT_TAG == null || $CI_COMMIT_TAG == ""
-


### PR DESCRIPTION
With the new publishing flow, there are additional checks that are performed on images before these are published to ngc. This change allows scans to fail so that these do not block the publishing step, but do provide a signal of possible exceptions that are required.