### PR TITLE
Deprecate the hook config mode for cri-o

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk-installer/container"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/config"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/engine/crio"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/config/ocihook"
@@ -35,7 +36,10 @@ import (
 const (
 	Name = "crio"
 
-	defaultConfigMode = "hook"
+	defaultConfigMode = configModeConfig
+
+	configModeConfig = "config"
+	configModeHook   = "hook"
 
 	// Hook-based settings
 	defaultHooksDir     = "/usr/share/containers/oci/hooks.d"
@@ -86,6 +90,16 @@ func Flags(opts *Options) []cli.Flag {
 	}
 
 	return flags
+}
+
+func (opts *Options) Validate(logger logger.Interface, _ *cli.Command) error {
+	if opts.configMode != configModeConfig && opts.configMode != configModeHook {
+		return fmt.Errorf("invalid cri-o config mode: %q", opts.configMode)
+	}
+	if opts.configMode == configModeHook {
+		logger.Warningf("The %q config for cri-o is deprecated", opts.configMode)
+	}
+	return nil
 }
 
 // Setup installs the prestart hook required to launch GPU-enabled containers

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -146,6 +146,9 @@ func (opts *Options) Validate(logger logger.Interface, c *cli.Command, runtime s
 		}
 	case containerd.Name:
 	case crio.Name:
+		if err := opts.crioOptions.Validate(logger, c); err != nil {
+			return fmt.Errorf("invalid cri-o config: %w", err)
+		}
 	}
 
 	// Apply the runtime-specific config changes.

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -177,13 +177,14 @@ func (m command) build() *cli.Command {
 }
 
 func (m command) validateFlags(config *config) error {
-	if config.mode == "oci-hook" {
+	if config.mode == "oci-hook" || config.mode == "hook" {
+		m.logger.Warningf("The %q config-mode is deprecated", config.mode)
 		if !filepath.IsAbs(config.nvidiaRuntime.hookPath) {
 			return fmt.Errorf("the NVIDIA runtime hook path %q is not an absolute path", config.nvidiaRuntime.hookPath)
 		}
 		return nil
 	}
-	if config.mode != "" && config.mode != "config-file" {
+	if config.mode != "" && config.mode != "config-file" && config.mode != "config" {
 		m.logger.Warningf("Ignoring unsupported config mode for %v: %q", config.runtime, config.mode)
 	}
 	config.mode = "config-file"
@@ -246,9 +247,9 @@ func (m command) validateFlags(config *config) error {
 // configureWrapper updates the specified container engine config to enable the NVIDIA runtime
 func (m command) configureWrapper(config *config) error {
 	switch config.mode {
-	case "oci-hook":
+	case "oci-hook", "hook":
 		return m.configureOCIHook(config)
-	case "config-file":
+	case "config-file", "config":
 		return m.configureConfigFile(config)
 	}
 	return fmt.Errorf("unsupported config-mode: %v", config.mode)


### PR DESCRIPTION
The GPU Operator is switching from 'hook' to 'config' by default in the next release. This change ensures the default behavior of the toolkit container and GPU Operator are aligned. We also add deprecation messages to cases where an OCI hook is explicitly requested.

See thread for additional context: https://github.com/NVIDIA/gpu-operator/pull/1578#discussion_r2361236018