### PR TITLE
Disable generation of nvidia.com/gpu.[non]coherent CDI specs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NVIDIA Container Toolkit Changelog
 
+## v1.18.0-rc.5
+- Update go-nvlib to restrict nvidia.com/gpu.coherent devices to devices with an ATS addressing mode.
+
 ## v1.18.0-rc.4
 
 - Add drop-in file support for containerd and crio

--- a/cmd/nvidia-ctk/cdi/generate/generate_test.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate_test.go
@@ -29,7 +29,6 @@ import (
 	"tags.cncf.io/container-device-interface/specs-go"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
-	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi"
 )
 
 func TestGenerateSpec(t *testing.T) {
@@ -478,7 +477,6 @@ containerEdits:
 			}
 			tc.options.nvmllib = server
 
-			tc.options.featureFlags = []string{string(nvcdi.FeatureDisableCoherentAnnotations)}
 			specs, err := c.generateSpecs(&tc.options)
 			require.ErrorIs(t, err, tc.expectedError)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/NVIDIA/go-nvlib v0.8.0
+	github.com/NVIDIA/go-nvlib v0.8.1
 	github.com/NVIDIA/go-nvml v0.13.0-1
 	github.com/cyphar/filepath-securejoin v0.4.1
 	github.com/moby/sys/reexec v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/NVIDIA/go-nvlib v0.8.0 h1:vorMvnsJYvZaxiluSXFd+fIFeQFPWSiSjNPiJyvDs0c=
-github.com/NVIDIA/go-nvlib v0.8.0/go.mod h1:bV+OEgjJCbFXf5T8c082mVPFuiF+gKwf9CMT7DWGUBI=
+github.com/NVIDIA/go-nvlib v0.8.1 h1:OPEHVvn3zcV5OXB68A7WRpeCnYMRSPl7LdeJH/d3gZI=
+github.com/NVIDIA/go-nvlib v0.8.1/go.mod h1:7mzx9FSdO9fXWP9NKuZmWkCwhkEcSWQFe2tmFwtLb9c=
 github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
 github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/nvcdi/api.go
+++ b/pkg/nvcdi/api.go
@@ -80,7 +80,7 @@ const (
 	// FeatureDisableNvsandboxUtils disables the use of nvsandboxutils when
 	// querying devices.
 	FeatureDisableNvsandboxUtils = FeatureFlag("disable-nvsandbox-utils")
-	// FeatureDisableCoherentAnnotations disables the addition of annotations
+	// FeatureEnableCoherentAnnotations enables the addition of annotations
 	// coherent or non-coherent devices.
-	FeatureDisableCoherentAnnotations = FeatureFlag("disable-coherent-annotations")
+	FeatureEnableCoherentAnnotations = FeatureFlag("enable-coherent-annotations")
 )

--- a/pkg/nvcdi/full-gpu-nvml.go
+++ b/pkg/nvcdi/full-gpu-nvml.go
@@ -112,7 +112,7 @@ func (l *fullGPUDeviceSpecGenerator) device() (device.Device, error) {
 }
 
 func (l *fullGPUDeviceSpecGenerator) getDeviceAnnotations() (map[string]string, error) {
-	if l.featureFlags[FeatureDisableCoherentAnnotations] {
+	if !l.featureFlags[FeatureEnableCoherentAnnotations] {
 		return nil, nil
 	}
 

--- a/pkg/nvcdi/mig-device-nvml.go
+++ b/pkg/nvcdi/mig-device-nvml.go
@@ -41,7 +41,7 @@ func (l *migDeviceSpecGenerator) GetUUID() (string, error) {
 }
 
 func (l *nvmllib) newMIGDeviceSpecGeneratorFromDevice(i int, d device.Device, j int, m device.MigDevice) (*migDeviceSpecGenerator, error) {
-	parent, err := l.newFullGPUDeviceSpecGeneratorFromDevice(i, d, map[FeatureFlag]bool{FeatureDisableCoherentAnnotations: true})
+	parent, err := l.newFullGPUDeviceSpecGeneratorFromDevice(i, d, make(map[FeatureFlag]bool))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/device.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/device.go
@@ -193,13 +193,8 @@ func (d *device) IsCoherent() (bool, error) {
 		return false, fmt.Errorf("error getting addressing mode: %v", ret)
 	}
 
-	switch nvml.DeviceAddressingModeType(mode.Value) {
-	case nvml.DEVICE_ADDRESSING_MODE_HMM:
+	if nvml.DeviceAddressingModeType(mode.Value) == nvml.DEVICE_ADDRESSING_MODE_ATS {
 		return true, nil
-	case nvml.DEVICE_ADDRESSING_MODE_ATS:
-		return true, nil
-	case nvml.DEVICE_ADDRESSING_MODE_NONE:
-		return false, nil
 	}
 	return false, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/NVIDIA/go-nvlib v0.8.0
+# github.com/NVIDIA/go-nvlib v0.8.1
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvlib/pkg/nvlib/device
 github.com/NVIDIA/go-nvlib/pkg/nvlib/info


### PR DESCRIPTION
This change bumps the `github.com/NVIDIA/go-nvlib` dependency from `v0.8.0` to `v0.8.1` to ensures that `nvidia.com/gpu.coherent` CDI specs are only generated for devices with an addressing mode of ATS.

It also disables the functionality for splitting generated CDI specifications based on device coherence by default. This was added in #1247, but due to discussions around whether coherence is an property that should be exposed, we are disabling this by default.

Note that users can opt in to the feature by running the `nvidia-ctk cdi generate` with the `--feature-flag=enable-coherent-annotations` command line flag. Alternatively the `nvidia-ctk cdi generate` command can be run with the `NVIDIA_CTK_CDI_GENERATE_FEATURE_FLAGS` enviroment set to include `"enable-coherent-annotations"` (in a comma-separated list).

The same feature flag can be passed to the `nvcdi` API when constructing a CDI spec generator.