### PR TITLE
Cleanup default runtime in runtime config when setAsDefault=false

### DIFF
--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -64,6 +64,11 @@ func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
 
 	if setAsDefault {
 		config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "default_runtime_name"}, name)
+	} else {
+		defaultRuntime, ok := config.GetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "default_runtime_name"}).(string)
+		if ok && defaultRuntime == name {
+			config.DeletePath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "default_runtime_name"})
+		}
 	}
 
 	*c.Tree = config

--- a/pkg/config/engine/containerd/config_test.go
+++ b/pkg/config/engine/containerd/config_test.go
@@ -53,6 +53,26 @@ func TestAddRuntime(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			description:  "empty config, set as default runtime",
+			setAsDefault: true,
+			expectedConfig: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				default_runtime_name = "test"
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = "io.containerd.runc.v2"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+			`,
+			expectedError: nil,
+		},
+		{
 			description: "options from runc are imported",
 			config: `
 			version = 2
@@ -256,6 +276,75 @@ func TestAddRuntime(t *testing.T) {
 						BinaryName = "/usr/bin/test"
 						SystemdCgroup = true
 				`,
+		},
+		{
+			description:  "runtime already exists in config, default runtime",
+			setAsDefault: true,
+			config: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				default_runtime_name = "test"
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = "io.containerd.runc.v2"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+			`,
+			expectedConfig: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				default_runtime_name = "test"
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = "io.containerd.runc.v2"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+			`,
+			expectedError: nil,
+		},
+		{
+			description:  "runtime already exists in config, not default runtime",
+			setAsDefault: false,
+			config: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				default_runtime_name = "test"
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = "io.containerd.runc.v2"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+			`,
+			expectedConfig: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = "io.containerd.runc.v2"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+			`,
+			expectedError: nil,
 		},
 	}
 

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -97,6 +97,12 @@ func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
 
 	if setAsDefault {
 		config.SetPath([]string{"crio", "runtime", "default_runtime"}, name)
+	} else {
+		if defaultRuntime, ok := config.GetPath([]string{"crio", "runtime", "default_runtime"}).(string); ok {
+			if defaultRuntime == name {
+				config.DeletePath([]string{"crio", "runtime", "default_runtime"})
+			}
+		}
 	}
 
 	*c.Tree = config

--- a/pkg/config/engine/crio/crio_test.go
+++ b/pkg/config/engine/crio/crio_test.go
@@ -45,6 +45,19 @@ func TestAddRuntime(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			description:  "empty config, set as default runtime",
+			setAsDefault: true,
+			expectedConfig: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "test"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			`,
+			expectedError: nil,
+		},
+		{
 			description: "options from runc are imported",
 			config: `
 			[crio]
@@ -122,6 +135,47 @@ func TestAddRuntime(t *testing.T) {
 			runtime_type = "oci"
 			default_option = "option"
 			`,
+		},
+		{
+			description:  "runtime already exists in config, default runtime",
+			setAsDefault: true,
+			config: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "test"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			`,
+			expectedConfig: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "test"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			`,
+			expectedError: nil,
+		},
+		{
+			description:  "runtime already exists in config, not default runtime",
+			setAsDefault: false,
+			config: `
+			[crio]
+			[crio.runtime]
+			default_runtime = "test"
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			`,
+			expectedConfig: `
+			[crio]
+			[crio.runtime]
+			[crio.runtime.runtimes.test]
+			runtime_path = "/usr/bin/test"
+			runtime_type = "oci"
+			`,
+			expectedError: nil,
 		},
 	}
 


### PR DESCRIPTION
This commit updates the AddRuntime() implementation for containerd and cri-o to clear the default runtime field if the runtime we are adding is currently set as the default AND setAsDefault=false.