### PR TITLE
Remove ppc64le artifacts from build

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -33,21 +33,15 @@ jobs:
         target:
           - ubuntu18.04-arm64
           - ubuntu18.04-amd64
-          - ubuntu18.04-ppc64le
           - centos7-aarch64
           - centos7-x86_64
-          - centos8-ppc64le
         ispr:
           - ${{ github.ref_name != 'main' && !startsWith( github.ref_name, 'release-' ) }}
         exclude:
           - ispr: true
             target: ubuntu18.04-arm64
           - ispr: true
-            target: ubuntu18.04-ppc64le
-          - ispr: true
             target: centos7-aarch64
-          - ispr: true
-            target: centos8-ppc64le
       fail-fast: false
 
     steps:

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -118,7 +118,5 @@ test-packaging:
 	@echo "Testing package image contents"
 	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/centos7/aarch64" || echo "Missing centos7/aarch64"
 	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/centos7/x86_64" || echo "Missing centos7/x86_64"
-	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/centos8/ppc64le" || echo "Missing centos8/ppc64le"
 	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/ubuntu18.04/amd64" || echo "Missing ubuntu18.04/amd64"
 	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/ubuntu18.04/arm64" || echo "Missing ubuntu18.04/arm64"
-	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/ubuntu18.04/ppc64le" || echo "Missing ubuntu18.04/ppc64le"

--- a/scripts/release-kitmaker-artifactory.sh
+++ b/scripts/release-kitmaker-artifactory.sh
@@ -221,6 +221,3 @@ create_and_upload "main" "sbsa" "ubuntu18.04-arm64" "centos7-aarch64"
 # Create archive for aarch64 linux distributions
 # NOTE: From the perspective of the NVIDIA Container Toolkit aarch64 is just a duplicate of sbsa
 create_and_upload "main" "aarch64" "ubuntu18.04-arm64" "centos7-aarch64"
-
-# Create archive for ppc64le linux distributions
-create_and_upload "main" "ppc64le" "ubuntu18.04-ppc64le" "centos8-ppc64le"


### PR DESCRIPTION
This change removes ppc64le artifacts from the build process.

Note that the make targets remain valid.