### PR TITLE
Don't inject enable-cuda-compat hook in CSV mode

### DIFF
--- a/internal/modifier/gated.go
+++ b/internal/modifier/gated.go
@@ -92,6 +92,11 @@ func NewFeatureGatedModifier(logger logger.Interface, cfg *config.Config, image 
 }
 
 func getCudaCompatModeDiscoverer(logger logger.Interface, cfg *config.Config, driver *root.Driver) (discover.Discover, error) {
+	// We don't support the enable-cuda-compat hook in CSV mode.
+	if cfg.NVIDIAContainerRuntimeConfig.Mode == "csv" {
+		return nil, nil
+	}
+
 	// For legacy mode, we only include the enable-cuda-compat hook if cuda-compat-mode is set to hook.
 	if cfg.NVIDIAContainerRuntimeConfig.Mode == "legacy" && cfg.NVIDIAContainerRuntimeConfig.Modes.Legacy.CUDACompatMode != config.CUDACompatModeHook {
 		return nil, nil


### PR DESCRIPTION
When running the nvidia runtime in csv mode, we should not inject the enable-cuda-compat hook until we make the host driver version detection more robust on these platforms. As it is, the host driver version detection returns a version of 1.1 (the suffix of libcuda.so) meaning that CUDA forward compatibility will always be used in a container regardless of whether this is required.

This will be properly added to the generated CDI spec for CSV-based platforms as a follow-up. See #1271 

This is a backport of #1270 