### PR TITLE
Bump release v1.17.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # NVIDIA Container Toolkit Changelog
 
+## v1.17.9
+- Don't inject enable-cuda-compat hook in CSV mode
+- Use securejoin to resolve /proc
+
+### Changes in the Toolkit Container
+
+- Bump nvidia/cuda to 12.9.1 in /deployments/container
+
 ## v1.17.8
 
 - Updated the ordering of Mounts in CDI to have a deterministic output. This makes testing more consistent.

--- a/versions.mk
+++ b/versions.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 LIB_NAME := nvidia-container-toolkit
-LIB_VERSION := 1.17.8
+LIB_VERSION := 1.17.9
 LIB_TAG :=
 
 # The package version is the combination of the library version and tag.


### PR DESCRIPTION
This prepares for a v1.17.9 release and includes the following notable changes:

* #1278 
* #1176