### PR TITLE
[nv-gha-runner-gh-action] use the updated action output

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -101,6 +101,6 @@ jobs:
         uses: nv-gha-runners/setup-artifactory-go-proxy@main
 
       - env:
-          GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy }}
+          GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
         run: |
           make build

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -123,7 +123,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           PUSH_ON_BUILD: "true"
           BUILD_MULTI_ARCH_IMAGES: ${{ inputs.build_multi_arch_images }}
-          GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy }}
+          GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
         run: |
           echo "${VERSION}"
           make -f deployments/container/Makefile build-${{ matrix.target }}


### PR DESCRIPTION
This change is needed to support the breaking change merged to the nv-gha-runners GH action

See this [commit](https://github.com/nv-gha-runners/setup-artifactory-go-proxy/commit/a15ec16ff434e8ca3b0f76919f902080e66ebc14) for more details