### PR TITLE
[no-relnote] Readd vdpau as driver library search path

### DIFF
--- a/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
@@ -105,11 +105,21 @@ containerEdits:
             - update-ldcache
             - --folder
             - /lib/x86_64-linux-gnu
+            - --folder
+            - /lib/x86_64-linux-gnu/vdpau
           env:
             - NVIDIA_CTK_DEBUG=false
     mounts:
         - hostPath: /host/driver/root/lib/x86_64-linux-gnu/libcuda.so.999.88.77
           containerPath: /lib/x86_64-linux-gnu/libcuda.so.999.88.77
+          options:
+            - ro
+            - nosuid
+            - nodev
+            - rbind
+            - rprivate
+        - hostPath: /host/driver/root/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
+          containerPath: /lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
           options:
             - ro
             - nosuid

--- a/cmd/nvidia-ctk/cdi/generate/generate_test.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate_test.go
@@ -109,6 +109,8 @@ containerEdits:
             - update-ldcache
             - --folder
             - /lib/x86_64-linux-gnu
+            - --folder
+            - /lib/x86_64-linux-gnu/vdpau
           env:
             - NVIDIA_CTK_DEBUG=false
         - hookName: createContainer
@@ -121,6 +123,14 @@ containerEdits:
     mounts:
         - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/libcuda.so.999.88.77
           containerPath: /lib/x86_64-linux-gnu/libcuda.so.999.88.77
+          options:
+            - ro
+            - nosuid
+            - nodev
+            - rbind
+            - rprivate
+        - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
+          containerPath: /lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
           options:
             - ro
             - nosuid
@@ -186,6 +196,8 @@ containerEdits:
             - update-ldcache
             - --folder
             - /lib/x86_64-linux-gnu
+            - --folder
+            - /lib/x86_64-linux-gnu/vdpau
           env:
             - NVIDIA_CTK_DEBUG=false
         - hookName: createContainer
@@ -198,6 +210,14 @@ containerEdits:
     mounts:
         - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/libcuda.so.999.88.77
           containerPath: /lib/x86_64-linux-gnu/libcuda.so.999.88.77
+          options:
+            - ro
+            - nosuid
+            - nodev
+            - rbind
+            - rprivate
+        - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
+          containerPath: /lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
           options:
             - ro
             - nosuid
@@ -272,6 +292,14 @@ containerEdits:
             - nodev
             - rbind
             - rprivate
+        - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
+          containerPath: /lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
+          options:
+            - ro
+            - nosuid
+            - nodev
+            - rbind
+            - rprivate
 `,
 		},
 		{
@@ -317,6 +345,14 @@ containerEdits:
     mounts:
         - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/libcuda.so.999.88.77
           containerPath: /lib/x86_64-linux-gnu/libcuda.so.999.88.77
+          options:
+            - ro
+            - nosuid
+            - nodev
+            - rbind
+            - rprivate
+        - hostPath: {{ .driverRoot }}/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
+          containerPath: /lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.999.88.77
           options:
             - ro
             - nosuid

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -211,7 +211,7 @@ func NewDriverBinariesDiscoverer(logger logger.Interface, driverRoot string) dis
 func getVersionLibs(logger logger.Interface, driver *root.Driver, version string) ([]string, error) {
 	logger.Infof("Using driver version %v", version)
 
-	libraries, err := driver.DriverLibraryLocator()
+	libraries, err := driver.DriverLibraryLocator("vdpau")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver library locator: %w", err)
 	}


### PR DESCRIPTION
The changes in #1219 inadvertently removed the `vdpau` as an additional driver library search path.

This change adds a test and fixes this.