### PR TITLE
[no-relnote] Refactor AddRuntime

### DIFF
--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -74,31 +74,42 @@ func New(opts ...Option) (engine.Interface, error) {
 	return &cfg, nil
 }
 
-// AddRuntime adds a new runtime to the crio config
+// AddRuntime adds a new runtime to the crio config.
+// The runtime options are extracted from the default runtime and the applicable
+// settings are overridden.
 func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
-	if c == nil {
+	if c == nil || c.Tree == nil {
 		return fmt.Errorf("config is nil")
 	}
+	defaultRuntimeOptions := c.GetDefaultRuntimeOptions()
+	return c.AddRuntimeWithOptions(name, path, setAsDefault, defaultRuntimeOptions)
+}
 
-	config := *c.Tree
-
+func (c *Config) GetDefaultRuntimeOptions() interface{} {
 	runtimeNamesForConfig := engine.GetLowLevelRuntimes(c)
 	for _, r := range runtimeNamesForConfig {
-		if options, ok := config.GetPath([]string{"crio", "runtime", "runtimes", r}).(*toml.Tree); ok {
-			c.Logger.Debugf("using options from runtime %v: %v", r, options.String())
-			options, _ = toml.Load(options.String())
-			config.SetPath([]string{"crio", "runtime", "runtimes", name}, options)
-			break
+		options := c.GetSubtreeByPath([]string{"crio", "runtime", "runtimes", r})
+		if options != nil {
+			c.Logger.Debugf("Using options from runtime %v: %v", r, options)
+			return options.Copy()
 		}
 	}
+	c.Logger.Warningf("Could not infer options from runtimes %v", runtimeNamesForConfig)
+	return nil
+}
 
+func (c *Config) AddRuntimeWithOptions(name string, path string, setAsDefault bool, options interface{}) error {
+	config := *c.Tree
+
+	if options != nil {
+		config.SetPath([]string{"crio", "runtime", "runtimes", name}, options)
+	}
 	config.SetPath([]string{"crio", "runtime", "runtimes", name, "runtime_path"}, path)
 	config.SetPath([]string{"crio", "runtime", "runtimes", name, "runtime_type"}, "oci")
 
 	if setAsDefault {
 		config.SetPath([]string{"crio", "runtime", "default_runtime"}, name)
 	}
-
 	*c.Tree = config
 	return nil
 }

--- a/pkg/config/engine/crio/crio_test.go
+++ b/pkg/config/engine/crio/crio_test.go
@@ -127,20 +127,19 @@ func TestAddRuntime(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			cfg, err := toml.Load(tc.config)
-			require.NoError(t, err)
 			expectedConfig, err := toml.Load(tc.expectedConfig)
 			require.NoError(t, err)
 
-			c := &Config{
-				Logger: logger,
-				Tree:   cfg,
-			}
+			c, err := New(
+				WithLogger(logger),
+				WithConfigSource(toml.FromString(tc.config)),
+			)
+			require.NoError(t, err)
 
 			err = c.AddRuntime("test", "/usr/bin/test", tc.setAsDefault)
 			require.NoError(t, err)
 
-			require.EqualValues(t, expectedConfig.String(), cfg.String())
+			require.EqualValues(t, expectedConfig.String(), c.String())
 		})
 	}
 }
@@ -188,13 +187,11 @@ monitor_path = "/usr/libexec/crio/conmon"
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			cfg, err := toml.Load(config)
+			c, err := New(
+				WithLogger(logger),
+				WithConfigSource(toml.FromString(config)),
+			)
 			require.NoError(t, err)
-
-			c := &Config{
-				Logger: logger,
-				Tree:   cfg,
-			}
 
 			rc, err := c.GetRuntimeConfig(tc.runtime)
 			require.Equal(t, tc.expectedError, err)


### PR DESCRIPTION
This change refactors the AddRuntime function into GetDefaultRuntimeOptions and AddRuntimeWithOptions. This allows for a clearer distinction between SOURCE and DESTINATION configs which should facilitate switching to drop-in files.