### PR TITLE
Add support for drop-in config files in a container

### DIFF
--- a/cmd/nvidia-ctk-installer/container/container.go
+++ b/cmd/nvidia-ctk-installer/container/container.go
@@ -35,7 +35,8 @@ const (
 
 // Options defines the shared options for the CLIs to configure containers runtimes.
 type Options struct {
-	DropInConfig string
+	DropInConfig         string
+	DropInConfigHostPath string
 	// TopLevelConfigPath stores the path to the top-level config for the runtime.
 	TopLevelConfigPath string
 	Socket             string

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -62,6 +62,13 @@ func Flags(opts *Options) []cli.Flag {
 			Sources:     cli.EnvVars("RUNTIME_DROP_IN_CONFIG"),
 		},
 		&cli.StringFlag{
+			Name: "drop-in-config-host-path",
+			Usage: "When running in a container, this is the path to the drop-in config (--drop-in-config) on the host. " +
+				"This is required to correctly update the top-level config if required since paths there must be host-relative.",
+			Destination: &opts.DropInConfigHostPath,
+			Sources:     cli.EnvVars("RUNTIME_DROP_IN_CONFIG_HOST_PATH"),
+		},
+		&cli.StringFlag{
 			Name:        "executable-path",
 			Usage:       "The path to the runtime executable. This is used to extract the current config",
 			Destination: &opts.ExecutablePath,

--- a/pkg/config/engine/containerd/containerd.go
+++ b/pkg/config/engine/containerd/containerd.go
@@ -141,7 +141,7 @@ func New(opts ...Option) (engine.Interface, error) {
 			},
 		}
 
-		cfg := NewConfigWithDropIn(b.topLevelConfigPath, topLevelConfig, dropInConfig)
+		cfg := NewConfigWithDropIn(b.topLevelConfigPath, b.containerToHostPathMap, topLevelConfig, dropInConfig)
 		return cfg, nil
 	}
 }

--- a/pkg/config/engine/containerd/option.go
+++ b/pkg/config/engine/containerd/option.go
@@ -29,10 +29,25 @@ type builder struct {
 	topLevelConfigPath   string
 	runtimeType          string
 	containerAnnotations []string
+
+	containerToHostPathMap map[string]string
 }
 
 // Option defines a function that can be used to configure the config builder
 type Option func(*builder)
+
+// WithContainerPathAsHostPath maps a given container path to a host path.
+func WithContainerPathAsHostPath(containerPath string, hostPath string) Option {
+	return func(b *builder) {
+		if containerPath == "" || hostPath == "" || containerPath == hostPath {
+			return
+		}
+		if b.containerToHostPathMap == nil {
+			b.containerToHostPathMap = make(map[string]string)
+		}
+		b.containerToHostPathMap[containerPath] = hostPath
+	}
+}
 
 // WithLogger sets the logger for the config builder
 func WithLogger(logger logger.Interface) Option {


### PR DESCRIPTION
This change adds support for drop-in files in a container. Here the user needs to set `RUNTIME_DROP_IN_CONFIG_HOST_PATH` in addition to `RUNTIME_DROP_IN_CONFIG`. In this case when updating the top-level containerd config, the imports will use the host path instead of the container path.