### PR TITLE
Fix handling of unrecognised CDI hooks

### DIFF
--- a/cmd/nvidia-cdi-hook/commands/commands.go
+++ b/cmd/nvidia-cdi-hook/commands/commands.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"context"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 
@@ -33,7 +34,7 @@ import (
 // and error handling for unsupported hooks.
 // This allows the same command to be used for the nvidia-cdi-hook and
 // nvidia-ctk hook commands.
-func ConfigureCDIHookCommand(logger logger.Interface, cmd *cli.Command) *cli.Command {
+func ConfigureCDIHookCommand(logger logger.Interface, base *cli.Command) *cli.Command {
 	// We set the default action for the command to issue a warning and exit
 	// with no error.
 	// This means that if an unsupported hook is run, a container will not fail
@@ -41,19 +42,65 @@ func ConfigureCDIHookCommand(logger logger.Interface, cmd *cli.Command) *cli.Com
 	// referring to a new hook that is not yet supported by an older NVIDIA
 	// Container Toolkit version or a hook that has been removed in newer
 	// version.
-	cmd.Action = func(ctx context.Context, cmd *cli.Command) error {
+	base.Action = func(ctx context.Context, cmd *cli.Command) error {
 		return issueUnsupportedHookWarning(logger, cmd)
 	}
-	// Define the subcommands
-	cmd.Commands = []*cli.Command{
+	// CommandNotFound is triggered when an unrecognised (sub)command is detected.
+	// We assume that an unrecognised (sub)command represents an unsupported hook
+	// (usually a hook that was added or removed)
+	base.CommandNotFound = func(ctx context.Context, cmd *cli.Command, commandName string) {
+		_ = issueUnsupportedHookWarning(logger, cmd)
+	}
+	// OnUsageError is triggered when an unexpected flag is detected.
+	// We check the invoked command to determine whether it is an expected
+	// hook, and assume that this is an unsupported hook otherwise.
+	base.OnUsageError = func(ctx context.Context, cmd *cli.Command, err error, isSubcommand bool) error {
+		// If this is not an error that comes from parsing an unrecognised flag,
+		// return it as is.
+		if !strings.HasPrefix(err.Error(), "flag provided but not defined: -") {
+			return err
+		}
+
+		// If the first argument is a recognised command, we return the error as
+		// is since it represents an incorrect argument to the specific hook.
+		var subcommandName string
+		for _, arg := range cmd.Args().Slice() {
+			if strings.HasPrefix(arg, "-") {
+				continue
+			}
+			subcommandName = arg
+			break
+		}
+		// If a subcommand is detected and is a recognised subcommand, we return
+		// the error as is.
+		if subcommandName != "" && cmd.Command(subcommandName) != nil {
+			return err
+		}
+
+		// At this point either no args have been supplied or the (sub)command
+		// (first arg) is not regognised.
+		// We issue a warning and returun nil.
+		return issueUnsupportedHookWarning(logger, cmd)
+	}
+
+	// Define the supported hooks.
+	base.Commands = []*cli.Command{
 		ldcache.NewCommand(logger),
 		symlinks.NewCommand(logger),
 		chmod.NewCommand(logger),
 		cudacompat.NewCommand(logger),
 		disabledevicenodemodification.NewCommand(logger),
+		{
+			Name:   "noop",
+			Usage:  "The noop hook performs no actions and is only added to facilitate basic testing of the CLI",
+			Hidden: true,
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		},
 	}
 
-	return cmd
+	return base
 }
 
 // issueUnsupportedHookWarning logs a warning that no hook or an unsupported

--- a/cmd/nvidia-cdi-hook/main.go
+++ b/cmd/nvidia-cdi-hook/main.go
@@ -45,7 +45,7 @@ func main() {
 	opts := options{}
 
 	// Create the top-level CLI
-	c := cli.Command{
+	c := commands.ConfigureCDIHookCommand(logger, &cli.Command{
 		Name:    "NVIDIA CDI Hook",
 		Usage:   "Command to structure files for usage inside a container, called as hooks from a container runtime, defined in a CDI yaml file",
 		Version: info.GetVersionString(),
@@ -61,19 +61,6 @@ func main() {
 			logger.SetLevel(logLevel)
 			return ctx, nil
 		},
-		// We set the default action for the `nvidia-cdi-hook` command to issue a
-		// warning and exit with no error.
-		// This means that if an unsupported hook is run, a container will not fail
-		// to launch. An unsupported hook could be the result of a CDI specification
-		// referring to a new hook that is not yet supported by an older NVIDIA
-		// Container Toolkit version or a hook that has been removed in newer
-		// version.
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			commands.IssueUnsupportedHookWarning(logger, cmd)
-			return nil
-		},
-		// Define the subcommands
-		Commands: commands.New(logger),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "debug",
@@ -91,7 +78,7 @@ func main() {
 				Sources: cli.EnvVars("NVIDIA_CTK_QUIET", "NVIDIA_CDI_QUIET"),
 			},
 		},
-	}
+	})
 
 	// Run the CLI
 	err := c.Run(context.Background(), os.Args)

--- a/cmd/nvidia-ctk/hook/hook.go
+++ b/cmd/nvidia-ctk/hook/hook.go
@@ -37,7 +37,6 @@ func NewCommand(logger logger.Interface) *cli.Command {
 
 // build
 func (m hookCommand) build() *cli.Command {
-	// Create the 'hook' subcommand
 	return commands.ConfigureCDIHookCommand(m.logger, &cli.Command{
 		Name:  "hook",
 		Usage: "A collection of hooks that may be injected into an OCI spec",

--- a/cmd/nvidia-ctk/hook/hook.go
+++ b/cmd/nvidia-ctk/hook/hook.go
@@ -17,8 +17,6 @@
 package hook
 
 import (
-	"context"
-
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-cdi-hook/commands"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 
@@ -40,22 +38,8 @@ func NewCommand(logger logger.Interface) *cli.Command {
 // build
 func (m hookCommand) build() *cli.Command {
 	// Create the 'hook' subcommand
-	hook := cli.Command{
+	return commands.ConfigureCDIHookCommand(m.logger, &cli.Command{
 		Name:  "hook",
 		Usage: "A collection of hooks that may be injected into an OCI spec",
-		// We set the default action for the `hook` subcommand to issue a
-		// warning and exit with no error.
-		// This means that if an unsupported hook is run, a container will not fail
-		// to launch. An unsupported hook could be the result of a CDI specification
-		// referring to a new hook that is not yet supported by an older NVIDIA
-		// Container Toolkit version or a hook that has been removed in newer
-		// version.
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			commands.IssueUnsupportedHookWarning(m.logger, cmd)
-			return nil
-		},
-		Commands: commands.New(m.logger),
-	}
-
-	return &hook
+	})
 }


### PR DESCRIPTION
Fixes #1225


Previously, when an unrecognized CDI hook was invoked with command-line flags, the nvidia-cdi-hook command would fail with a flag parsing error instead of gracefully handling the unsupported hook. This could cause container launch failures when CDI specifications reference hooks that are not yet supported by the current NVIDIA Container Toolkit version.

This PR enhances the error handling in nvidia-cdi-hook to gracefully handle unrecognized CDI hooks that include command-line flags. The changes ensure that:
Unrecognized hooks with flags are handled gracefully - Instead of failing with flag parsing errors, the command now issues a warning and continues
Backwards compatibility is maintained - Existing behavior for supported hooks remains unchanged
Container launches don't fail - Unsupported hooks result in warnings rather than errors
Changes
Added OnUsageError handler in ConfigureCDIHookCommand to detect flag parsing errors for unrecognized commands
Added strings import for error message parsing to identify flag-related errors
Enhanced error detection to specifically catch "flag provided but not defined" errors for unrecognized hooks
Improved warning consistency by reusing the existing IssueUnsupportedHookWarning logic

# Test Cases
The following test cases demonstrate the improved behavior:

Before (failing):

```bash
$ ./nvidia-cdi-hook unknown-hook --some-flag value
Error: flag provided but not defined: -some-flag
```

After (graceful handling):

```bash
$ ./nvidia-cdi-hook unknown-hook --some-flag value
time="2025-09-22T11:25:26+02:00" level=warning msg="Unsupported CDI hook: unknown-hook"
```

Additional test cases:

```bash
# Unrecognized hook without flags
$ ./nvidia-cdi-hook unknown-hook
time="2025-09-22T11:25:26+02:00" level=warning msg="Unsupported CDI hook: unknown-hook"

# No hook specified
$ ./nvidia-cdi-hook
time="2025-09-22T11:25:26+02:00" level=warning msg="No CDI hook specified"

# Recognized hook with valid flags (unchanged behavior)
$ ./nvidia-cdi-hook update-ldcache --debug
# Works as expected, no warning

# Recognized hook with invalid flags (unchanged behavior)
$ ./nvidia-cdi-hook update-ldcache --invalid-flag
Error: flag provided but not defined: -invalid-flag
```