### PR TITLE
Remove redundant CDI annotations

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -447,15 +447,22 @@ type deviceSpecs []specs.Device
 func (d deviceSpecs) splitOnAnnotation(key string) map[string][]specs.Device {
 	splitSpecs := make(map[string][]specs.Device)
 
+	var specsToRemoveAnnotations []*specs.Device
 	for _, deviceSpec := range d {
-		if len(deviceSpec.Annotations) == 0 {
-			continue
-		}
 		value, ok := deviceSpec.Annotations[key]
 		if !ok {
 			continue
 		}
 		splitSpecs[key+"="+value] = append(splitSpecs[key+"="+value], deviceSpec)
+		specsToRemoveAnnotations = append(specsToRemoveAnnotations, &deviceSpec)
+	}
+
+	// We also remove the annotations that were used to split the devices:
+	for _, deviceSpec := range specsToRemoveAnnotations {
+		if _, ok := deviceSpec.Annotations[key]; !ok {
+			continue
+		}
+		delete(deviceSpec.Annotations, key)
 	}
 
 	return splitSpecs


### PR DESCRIPTION
When generating CDI specs for coherent and noncoherent devices, we include CDI device annotations. This increases the minimum CDI spec version to v0.6.0 which is not as widely supported as v0.5.0 or v0.3.0.

This change removes these annotations after splitting the generated specs to produce coherent and/or non-coherent specs.

Closes #1262 

Note that since we're generating a CDI spec for `nvidia.com/gpu.coherent` devices, these are `v0.6.0` specs since `.` was only allowed in the spec from `v0.6.0`.