### PR TITLE
Bump third_party/libnvidia-container from 6eda4d7 to e78456a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Bump nvidia/cuda to 12.9.1 in /deployments/container
 
+### Changes in libnvidia-container
+- Add clock_gettime to allowed syscalls
+- Add libnvidia-gpucomp.so to the list of compute libs
+
 ## v1.17.8
 
 - Updated the ordering of Mounts in CDI to have a deterministic output. This makes testing more consistent.

--- a/versions.mk
+++ b/versions.mk
@@ -30,3 +30,10 @@ GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=4
 GIT_COMMIT_SHORT ?= $(shell git rev-parse --short HEAD 2> /dev/null || echo "")
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo "${GIT_COMMIT}")
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct  2> /dev/null || echo "")
+
+ifeq ($(IMAGE_NAME),)
+REGISTRY ?= nvidia
+IMAGE_NAME := $(REGISTRY)/container-toolkit
+endif
+
+VERSION ?= $(LIB_VERSION)$(if $(LIB_TAG),-$(LIB_TAG))


### PR DESCRIPTION
This bumps libnvidia-contianer from https://github.com/NVIDIA/libnvidia-container/commit/6eda4d76c8c5f8fc174e4abca83e513fb4dd63b0 to https://github.com/NVIDIA/libnvidia-container/commit/e78456a41c71d73eabf7a85d1e531a108789349b to backport the following changes:

* https://github.com/NVIDIA/libnvidia-container/pull/326
* https://github.com/NVIDIA/libnvidia-container/pull/315