### PR TITLE
[no-relnote] Auto-regenerate CDI spec on toolkit changes

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.path
+++ b/deployments/systemd/nvidia-cdi-refresh.path
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 [Unit]
-Description=Trigger CDI refresh on NVIDIA driver install / uninstall events
+Description=Trigger CDI refresh on NVIDIA driver or toolkit install / upgrade events
 
 [Path]
 PathChanged=/lib/modules/%v/modules.dep
 PathChanged=/lib/modules/%v/modules.dep.bin
+PathChanged=/usr/bin/nvidia-ctk
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/debian/nvidia-container-toolkit-base.postinst
+++ b/packaging/debian/nvidia-container-toolkit-base.postinst
@@ -13,6 +13,10 @@ case "$1" in
           systemctl daemon-reload || echo "Warning: Failed to reload systemd daemon" >&2
           systemctl enable --now nvidia-cdi-refresh.path || echo "Warning: Failed to enable nvidia-cdi-refresh.path" >&2
           systemctl enable --now nvidia-cdi-refresh.service || echo "Warning: Failed to enable nvidia-cdi-refresh.service" >&2
+          
+          # Trigger CDI spec regeneration immediately after install/upgrade
+          echo "Regenerating NVIDIA CDI specification..."
+          systemctl start nvidia-cdi-refresh.service || echo "Warning: Failed to trigger CDI refresh" >&2
         fi
     ;;
 


### PR DESCRIPTION
Monitor /usr/bin/nvidia-ctk for changes and trigger CDI refresh during package installation to ensure CDI specifications stay current with both driver and toolkit updates.

- Add nvidia-ctk binary monitoring to systemd path unit
- Trigger CDI refresh in DEB/RPM post-install scripts
- Reorganize RPM spec to handle base package services correctly
