### PR TITLE
Add explicitLibs list to libs discovery

### DIFF
--- a/internal/lookup/root/root.go
+++ b/internal/lookup/root/root.go
@@ -128,7 +128,7 @@ func (r *Driver) DriverLibraryLocator(additionalDirs ...string) (lookup.Locator,
 		}
 	}
 
-	l := lookup.NewFileLocator(
+	l := lookup.NewSymlinkLocator(
 		lookup.WithRoot(r.Root),
 		lookup.WithLogger(r.logger),
 		lookup.WithSearchPaths(

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -150,17 +150,17 @@ func (l *nvcdilib) getExplicitDriverLibraryMounts() (discover.Discover, error) {
 	// the sandboxutils-filelist or have a way to allow users to specify the
 	// libraries to mount from the config file.
 	explicitLibraries := []string{
-		"libEGL.so.1.1.0",
-		"libGL.so.1.7.0",
-		"libGLESv1_CM.so.1.2.0",
-		"libGLESv2.so.2.1.0",
-		"libGLX.so.0",
-		"libGLdispatch.so.0",
-		"libOpenCL.so.1.0.0",
-		"libOpenGL.so.0",
-		"libnvidia-api.so.1",
-		"libnvidia-egl-xcb.so.1.0.0",
-		"libnvidia-egl-xlib.so.1.0.0",
+		"libEGL.so",
+		"libGL.so",
+		"libGLESv1_CM.so",
+		"libGLESv2.so",
+		"libGLX.so",
+		"libGLdispatch.so",
+		"libOpenCL.so",
+		"libOpenGL.so",
+		"libnvidia-api.so",
+		"libnvidia-egl-xcb.so",
+		"libnvidia-egl-xlib.so",
 	}
 
 	driverLibraryLocator, err := l.driver.DriverLibraryLocator()

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -76,19 +76,18 @@ func (l *nvcdilib) newDriverVersionDiscoverer() (discover.Discover, error) {
 
 // NewDriverLibraryDiscoverer creates a discoverer for the libraries associated with the specified driver version.
 func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDirPath string) (discover.Discover, error) {
-	libraryPaths, err := getVersionLibs(l.logger, l.driver, version)
+	versionSuffixLibraryMounts, err := l.getVersionSuffixDriverLibraryMounts(version)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get libraries for driver version: %v", err)
+		return nil, err
+	}
+	explicitLibraryMounts, err := l.getExplicitDriverLibraryMounts()
+	if err != nil {
+		return nil, err
 	}
 
-	libraries := discover.NewMounts(
-		l.logger,
-		lookup.NewFileLocator(
-			lookup.WithLogger(l.logger),
-			lookup.WithRoot(l.driver.Root),
-		),
-		l.driver.Root,
-		libraryPaths,
+	libraries := discover.Merge(
+		versionSuffixLibraryMounts,
+		explicitLibraryMounts,
 	)
 
 	var discoverers []discover.Discover
@@ -96,12 +95,12 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
 	driverDotSoSymlinksDiscoverer := discover.WithDriverDotSoSymlinks(
 		l.logger,
 		libraries,
-		version,
+		// Since we don't only match version suffixes, we now need to match on wildcards.
+		"",
 		l.hookCreator,
 	)
 	discoverers = append(discoverers, driverDotSoSymlinksDiscoverer)
 
-	// TODO: The following should use the version directly.
 	cudaCompatLibHookDiscoverer := discover.NewCUDACompatHookDiscoverer(l.logger, l.hookCreator, version)
 	discoverers = append(discoverers, cudaCompatLibHookDiscoverer)
 
@@ -124,6 +123,59 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
 	d := discover.Merge(discoverers...)
 
 	return d, nil
+}
+
+func (l *nvcdilib) getVersionSuffixDriverLibraryMounts(version string) (discover.Discover, error) {
+	versionSuffixLibraryPaths, err := getVersionLibs(l.logger, l.driver, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get libraries for driver version: %v", err)
+	}
+
+	mounts := discover.NewMounts(
+		l.logger,
+		lookup.NewFileLocator(
+			lookup.WithLogger(l.logger),
+			lookup.WithRoot(l.driver.Root),
+		),
+		l.driver.Root,
+		versionSuffixLibraryPaths,
+	)
+
+	return mounts, nil
+}
+
+func (l *nvcdilib) getExplicitDriverLibraryMounts() (discover.Discover, error) {
+	// List of explicit libraries to locate
+	// TODO(ArangoGutierrez): we should load the version of the libraries from
+	// the sandboxutils-filelist or have a way to allow users to specify the
+	// libraries to mount from the config file.
+	explicitLibraries := []string{
+		"libEGL.so.1.1.0",
+		"libGL.so.1.7.0",
+		"libGLESv1_CM.so.1.2.0",
+		"libGLESv2.so.2.1.0",
+		"libGLX.so.0",
+		"libGLdispatch.so.0",
+		"libOpenCL.so.1.0.0",
+		"libOpenGL.so.0",
+		"libnvidia-api.so.1",
+		"libnvidia-egl-xcb.so.1.0.0",
+		"libnvidia-egl-xlib.so.1.0.0",
+	}
+
+	driverLibraryLocator, err := l.driver.DriverLibraryLocator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get driver library locator: %w", err)
+	}
+	mounts := discover.NewMounts(
+		l.logger,
+		driverLibraryLocator,
+		l.driver.Root,
+		explicitLibraries,
+	)
+
+	return mounts, nil
+
 }
 
 func getUTSRelease() (string, error) {

--- a/tests/e2e/nvidia-container-toolkit_test.go
+++ b/tests/e2e/nvidia-container-toolkit_test.go
@@ -325,23 +325,20 @@ var _ = Describe("docker", Ordered, ContinueOnFailure, func() {
 				}
 			}
 
-			// The symlink chains have the pattern:
-			// [A.so, A.so.1, A.so.1, A.so.driverVersion, A.so.driverVersion]
+			// The RM_VERSION symlink chains have the pattern:
+			// [A.so -> A.so.1 -> A.so.driverVersion]
 			// A has the suffix .so.
 			Expect(symlinks).ToNot(BeEmpty())
 			for soSymlink, chain := range symlinks {
 				if soSymlink == "" {
 					continue
 				}
-				Expect(chain).To(HaveLen(5))
 				for _, c := range chain {
 					Expect(c).To(HavePrefix(soSymlink))
 				}
 				Expect(chain[0]).To(HaveSuffix(".so"))
-				Expect(chain[1]).To(Equal(chain[2]))
-				Expect(chain[3]).To(Equal(chain[4]))
-				Expect(chain[3]).To(HaveSuffix(hostDriverVersion))
-				Expect(chain[4]).To(HaveSuffix(hostDriverVersion))
+				Expect(chain[1]).ToNot(Equal(soSymlink))
+				Expect(chain[len(chain)-1]).ToNot(Equal(soSymlink))
 			}
 			Expect(symlinks).To(And(
 				HaveKey("libcuda.so"),


### PR DESCRIPTION
Fixes:  #1215

Add a list of explicit libraries that don't share the libcuda version suffix.

This can be considered an early iteration; a future iteration should read the libraries from nvsandboxutils to avoid hardcoding the library version suffix.

### Enhancements to library management:
* Added a list of explicit library names to be located, including `libEGL.so.1.1.0`, `libGL.so.1.7.0`, `libGLESv1_CM.so.1.2.0`, and others. These libraries are critical for the driver version being processed.
* Implemented a loop to locate each library in the list, appending found libraries to the main `libs` list and logging warnings for any missing libraries without causing errors. This ensures better visibility into missing dependencies while maintaining robustness.