### PR TITLE
Add ability to opt-out of drop-in files

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
@@ -183,6 +183,7 @@ func getRuntimeConfig(o *container.Options, co *Options) (engine.Interface, erro
 		containerd.WithRuntimeType(co.runtimeType),
 		containerd.WithUseLegacyConfig(co.useLegacyConfig),
 		containerd.WithContainerAnnotations(co.containerAnnotationsFromCDIPrefixes()...),
+		containerd.WithDisableDropInConfig(o.DropInConfig == ""),
 	}
 	if o.DropInConfigHostPath != "" && o.DropInConfig != "" {
 		options = append(options,

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
@@ -222,5 +222,6 @@ func getRuntimeConfig(o *container.Options) (engine.Interface, error) {
 				toml.FromFile(o.TopLevelConfigPath),
 			),
 		),
+		crio.WithDisableDropInConfig(o.DropInConfig == ""),
 	)
 }

--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -56,7 +56,7 @@ func Flags(opts *Options) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "drop-in-config",
-			Usage:       "Path to the NVIDIA-specific drop-in config file",
+			Usage:       "Path to the NVIDIA-specific drop-in config file. If this is empty, the top-level config is modified directly.",
 			Value:       runtimeSpecificDefault,
 			Destination: &opts.DropInConfig,
 			Sources:     cli.EnvVars("RUNTIME_DROP_IN_CONFIG"),

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -302,12 +302,14 @@ func (m command) configureConfigFile(config *config) error {
 			containerd.WithLogger(m.logger),
 			containerd.WithTopLevelConfigPath(config.configFilePath),
 			containerd.WithConfigSource(configSource),
+			containerd.WithDisableDropInConfig(config.dropInConfigPath == ""),
 		)
 	case "crio":
 		cfg, err = crio.New(
 			crio.WithLogger(m.logger),
 			crio.WithTopLevelConfigPath(config.configFilePath),
 			crio.WithConfigSource(configSource),
+			crio.WithDisableDropInConfig(config.dropInConfigPath == ""),
 		)
 	case "docker":
 		cfg, err = docker.New(

--- a/pkg/config/engine/containerd/containerd.go
+++ b/pkg/config/engine/containerd/containerd.go
@@ -50,6 +50,7 @@ type configOptions struct {
 	// for the CRI runtime service. The name of this plugin was changed in v3 of the
 	// containerd configuration file.
 	CRIRuntimePluginName string
+	DisableDropInConfig  bool
 }
 
 var _ engine.Interface = (*Config)(nil)
@@ -122,6 +123,10 @@ func New(opts ...Option) (engine.Interface, error) {
 		// We return the sourceConfig as is.
 		return (*ConfigV1)(sourceConfig), nil
 	default:
+		if b.disableDropInConfig {
+			b.logger.Info("Drop-in config files are disabled. Modifying the source config directly.")
+			return sourceConfig, nil
+		}
 		// For other versions, we create a DropInConfig with a reference to the
 		// top-level config if present.
 		topLevelConfig := &Config{

--- a/pkg/config/engine/containerd/option.go
+++ b/pkg/config/engine/containerd/option.go
@@ -31,6 +31,8 @@ type builder struct {
 	containerAnnotations []string
 
 	containerToHostPathMap map[string]string
+
+	disableDropInConfig bool
 }
 
 // Option defines a function that can be used to configure the config builder
@@ -95,5 +97,12 @@ func WithConfigVersion(configVersion int) Option {
 func WithContainerAnnotations(containerAnnotations ...string) Option {
 	return func(b *builder) {
 		b.containerAnnotations = containerAnnotations
+	}
+}
+
+// WithDisableDropInConfig disables the use of drop-in config files
+func WithDisableDropInConfig(disable bool) Option {
+	return func(b *builder) {
+		b.disableDropInConfig = disable
 	}
 }

--- a/pkg/config/engine/crio/crio.go
+++ b/pkg/config/engine/crio/crio.go
@@ -62,16 +62,22 @@ func New(opts ...Option) (engine.Interface, error) {
 		b.configSource = toml.FromFile(b.topLevelConfigPath)
 	}
 
-	sourceConfig, err := b.configSource.Load()
+	sourceConfigTree, err := b.configSource.Load()
 	if err != nil {
 		return nil, err
 	}
 
+	sourceConfig := &Config{
+		Tree:   sourceConfigTree,
+		Logger: b.logger,
+	}
+
+	if b.disableDropInConfig {
+		return sourceConfig, nil
+	}
+
 	cfg := &engine.Config{
-		Source: &Config{
-			Tree:   sourceConfig,
-			Logger: b.logger,
-		},
+		Source: sourceConfig,
 		Destination: &Config{
 			Tree:   toml.NewEmpty(),
 			Logger: b.logger,

--- a/pkg/config/engine/crio/option.go
+++ b/pkg/config/engine/crio/option.go
@@ -22,13 +22,21 @@ import (
 )
 
 type builder struct {
-	logger             logger.Interface
-	configSource       toml.Loader
-	topLevelConfigPath string
+	logger              logger.Interface
+	configSource        toml.Loader
+	topLevelConfigPath  string
+	disableDropInConfig bool
 }
 
 // Option defines a function that can be used to configure the config builder
 type Option func(*builder)
+
+// WithDisableDropInConfig disables the use of drop-in config files
+func WithDisableDropInConfig(disable bool) Option {
+	return func(b *builder) {
+		b.disableDropInConfig = disable
+	}
+}
 
 // WithLogger sets the logger for the config builder
 func WithLogger(logger logger.Interface) Option {


### PR DESCRIPTION
This change allows the use of drop-in config files for containerd and cri-o to be disabled when setting `RUNTIME_DROP_IN_CONFIG` to `""`. This allows better support for use cases such as `microk8s` where the top-level config may be a template that is rendered at runtime.