### PR TITLE
Bump version for v1.18.0-rc.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # NVIDIA Container Toolkit Changelog
 
+## v1.18.0-rc.6
+- Remove ppc64le artifacts from build
+- Add support for building artifacts with custom GOPROXY
+- Always update the ldcache in the container.
+
+### Changes in the Toolkit Container
+
+- Bump nvidia/distroless/go to v3.1.13-dev in /deployments/container
+- Allow config sources to be specified for containerd and crio
+- Allow file for config source to be specified explicitly
+
 ## Changes in libnvidia-container
 - Add clock_gettime to the set of allowed syscalls under seccomp.
 

--- a/versions.mk
+++ b/versions.mk
@@ -14,7 +14,7 @@
 
 LIB_NAME := nvidia-container-toolkit
 LIB_VERSION := 1.18.0
-LIB_TAG := rc.5
+LIB_TAG := rc.6
 
 # The package version is the combination of the library version and tag.
 # If the tag is specified the two components are joined with a tilde (~).


### PR DESCRIPTION
This should be the final rc for the 1.18.0 release.