### PR TITLE
Add CRI plugin config from source containerd config to drop-in file

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/config_test.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/config_test.go
@@ -789,6 +789,7 @@ version = 2
     enable_cdi = true
 
     [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
 
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 
@@ -809,6 +810,12 @@ version = 2
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
 `
 				require.Equal(t, expectedDropIn, string(actualDropIn))
 				return nil
@@ -954,6 +961,12 @@ version = 2
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
 `
 				require.Equal(t, expectedDropIn, string(actualDropIn))
 				return nil
@@ -1106,8 +1119,16 @@ version = 2
     enable_cdi = true
 
     [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      snapshotter = "overlayfs"
 
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.custom]
+          runtime_type = "io.containerd.custom.v1"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.custom.options]
+            TypeUrl = "custom.runtime/options"
 
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
           container_annotations = ["cdi.k8s.io*"]
@@ -1132,6 +1153,20 @@ version = 2
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
             SystemdCgroup = true
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
+            SystemdCgroup = true
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
 `
 				require.Equal(t, expectedDropIn, string(actualDropIn))
 				return nil
@@ -1278,6 +1313,12 @@ version = 2
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
 `
 
 				require.Equal(t, expectedDropIn, string(actualDropIn))
@@ -1407,6 +1448,12 @@ version = 2
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
 `
 				require.Equal(t, expectedDropIn, string(actualDropIn))
 				return nil
@@ -1533,6 +1580,12 @@ version = 3
 
           [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
+
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
 `
 				require.Equal(t, expectedDropIn, string(actualDropIn))
 
@@ -1675,6 +1728,15 @@ version = 3
 
           [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy.options]
             BinaryName = "/usr/bin/nvidia-container-runtime.legacy"
+            NoPivotRoot = false
+            Root = "/run/containerd/runc"
+            SystemdCgroup = true
+
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+            BinaryName = "/usr/bin/runc"
             NoPivotRoot = false
             Root = "/run/containerd/runc"
             SystemdCgroup = true

--- a/pkg/config/engine/containerd/config_test.go
+++ b/pkg/config/engine/containerd/config_test.go
@@ -94,7 +94,15 @@ func TestAddRuntime(t *testing.T) {
 			[plugins]
 			[plugins."io.containerd.grpc.v1.cri"]
 				[plugins."io.containerd.grpc.v1.cri".containerd]
-				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+                    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+                    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+					privileged_without_host_devices = true
+					runtime_engine = "engine"
+					runtime_root = "root"
+					runtime_type = "type"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+						BinaryName = "/usr/bin/runc"
+						SystemdCgroup = true
 					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
@@ -128,7 +136,16 @@ func TestAddRuntime(t *testing.T) {
 			[plugins]
 			[plugins."io.containerd.grpc.v1.cri"]
 				[plugins."io.containerd.grpc.v1.cri".containerd]
+				default_runtime_name = "default"
 				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
+					privileged_without_host_devices = true
+					runtime_engine = "engine"
+					runtime_root = "root"
+					runtime_type = "type"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
+						BinaryName = "/usr/bin/default"
+						SystemdCgroup = true
 					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"
@@ -170,7 +187,24 @@ func TestAddRuntime(t *testing.T) {
 			[plugins]
 			[plugins."io.containerd.grpc.v1.cri"]
 				[plugins."io.containerd.grpc.v1.cri".containerd]
+				default_runtime_name = "default"
 				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+					privileged_without_host_devices = true
+					runtime_engine = "engine"
+					runtime_root = "root"
+					runtime_type = "type"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+						BinaryName = "/usr/bin/runc"
+						SystemdCgroup = true
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default]
+					privileged_without_host_devices = false
+					runtime_engine = "defaultengine"
+					runtime_root = "defaultroot"
+					runtime_type = "defaulttype"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.default.options]
+						BinaryName = "/usr/bin/default"
+						SystemdCgroup = false
 					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
 					privileged_without_host_devices = false
 					runtime_engine = "defaultengine"
@@ -225,6 +259,14 @@ func TestAddRuntime(t *testing.T) {
 			[plugins."io.containerd.cri.v1.runtime"]
 				[plugins."io.containerd.cri.v1.runtime".containerd]
 				[plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
+					[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+					privileged_without_host_devices = true
+					runtime_engine = "engine"
+					runtime_root = "root"
+					runtime_type = "type"
+					[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+						BinaryName = "/usr/bin/runc"
+						SystemdCgroup = true
 					[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.test]
 					privileged_without_host_devices = true
 					runtime_engine = "engine"


### PR DESCRIPTION
This change updates the drop-in file contents that the nvidia-ctk-installer creates for containerd. In addition to adding nvidia runtimes, the nvidia-ctk-installer also includes all existing configuration present in the source containerd configuration for the CRI plugin. That is, all configuration already present in the 'plugins."io.containerd.grpc.v1.cri"' section will be added to our drop-in file.

This is needed due to how containerd merges configuration from multiple files. See https://github.com/containerd/containerd/issues/5837