### PR TITLE
Add drop-in file support for containerd and crio

### DIFF
--- a/cmd/nvidia-ctk-installer/container/container.go
+++ b/cmd/nvidia-ctk-installer/container/container.go
@@ -35,6 +35,8 @@ const (
 
 // Options defines the shared options for the CLIs to configure containers runtimes.
 type Options struct {
+	DropInConfig string
+	// TODO: Rename to TopLevelConfig
 	Config string
 	Socket string
 	// ExecutablePath specifies the path to the container runtime executable.
@@ -71,8 +73,12 @@ func (o Options) Unconfigure(cfg engine.Interface) error {
 
 // flush flushes the specified config to disk
 func (o Options) flush(cfg engine.Interface) error {
-	logrus.Infof("Flushing config to %v", o.Config)
-	n, err := cfg.Save(o.Config)
+	filepath := o.DropInConfig
+	if filepath == "" {
+		filepath = o.Config
+	}
+	logrus.Infof("Flushing config to %v", filepath)
+	n, err := cfg.Save(filepath)
 	if err != nil {
 		return fmt.Errorf("unable to flush config: %v", err)
 	}

--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
@@ -32,7 +32,9 @@ import (
 const (
 	Name = "containerd"
 
-	DefaultConfig      = "/etc/containerd/config.toml"
+	DefaultConfig       = "/etc/containerd/config.toml"
+	DefaultDropInConfig = "/etc/containerd/config.d/99-nvidia.toml"
+
 	DefaultSocket      = "/run/containerd/containerd.sock"
 	DefaultRestartMode = "signal"
 
@@ -170,7 +172,7 @@ func GetLowlevelRuntimePaths(o *container.Options, co *Options) ([]string, error
 
 func getRuntimeConfig(o *container.Options, co *Options) (engine.Interface, error) {
 	return containerd.New(
-		containerd.WithPath(o.Config),
+		containerd.WithTopLevelConfigPath(o.Config),
 		containerd.WithConfigSource(
 			toml.LoadFirst(
 				containerd.CommandLineSource(o.HostRootMount, o.ExecutablePath),

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
@@ -42,7 +42,9 @@ const (
 	defaultHookFilename = "oci-nvidia-hook.json"
 
 	// Config-based settings
-	DefaultConfig      = "/etc/crio/crio.conf"
+	DefaultConfig       = "/etc/crio/crio.conf"
+	DefaultDropInConfig = "/etc/crio/conf.d/99-nvidia.toml"
+
 	DefaultSocket      = "/var/run/crio/crio.sock"
 	DefaultRestartMode = "systemd"
 )
@@ -199,7 +201,7 @@ func GetLowlevelRuntimePaths(o *container.Options) ([]string, error) {
 
 func getRuntimeConfig(o *container.Options) (engine.Interface, error) {
 	return crio.New(
-		crio.WithPath(o.Config),
+		crio.WithTopLevelConfigPath(o.Config),
 		crio.WithConfigSource(
 			toml.LoadFirst(
 				crio.CommandLineSource(o.HostRootMount, o.ExecutablePath),

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -266,13 +266,13 @@ func (m command) configureConfigFile(config *config) error {
 	case "containerd":
 		cfg, err = containerd.New(
 			containerd.WithLogger(m.logger),
-			containerd.WithPath(config.configFilePath),
+			containerd.WithTopLevelConfigPath(config.configFilePath),
 			containerd.WithConfigSource(configSource),
 		)
 	case "crio":
 		cfg, err = crio.New(
 			crio.WithLogger(m.logger),
-			crio.WithPath(config.configFilePath),
+			crio.WithTopLevelConfigPath(config.configFilePath),
 			crio.WithConfigSource(configSource),
 		)
 	case "docker":

--- a/pkg/config/engine/config.go
+++ b/pkg/config/engine/config.go
@@ -1,0 +1,85 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package engine
+
+// A Config represents a config for a container engine.
+// These include container, cri-o, and docker.
+// The config is logically split into a Source and Destination. This allows an
+// existing config to be updated (Source == Destination) or runtime-specific
+// settings to be written to a new config. The latter is useful when creation
+// NVIDIA-specific drop-in files for container engines that support this.
+type Config struct {
+	Source      RuntimeConfigSource
+	Destination RuntimeConfigDestination
+}
+
+// A RuntimeConfigSource allows runtime-specific settings to be READ from a
+// config.
+type RuntimeConfigSource interface {
+	DefaultRuntime() string
+	GetRuntimeConfig(string) (RuntimeConfig, error)
+	GetDefaultRuntimeOptions() interface{}
+	String() string
+}
+
+// A RuntimeConfigDestination allows a runtime with specific settings to be
+// WRITTEN to a config.
+type RuntimeConfigDestination interface {
+	AddRuntimeWithOptions(string, string, bool, interface{}) error
+	EnableCDI()
+	RemoveRuntime(string) error
+	Save(string) (int64, error)
+	String() string
+}
+
+// AddRuntime adds a runtime to the destination config and optionally sets it as the default.
+// The options to apply to the added runtime are read from the source config
+// default runtime.
+func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
+	options := c.Source.GetDefaultRuntimeOptions()
+	return c.Destination.AddRuntimeWithOptions(name, path, setAsDefault, options)
+}
+
+// RemoveRuntime removes a runtime from the destination config.
+func (c *Config) RemoveRuntime(runtime string) error {
+	return c.Destination.RemoveRuntime(runtime)
+}
+
+// EnableCDI enables CDI in the destination config.
+func (c *Config) EnableCDI() {
+	c.Destination.EnableCDI()
+}
+
+// DefaultRuntime returns the default runtime for the source config.
+func (c *Config) DefaultRuntime() string {
+	return c.Source.DefaultRuntime()
+}
+
+// GetRuntimeConfig returns the source config for the specified runtime.
+func (c *Config) GetRuntimeConfig(runtime string) (RuntimeConfig, error) {
+	return c.Source.GetRuntimeConfig(runtime)
+}
+
+// Save saves the destination runtime to the specified path.
+func (c *Config) Save(path string) (int64, error) {
+	return c.Destination.Save(path)
+}
+
+func (c *Config) String() string {
+	return c.Destination.String()
+}

--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -60,7 +60,7 @@ func (c *Config) AddRuntimeWithOptions(name string, path string, setAsDefault bo
 		config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name}, options)
 	}
 	if len(c.ContainerAnnotations) > 0 {
-		annotations, err := c.getRuntimeAnnotations([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name, "container_annotations"})
+		annotations, err := c.getStringArrayValue([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name, "container_annotations"})
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func (c *Config) AddRuntimeWithOptions(name string, path string, setAsDefault bo
 	return nil
 }
 
-func (c *Config) getRuntimeAnnotations(path []string) ([]string, error) {
+func (c *Config) getStringArrayValue(path []string) ([]string, error) {
 	if c == nil || c.Tree == nil {
 		return nil, nil
 	}

--- a/pkg/config/engine/containerd/config_drop_in.go
+++ b/pkg/config/engine/containerd/config_drop_in.go
@@ -1,0 +1,165 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package containerd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine"
+)
+
+// A ConfigWithDropIn represents a pair of containerd configs.
+// The first is the top-level config and the second is an in-memory drop-in config
+// that only contains modifications made to the config.
+type ConfigWithDropIn struct {
+	topLevelConfig *topLevelConfig
+	engine.Interface
+}
+
+var _ engine.Interface = (*ConfigWithDropIn)(nil)
+
+// A topLevelConfig stores the original on-disk top-level config.
+// The path to the config is also stored to allow it to be modified if required.
+type topLevelConfig struct {
+	path   string
+	config *Config
+}
+
+func NewConfigWithDropIn(topLevelConfigPath string, tlConfig *Config, dropInConfig engine.Interface) *ConfigWithDropIn {
+	return &ConfigWithDropIn{
+		topLevelConfig: &topLevelConfig{
+			path:   topLevelConfigPath,
+			config: tlConfig,
+		},
+		Interface: dropInConfig,
+	}
+}
+
+// Save the drop-in config to the specified path.
+// The top-level config is optionally updated to include the required imports
+// to allow the drop-in-file to be created.
+func (c *ConfigWithDropIn) Save(dropInPath string) (int64, error) {
+	bytesWritten, err := c.Interface.Save(dropInPath)
+	if err != nil {
+		return 0, err
+	}
+
+	switch {
+	case bytesWritten == 0:
+		// If the drop-in config is empty, we try to simplify the config.
+		c.topLevelConfig.simplify(dropInPath)
+	case bytesWritten > 0:
+		// If the drop-in config has contents, we need to ensure that the
+		// drop-in path is included in the imports.
+		c.topLevelConfig.ensureImports(dropInPath)
+	}
+
+	// TODO: Only do this if we've actually modified the config.
+	if err := c.topLevelConfig.flush(); err != nil {
+		return 0, fmt.Errorf("failed to save top-level config: %w", err)
+	}
+
+	return bytesWritten, nil
+}
+
+// RemoveRuntime removes the runtime from both configs.
+func (c *ConfigWithDropIn) RemoveRuntime(name string) error {
+	if err := c.topLevelConfig.RemoveRuntime(name); err != nil {
+		return err
+	}
+	return c.Interface.RemoveRuntime(name)
+}
+
+// flush saves the top-level config to it's path.
+// If the config is empty, the file will be deleted.
+func (c *topLevelConfig) flush() error {
+	_, err := c.config.Save(c.path)
+	if err != nil {
+		return fmt.Errorf("failed to flush config to %q: %w", c.path, err)
+	}
+	return nil
+}
+
+func (c *topLevelConfig) simplify(dropInFilename string) {
+	c.removeImports(dropInFilename)
+	c.removeVersion()
+}
+
+// removeImports removes the imports specified in the file if the only entry
+// corresponds to the path for the drop-in-file and the only other field in the
+// file is the version field.
+func (c *topLevelConfig) removeImports(dropInFilename string) {
+	if len(c.config.Keys()) != 2 {
+		return
+	}
+	if c.config.Get("version") == nil || c.config.Get("imports") == nil {
+		return
+	}
+
+	currentImports, _ := c.config.getStringArrayValue([]string{"imports"})
+	if len(currentImports) != 1 {
+		return
+	}
+
+	requiredImport := filepath.Dir(dropInFilename) + "/*.toml"
+	if currentImports[0] != requiredImport {
+		return
+	}
+	c.config.Delete("imports")
+}
+
+// removeVersion removes the version if it is the ONLY field in the file.
+func (c *topLevelConfig) removeVersion() {
+	if len(c.config.Keys()) > 1 {
+		return
+	}
+	if c.config.Get("version") == nil {
+		return
+	}
+	c.config.Delete("version")
+}
+
+func (c *topLevelConfig) ensureImports(dropInFilename string) {
+	config := c.config.Tree
+	var currentImports []string
+	if ci, ok := c.config.Get("imports").([]string); ok {
+		currentImports = ci
+	}
+
+	requiredImport := filepath.Dir(dropInFilename) + "/*.toml"
+	for _, currentImport := range currentImports {
+		// If the requiredImport is already present, then we need not update the config.
+		if currentImport == requiredImport {
+			return
+		}
+	}
+
+	currentImports = append(currentImports, requiredImport)
+
+	// If the config is empty we need to set the version too.
+	if len(config.Keys()) == 0 {
+		config.Set("version", c.config.Version)
+	}
+	config.Set("imports", currentImports)
+}
+
+// RemoveRuntime removes the specified runtime from the top-level config.
+func (c *topLevelConfig) RemoveRuntime(name string) error {
+	return c.config.RemoveRuntime(name)
+}

--- a/pkg/config/engine/containerd/config_test.go
+++ b/pkg/config/engine/containerd/config_test.go
@@ -95,14 +95,6 @@ func TestAddRuntime(t *testing.T) {
 			[plugins."io.containerd.grpc.v1.cri"]
 				[plugins."io.containerd.grpc.v1.cri".containerd]
 				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-					privileged_without_host_devices = true
-					runtime_engine = "engine"
-					runtime_root = "root"
-					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-						BinaryName = "/usr/bin/runc"
-						SystemdCgroup = true
 					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
@@ -136,16 +128,7 @@ func TestAddRuntime(t *testing.T) {
 			[plugins]
 			[plugins."io.containerd.grpc.v1.cri"]
 				[plugins."io.containerd.grpc.v1.cri".containerd]
-				default_runtime_name = "default"
 				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
-					privileged_without_host_devices = true
-					runtime_engine = "engine"
-					runtime_root = "root"
-					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
-						BinaryName = "/usr/bin/default"
-						SystemdCgroup = true
 					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
@@ -187,24 +170,7 @@ func TestAddRuntime(t *testing.T) {
 			[plugins]
 			[plugins."io.containerd.grpc.v1.cri"]
 				[plugins."io.containerd.grpc.v1.cri".containerd]
-				default_runtime_name = "default"
 				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-					privileged_without_host_devices = true
-					runtime_engine = "engine"
-					runtime_root = "root"
-					runtime_type = "type"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-						BinaryName = "/usr/bin/runc"
-						SystemdCgroup = true
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
-					privileged_without_host_devices = false
-					runtime_engine = "defaultengine"
-					runtime_root = "defaultroot"
-					runtime_type = "defaulttype"
-					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
-						BinaryName = "/usr/bin/default"
-						SystemdCgroup = false
 					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
 					privileged_without_host_devices = false
 					runtime_engine = "defaultengine"
@@ -259,14 +225,6 @@ func TestAddRuntime(t *testing.T) {
 			[plugins."io.containerd.cri.v1.runtime"]
 				[plugins."io.containerd.cri.v1.runtime".containerd]
 				[plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
-					[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
-					privileged_without_host_devices = true
-					runtime_engine = "engine"
-					runtime_root = "root"
-					runtime_type = "type"
-					[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
-						BinaryName = "/usr/bin/runc"
-						SystemdCgroup = true
 					[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"

--- a/pkg/config/engine/containerd/option.go
+++ b/pkg/config/engine/containerd/option.go
@@ -41,8 +41,8 @@ func WithLogger(logger logger.Interface) Option {
 	}
 }
 
-// WithPath sets the path for the config builder
-func WithPath(path string) Option {
+// WithTopLevelConfigPath sets the path for the top-level containerd config.
+func WithTopLevelConfigPath(path string) Option {
 	return func(b *builder) {
 		b.topLevelConfigPath = path
 	}

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -62,16 +62,23 @@ func New(opts ...Option) (engine.Interface, error) {
 		b.configSource = toml.FromFile(b.topLevelConfigPath)
 	}
 
-	tomlConfig, err := b.configSource.Load()
+	sourceConfig, err := b.configSource.Load()
 	if err != nil {
 		return nil, err
 	}
 
-	cfg := Config{
-		Tree:   tomlConfig,
-		Logger: b.logger,
+	cfg := &engine.Config{
+		Source: &Config{
+			Tree:   sourceConfig,
+			Logger: b.logger,
+		},
+		Destination: &Config{
+			Tree:   toml.NewEmpty(),
+			Logger: b.logger,
+		},
 	}
-	return &cfg, nil
+
+	return cfg, nil
 }
 
 // AddRuntime adds a new runtime to the crio config.

--- a/pkg/config/engine/crio/crio_test.go
+++ b/pkg/config/engine/crio/crio_test.go
@@ -68,10 +68,6 @@ func TestAddRuntime(t *testing.T) {
 			`,
 			expectedConfig: `
 			[crio]
-			[crio.runtime.runtimes.runc]
-			runtime_path = "/usr/bin/runc"
-			runtime_type = "runcoci"
-			runc_option = "option"
 			[crio.runtime.runtimes.test]
 			runtime_path = "/usr/bin/test"
 			runtime_type = "oci"
@@ -92,11 +88,6 @@ func TestAddRuntime(t *testing.T) {
 			expectedConfig: `
 			[crio]
 			[crio.runtime]
-			default_runtime = "default"
-			[crio.runtime.runtimes.default]
-			runtime_path = "/usr/bin/default"
-			runtime_type = "defaultoci"
-			default_option = "option"
 			[crio.runtime.runtimes.test]
 			runtime_path = "/usr/bin/test"
 			runtime_type = "oci"
@@ -121,15 +112,6 @@ func TestAddRuntime(t *testing.T) {
 			expectedConfig: `
 			[crio]
 			[crio.runtime]
-			default_runtime = "default"
-			[crio.runtime.runtimes.default]
-			runtime_path = "/usr/bin/default"
-			runtime_type = "defaultoci"
-			default_option = "option"
-			[crio.runtime.runtimes.runc]
-			runtime_path = "/usr/bin/runc"
-			runtime_type = "runcoci"
-			runc_option = "option"
 			[crio.runtime.runtimes.test]
 			runtime_path = "/usr/bin/test"
 			runtime_type = "oci"

--- a/pkg/config/engine/crio/option.go
+++ b/pkg/config/engine/crio/option.go
@@ -37,8 +37,8 @@ func WithLogger(logger logger.Interface) Option {
 	}
 }
 
-// WithPath sets the path for the config builder
-func WithPath(path string) Option {
+// WithTopLevelConfigPath sets the path for the top-level containerd config.
+func WithTopLevelConfigPath(path string) Option {
 	return func(b *builder) {
 		b.topLevelConfigPath = path
 	}

--- a/pkg/config/engine/engine.go
+++ b/pkg/config/engine/engine.go
@@ -24,7 +24,7 @@ import "strings"
 //	the default runtime, "runc", and "crun"
 //
 // If an nvidia* runtime is set as the default runtime, this is ignored.
-func GetBinaryPathsForRuntimes(cfg Interface) []string {
+func GetBinaryPathsForRuntimes(cfg defaultRuntimesGetter) []string {
 
 	var binaryPaths []string
 	seen := make(map[string]bool)
@@ -45,9 +45,14 @@ func GetBinaryPathsForRuntimes(cfg Interface) []string {
 	return binaryPaths
 }
 
+type defaultRuntimesGetter interface {
+	DefaultRuntime() string
+	GetRuntimeConfig(string) (RuntimeConfig, error)
+}
+
 // GetLowLevelRuntimes returns a predefined list low-level runtimes from the specified config.
 // nvidia* runtimes are ignored.
-func GetLowLevelRuntimes(cfg Interface) []string {
+func GetLowLevelRuntimes(cfg defaultRuntimesGetter) []string {
 	var runtimes []string
 	isValidDefault := func(s string) bool {
 		if s == "" {


### PR DESCRIPTION
This change adds drop-in file support for containerd and crio. Instead of writing the entire in-memory config to the specified config path, we write only the modified settings (nvidia runtimes, default runtime, enable_cdi) settings to a drop-in file and update the top-level configs to import this if required.

See also #1272

For GPU Operator integration see https://github.com/NVIDIA/gpu-operator/pull/1710