### PR TITLE
Allow config sources to be specified for containerd and cri-o

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/config_test.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/config_test.go
@@ -1783,6 +1783,10 @@ version = 3
 	}
 
 	for _, tc := range testCases {
+		// Set default options that would normally be set by the CLI.
+		if tc.containerOptions.ConfigSources == nil {
+			tc.containerOptions.ConfigSources = []string{"command", "file"}
+		}
 		t.Run(tc.description, func(t *testing.T) {
 			// Create a temporary directory for the test
 			testRoot := t.TempDir()
@@ -1791,6 +1795,11 @@ version = 3
 			tc.containerOptions.TopLevelConfigPath = strings.ReplaceAll(tc.containerOptions.TopLevelConfigPath, "{{ .testRoot }}", testRoot)
 			tc.containerOptions.DropInConfig = strings.ReplaceAll(tc.containerOptions.DropInConfig, "{{ .testRoot }}", testRoot)
 			tc.containerOptions.RuntimeDir = strings.ReplaceAll(tc.containerOptions.RuntimeDir, "{{ .testRoot }}", testRoot)
+			var testConfigSources []string
+			for _, configSource := range tc.containerOptions.ConfigSources {
+				testConfigSources = append(testConfigSources, strings.ReplaceAll(configSource, "{{ .testRoot }}", testRoot))
+			}
+			tc.containerOptions.ConfigSources = testConfigSources
 
 			// Prepare the environment
 			if tc.prepareEnvironment != nil {

--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
@@ -172,12 +172,15 @@ func GetLowlevelRuntimePaths(o *container.Options, co *Options) ([]string, error
 }
 
 func getRuntimeConfig(o *container.Options, co *Options) (engine.Interface, error) {
+	loaders, err := o.GetConfigLoaders(containerd.CommandLineSource)
+	if err != nil {
+		return nil, err
+	}
 	options := []containerd.Option{
 		containerd.WithTopLevelConfigPath(o.TopLevelConfigPath),
 		containerd.WithConfigSource(
 			toml.LoadFirst(
-				containerd.CommandLineSource(o.HostRootMount, o.ExecutablePath),
-				toml.FromFile(o.TopLevelConfigPath),
+				loaders...,
 			),
 		),
 		containerd.WithRuntimeType(co.runtimeType),

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/config_test.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/config_test.go
@@ -622,13 +622,23 @@ plugin_dirs = [
 	}
 
 	for _, tc := range testCases {
+		// Set default options that would normally be set by the CLI.
+		if tc.containerOptions.ConfigSources == nil {
+			tc.containerOptions.ConfigSources = []string{"command", "file"}
+		}
+		tc.options.hookFilename = "99-nvidia.json"
+
 		t.Run(tc.description, func(t *testing.T) {
 			// Update any paths as required
 			testRoot := t.TempDir()
 			tc.containerOptions.TopLevelConfigPath = strings.ReplaceAll(tc.containerOptions.TopLevelConfigPath, "{{ .testRoot }}", testRoot)
 			tc.containerOptions.DropInConfig = strings.ReplaceAll(tc.containerOptions.DropInConfig, "{{ .testRoot }}", testRoot)
 			tc.options.hooksDir = strings.ReplaceAll(tc.options.hooksDir, "{{ .testRoot }}", testRoot)
-			tc.options.hookFilename = "99-nvidia.json"
+			var testConfigSources []string
+			for _, configSource := range tc.containerOptions.ConfigSources {
+				testConfigSources = append(testConfigSources, strings.ReplaceAll(configSource, "{{ .testRoot }}", testRoot))
+			}
+			tc.containerOptions.ConfigSources = testConfigSources
 
 			// Prepare the test environment
 			if tc.prepareEnvironment != nil {

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/config_test.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/config_test.go
@@ -621,10 +621,7 @@ plugin_dirs = [
 		},
 	}
 
-	for i, tc := range testCases {
-		if i > 3 {
-			t.SkipNow()
-		}
+	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// Update any paths as required
 			testRoot := t.TempDir()

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
@@ -214,12 +214,15 @@ func GetLowlevelRuntimePaths(o *container.Options) ([]string, error) {
 }
 
 func getRuntimeConfig(o *container.Options) (engine.Interface, error) {
+	loaders, err := o.GetConfigLoaders(crio.CommandLineSource)
+	if err != nil {
+		return nil, err
+	}
 	return crio.New(
 		crio.WithTopLevelConfigPath(o.TopLevelConfigPath),
 		crio.WithConfigSource(
 			toml.LoadFirst(
-				crio.CommandLineSource(o.HostRootMount, o.ExecutablePath),
-				toml.FromFile(o.TopLevelConfigPath),
+				loaders...,
 			),
 		),
 	)

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -118,9 +118,12 @@ func Flags(opts *Options) []cli.Flag {
 			Hidden:      true,
 		},
 		&cli.StringSliceFlag{
-			Name:        "config-source",
-			Aliases:     []string{"config-sources"},
-			Usage:       "Specify the config sources for the container runtime. Any combination of [command | file].",
+			Name:    "config-source",
+			Aliases: []string{"config-sources"},
+			Usage: "Specify the config sources for the container runtime. Any combination of " +
+				"[command | file]. " +
+				"When `file` is specified, the absolute path to the file to be used as a config source can " +
+				"be specified as `file=/path/to/source/config.toml",
 			Value:       []string{"command", "file"},
 			Destination: &opts.ConfigSources,
 			Sources:     cli.EnvVars("RUNTIME_CONFIG_SOURCES", "RUNTIME_CONFIG_SOURCE"),

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -152,7 +152,6 @@ func (opts *Options) Validate(logger logger.Interface, c *cli.Command, runtime s
 	}
 
 	// Apply the runtime-specific config changes.
-	// TODO: Add the runtime-specific DropInConfigs here.
 	switch runtime {
 	case containerd.Name:
 		if opts.TopLevelConfigPath == runtimeSpecificDefault {

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -117,6 +117,14 @@ func Flags(opts *Options) []cli.Flag {
 			Sources:     cli.EnvVars("NVIDIA_RUNTIME_SET_AS_DEFAULT", "CONTAINERD_SET_AS_DEFAULT", "DOCKER_SET_AS_DEFAULT"),
 			Hidden:      true,
 		},
+		&cli.StringSliceFlag{
+			Name:        "config-source",
+			Aliases:     []string{"config-sources"},
+			Usage:       "Specify the config sources for the container runtime. Any combination of [command | file].",
+			Value:       []string{"command", "file"},
+			Destination: &opts.ConfigSources,
+			Sources:     cli.EnvVars("RUNTIME_CONFIG_SOURCES", "RUNTIME_CONFIG_SOURCE"),
+		},
 	}
 
 	flags = append(flags, containerd.Flags(&opts.containerdOptions)...)
@@ -144,6 +152,7 @@ func (opts *Options) Validate(logger logger.Interface, c *cli.Command, runtime s
 			logger.Warningf("Ignoring drop-in-config=%q flag for %v", opts.DropInConfig, opts.RuntimeName)
 			opts.DropInConfig = ""
 		}
+		opts.ConfigSources = []string{"file"}
 	case containerd.Name:
 	case crio.Name:
 		if err := opts.crioOptions.Validate(logger, c); err != nil {


### PR DESCRIPTION
By default container extracts the current config by running the `containerd config dump` command and if that fails we read the existing config file.

This change allows ordering of these sources to be defined as we do for the nvidia-ctk runtime configure command.

See #1222 where setting `RUNTIME_CONFIG_SOURCES=file` or `RUNTIME_CONFIG_SOURCES=file,command` should allow the current config to be preferred over the `containerd config dump` command.

This further allows an explicit path to be specified for the `file` config source so that there is a separation between the config file being modified by the tooling and the config used as the source for drop-in files, for example.