### PR TITLE
[nvidia-ctk-installer] do not revert cri-o config on shutdown

### DIFF
--- a/cmd/nvidia-ctk-installer/container/container.go
+++ b/cmd/nvidia-ctk-installer/container/container.go
@@ -65,7 +65,7 @@ func (o Options) Configure(cfg engine.Interface) error {
 	if err != nil {
 		return fmt.Errorf("unable to update config: %v", err)
 	}
-	return o.flush(cfg)
+	return o.Flush(cfg)
 }
 
 // Unconfigure removes the options from the specified config
@@ -75,7 +75,7 @@ func (o Options) Unconfigure(cfg engine.Interface) error {
 		return fmt.Errorf("unable to update config: %v", err)
 	}
 
-	if err := o.flush(cfg); err != nil {
+	if err := o.Flush(cfg); err != nil {
 		return err
 	}
 
@@ -93,8 +93,8 @@ func (o Options) Unconfigure(cfg engine.Interface) error {
 	return nil
 }
 
-// flush flushes the specified config to disk
-func (o Options) flush(cfg engine.Interface) error {
+// Flush flushes the specified config to disk
+func (o Options) Flush(cfg engine.Interface) error {
 	filepath := o.DropInConfig
 	if filepath == "" {
 		filepath = o.TopLevelConfigPath

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/config_test.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/config_test.go
@@ -88,6 +88,30 @@ func TestCrioConfigLifecycle(t *testing.T) {
 			},
 			assertCleanupPostConditions: func(t *testing.T, co *container.Options, _ *Options) error {
 				require.NoFileExists(t, co.TopLevelConfigPath)
+				// drop-in file not removed on cleanup
+				actual, err := os.ReadFile(co.DropInConfig)
+				require.NoError(t, err)
+
+				expected := `
+[crio]
+
+  [crio.runtime]
+
+    [crio.runtime.runtimes]
+
+      [crio.runtime.runtimes.nvidia]
+        runtime_path = "/usr/bin/nvidia-container-runtime"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-cdi]
+        runtime_path = "/usr/bin/nvidia-container-runtime.cdi"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-legacy]
+        runtime_path = "/usr/bin/nvidia-container-runtime.legacy"
+        runtime_type = "oci"
+`
+				require.Equal(t, expected, string(actual))
 				return nil
 			},
 		},
@@ -200,6 +224,37 @@ signature_policy = "/etc/crio/policy.json"
 `
 				require.Equal(t, expectedTopLevel, string(actualTopLevel))
 
+				// drop-in file not removed on cleanup
+				require.FileExists(t, co.DropInConfig)
+				actual, err := os.ReadFile(co.DropInConfig)
+				require.NoError(t, err)
+
+				expected := `
+[crio]
+
+  [crio.runtime]
+
+    [crio.runtime.runtimes]
+
+      [crio.runtime.runtimes.nvidia]
+        monitor_path = "/usr/libexec/crio/conmon"
+        runtime_path = "/usr/bin/nvidia-container-runtime"
+        runtime_root = "/run/crun"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-cdi]
+        monitor_path = "/usr/libexec/crio/conmon"
+        runtime_path = "/usr/bin/nvidia-container-runtime.cdi"
+        runtime_root = "/run/crun"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-legacy]
+        monitor_path = "/usr/libexec/crio/conmon"
+        runtime_path = "/usr/bin/nvidia-container-runtime.legacy"
+        runtime_root = "/run/crun"
+        runtime_type = "oci"
+`
+				require.Equal(t, expected, string(actual))
 				return nil
 			},
 		},
@@ -309,8 +364,33 @@ runtime_type = "oci"
 
 				require.Equal(t, expectedTopLevel, string(actualTopLevel))
 
-				require.NoFileExists(t, co.DropInConfig)
+				// drop-in file not removed on cleanup
+				// default_runtime setting removed from drop-in
+				require.FileExists(t, co.DropInConfig)
+				actual, err := os.ReadFile(co.DropInConfig)
+				require.NoError(t, err)
 
+				expected := `
+[crio]
+
+  [crio.runtime]
+
+    [crio.runtime.runtimes]
+
+      [crio.runtime.runtimes.nvidia]
+        runtime_path = "/usr/bin/nvidia-container-runtime"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-cdi]
+        runtime_path = "/usr/bin/nvidia-container-runtime.cdi"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-legacy]
+        runtime_path = "/usr/bin/nvidia-container-runtime.legacy"
+        runtime_type = "oci"
+`
+
+				require.Equal(t, expected, string(actual))
 				return nil
 			},
 		},
@@ -476,6 +556,38 @@ plugin_dirs = [
 ]
 `
 				require.Equal(t, expected, string(actual))
+
+				// drop-in file not removed on cleanup
+				require.FileExists(t, co.DropInConfig)
+				actualDropIn, err := os.ReadFile(co.DropInConfig)
+				require.NoError(t, err)
+
+				expectedDropIn := `
+[crio]
+
+  [crio.runtime]
+
+    [crio.runtime.runtimes]
+
+      [crio.runtime.runtimes.nvidia]
+        monitor_path = "/usr/libexec/crio/conmon"
+        runtime_path = "/usr/bin/nvidia-container-runtime"
+        runtime_root = "/run/crun"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-cdi]
+        monitor_path = "/usr/libexec/crio/conmon"
+        runtime_path = "/usr/bin/nvidia-container-runtime.cdi"
+        runtime_root = "/run/crun"
+        runtime_type = "oci"
+
+      [crio.runtime.runtimes.nvidia-legacy]
+        monitor_path = "/usr/libexec/crio/conmon"
+        runtime_path = "/usr/bin/nvidia-container-runtime.legacy"
+        runtime_root = "/run/crun"
+        runtime_type = "oci"
+`
+				require.Equal(t, expectedDropIn, string(actualDropIn))
 
 				return nil
 			},

--- a/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
@@ -133,7 +133,7 @@ func setupHook(o *container.Options, co *Options) error {
 func setupConfig(o *container.Options) error {
 	log.Infof("Updating config file")
 
-	cfg, err := getRuntimeConfig(o)
+	cfg, err := getRuntimeConfig(o, false)
 	if err != nil {
 		return fmt.Errorf("unable to load config: %v", err)
 	}
@@ -186,14 +186,18 @@ func cleanupConfig(o *container.Options) error {
 
 	log.Infof("Reverting config file modifications")
 
-	cfg, err := getRuntimeConfig(o)
+	cfg, err := getRuntimeConfig(o, true)
 	if err != nil {
 		return fmt.Errorf("unable to load config: %v", err)
 	}
 
-	err = o.Unconfigure(cfg)
+	err = cfg.UpdateDefaultRuntime(o.RuntimeName, engine.UpdateActionUnset)
 	if err != nil {
-		return fmt.Errorf("unable to unconfigure cri-o: %v", err)
+		return fmt.Errorf("failed to unset %q as the default runtime: %w", o.RuntimeName, err)
+	}
+
+	if err := o.Flush(cfg); err != nil {
+		return err
 	}
 
 	err = RestartCrio(o)
@@ -210,24 +214,35 @@ func RestartCrio(o *container.Options) error {
 }
 
 func GetLowlevelRuntimePaths(o *container.Options) ([]string, error) {
-	cfg, err := getRuntimeConfig(o)
+	cfg, err := getRuntimeConfig(o, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load crio config: %w", err)
 	}
 	return engine.GetBinaryPathsForRuntimes(cfg), nil
 }
 
-func getRuntimeConfig(o *container.Options) (engine.Interface, error) {
+func getRuntimeConfig(o *container.Options, loadDestinationConfig bool) (engine.Interface, error) {
 	loaders, err := o.GetConfigLoaders(crio.CommandLineSource)
 	if err != nil {
 		return nil, err
 	}
-	return crio.New(
+
+	options := []crio.Option{
 		crio.WithTopLevelConfigPath(o.TopLevelConfigPath),
 		crio.WithConfigSource(
 			toml.LoadFirst(
 				loaders...,
 			),
 		),
-	)
+	}
+
+	if loadDestinationConfig {
+		destinationConfigPath := o.TopLevelConfigPath
+		if o.DropInConfig != "" {
+			destinationConfigPath = o.DropInConfig
+		}
+		options = append(options, crio.WithConfigDestination(toml.FromFile(destinationConfigPath)))
+	}
+
+	return crio.New(options...)
 }

--- a/pkg/config/engine/api.go
+++ b/pkg/config/engine/api.go
@@ -20,6 +20,12 @@ const (
 	// SaveToSTDOUT is used to write the specified config to stdout instead of
 	// to a file on disk.
 	SaveToSTDOUT = ""
+	// UpdateActionSet is used as an argument to UpdateDefaultRuntime
+	// when setting a runtime handler as the default in the config
+	UpdateActionSet = "set"
+	// UpdateActionUnset is used as an argument to UpdateDefaultRuntime
+	// when unsetting a runtime handler as the default in the config
+	UpdateActionUnset = "unset"
 )
 
 // Interface defines the API for a runtime config updater.
@@ -29,6 +35,7 @@ type Interface interface {
 	EnableCDI()
 	GetRuntimeConfig(string) (RuntimeConfig, error)
 	RemoveRuntime(string) error
+	UpdateDefaultRuntime(string, string) error
 	Save(string) (int64, error)
 	String() string
 }

--- a/pkg/config/engine/config.go
+++ b/pkg/config/engine/config.go
@@ -43,6 +43,7 @@ type RuntimeConfigDestination interface {
 	AddRuntimeWithOptions(string, string, bool, interface{}) error
 	EnableCDI()
 	RemoveRuntime(string) error
+	UpdateDefaultRuntime(string, string) error
 	Save(string) (int64, error)
 	String() string
 }
@@ -58,6 +59,14 @@ func (c *Config) AddRuntime(name string, path string, setAsDefault bool) error {
 // RemoveRuntime removes a runtime from the destination config.
 func (c *Config) RemoveRuntime(runtime string) error {
 	return c.Destination.RemoveRuntime(runtime)
+}
+
+// UpdateDefaultRuntime updates the default runtime setting in the destination config.
+// When action is 'set' the provided runtime name is set as the default.
+// When action is 'unset' we make sure the provided runtime name is not
+// the default.
+func (c *Config) UpdateDefaultRuntime(runtime string, action string) error {
+	return c.Destination.UpdateDefaultRuntime(runtime, action)
 }
 
 // EnableCDI enables CDI in the destination config.

--- a/pkg/config/engine/containerd/config_drop_in.go
+++ b/pkg/config/engine/containerd/config_drop_in.go
@@ -96,6 +96,14 @@ func (c *ConfigWithDropIn) RemoveRuntime(name string) error {
 	return c.Interface.RemoveRuntime(name)
 }
 
+// UpdateDefaultRuntime updates the default runtime setting in the drop-in config.
+// When action is 'set' the provided runtime name is set as the default.
+// When action is 'unset' we make sure the provided runtime name is not
+// the default.
+func (c *ConfigWithDropIn) UpdateDefaultRuntime(name string, action string) error {
+	return c.Interface.UpdateDefaultRuntime(name, action)
+}
+
 // flush saves the top-level config to its path.
 // If the config is empty, the file will be deleted.
 func (c *topLevelConfig) Save(dropInPath string) (int64, error) {

--- a/pkg/config/engine/containerd/config_v1.go
+++ b/pkg/config/engine/containerd/config_v1.go
@@ -120,6 +120,10 @@ func (c *ConfigV1) RemoveRuntime(name string) error {
 	return nil
 }
 
+func (c *ConfigV1) UpdateDefaultRuntime(name string, action string) error {
+	return fmt.Errorf("this method is not implemented")
+}
+
 // Save writes the config to a file
 func (c ConfigV1) Save(path string) (int64, error) {
 	return (Config)(c).Save(path)

--- a/pkg/config/engine/crio/option.go
+++ b/pkg/config/engine/crio/option.go
@@ -24,6 +24,7 @@ import (
 type builder struct {
 	logger             logger.Interface
 	configSource       toml.Loader
+	configDestination  toml.Loader
 	topLevelConfigPath string
 }
 
@@ -48,5 +49,12 @@ func WithTopLevelConfigPath(path string) Option {
 func WithConfigSource(configSource toml.Loader) Option {
 	return func(b *builder) {
 		b.configSource = configSource
+	}
+}
+
+// WithConfigDestination sets the TOML destination for the config.
+func WithConfigDestination(configDestination toml.Loader) Option {
+	return func(b *builder) {
+		b.configDestination = configDestination
 	}
 }

--- a/pkg/config/engine/docker/docker.go
+++ b/pkg/config/engine/docker/docker.go
@@ -150,6 +150,39 @@ func (c *Config) RemoveRuntime(name string) error {
 	return nil
 }
 
+// UpdateDefaultRuntime updates the default runtime setting in the config.
+// When action is 'set' the provided runtime name is set as the default.
+// When action is 'unset' we make sure the provided runtime name is not
+// the default.
+func (c *Config) UpdateDefaultRuntime(name string, action string) error {
+	if action != engine.UpdateActionSet && action != engine.UpdateActionUnset {
+		return fmt.Errorf("invalid action %q, valid actions are %q and %q", action, engine.UpdateActionSet, engine.UpdateActionUnset)
+	}
+
+	if c == nil {
+		if action == engine.UpdateActionSet {
+			return fmt.Errorf("config toml is nil")
+		}
+		return nil
+	}
+
+	config := *c
+
+	if action == engine.UpdateActionSet {
+		config["default-runtime"] = name
+	} else {
+		if _, exists := config["default-runtime"]; exists {
+			defaultRuntime := config["default-runtime"].(string)
+			if defaultRuntime == name {
+				config["default-runtime"] = defaultDockerRuntime
+			}
+		}
+	}
+
+	*c = config
+	return nil
+}
+
 // Save writes the config to the specified path
 func (c Config) Save(path string) (int64, error) {
 	output, err := json.MarshalIndent(c, "", "    ")


### PR DESCRIPTION
This commit updates the behavior of the nvidia-ctk-installer for cri-o.
On shutdown, we no longer delete the drop-in config file as long as
none of the nvidia runtime handlers are set as the default runtime.
This change was made to workaround an issue observed when uninstalling
the gpu-operator -- management containers launched with the nvidia
runtime handler would get stuck in the terminating state with the below
error message:

```
failed to find runtime handler nvidia from runtime list map[crun:... runc:...], failed to "KillPodSandbox" for ...
```

There appears to be a race condition where the nvidia-ctk-installer removes the drop-in file
and restarts cri-o. After the cri-o restart, if there are still pods / containers to terminate
that were started with the nvidia runtime, then cri-o fails to terminate them. The behavior
of cri-o, and its in-memory runtime handler cache, appears to differ from that of containerd as
we have never encountered such an issue with containerd.

This commit can be considered a stop-gap solution until more robust solution is developed.

Signed-off-by: Christopher Desiniotis <cdesiniotis@nvidia.com>