### PR TITLE
Allow config sources to be specified for containerd

### DIFF
--- a/tools/container/container.go
+++ b/tools/container/container.go
@@ -50,6 +50,8 @@ type Options struct {
 	SetAsDefault  bool
 	RestartMode   string
 	HostRootMount string
+
+	ConfigSources cli.StringSlice
 }
 
 // ParseArgs parses the command line arguments to the CLI

--- a/tools/container/runtime/runtime.go
+++ b/tools/container/runtime/runtime.go
@@ -103,6 +103,12 @@ func Flags(opts *Options) []cli.Flag {
 			EnvVars:     []string{"NVIDIA_RUNTIME_SET_AS_DEFAULT", "CONTAINERD_SET_AS_DEFAULT", "DOCKER_SET_AS_DEFAULT"},
 			Hidden:      true,
 		},
+		&cli.StringSliceFlag{
+			Name:        "config-source",
+			Usage:       "specify the config sources",
+			Destination: &opts.ConfigSources,
+			EnvVars:     []string{"RUNTIME_CONFIG_SOURCES"},
+		},
 	}
 
 	flags = append(flags, containerd.Flags(&opts.containerdOptions)...)
@@ -136,6 +142,9 @@ func (opts *Options) Validate(c *cli.Context, runtime string, toolkitRoot string
 		}
 		if opts.RestartMode == runtimeSpecificDefault {
 			opts.RestartMode = containerd.DefaultRestartMode
+		}
+		if len(opts.ConfigSources.Value()) == 0 {
+			_ = opts.ConfigSources.Set("command,file")
 		}
 	case crio.Name:
 		if opts.Config == runtimeSpecificDefault {


### PR DESCRIPTION
By default container extracts the current config by running the `containerd config dump` command and if that fails we read the existing config file.

This change allows ordering of these sources to be defined as we do for the nvidia-ctk runtime configure command.

Backport of #1251
See #1222 