### PR TITLE
Don't inject enable-cuda-compat hook in CSV mode

### DIFF
--- a/internal/modifier/gated.go
+++ b/internal/modifier/gated.go
@@ -92,6 +92,11 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 }
 
 func getCudaCompatModeDiscoverer(logger logger.Interface, cfg *config.Config, driver *root.Driver, hookCreator discover.HookCreator) (discover.Discover, error) {
+	// We don't support the enable-cuda-compat hook in CSV mode.
+	if cfg.NVIDIAContainerRuntimeConfig.Mode == "csv" {
+		return nil, nil
+	}
+
 	// For legacy mode, we only include the enable-cuda-compat hook if cuda-compat-mode is set to hook.
 	if cfg.NVIDIAContainerRuntimeConfig.Mode == "legacy" && cfg.NVIDIAContainerRuntimeConfig.Modes.Legacy.CUDACompatMode != config.CUDACompatModeHook {
 		return nil, nil


### PR DESCRIPTION
Since the logic to determine the host driver version relies on the extension of `libcuda.so.<RM_VERSION>`, this is not supported on some Tegra-based systems where the file always has the name `libcuda.so.1.1`. This means that the `enable-cuda-compat` hook should not be injected in CSV mode in the `nvidia` runtime.