### PR TITLE
Add rockylinux 8 as an RPM builder

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -33,15 +33,19 @@ jobs:
         target:
           - ubuntu18.04-arm64
           - ubuntu18.04-amd64
-          - centos7-aarch64
-          - centos7-x86_64
+          - rhel7-aarch64
+          - rhel7-x86_64
+          - rhel8-aarch64
+          - rhel8-x86_64
         ispr:
           - ${{ github.ref_name != 'main' && !startsWith( github.ref_name, 'release-' ) }}
         exclude:
           - ispr: true
             target: ubuntu18.04-arm64
           - ispr: true
-            target: centos7-aarch64
+            target: rhel7-aarch64
+          - ispr: true
+            target: rhel8-aarch64
       fail-fast: false
 
     steps:

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux; \
         aarch64 | arm64) ARCH='arm64' ;; \
         *) echo "unsupported architecture" ; exit 1 ;; \
     esac; \
-    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    wget -nv -O - https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 
@@ -117,7 +117,7 @@ RUN rm -f /etc/yum.repos.d/cuda.repo && rm -f /etc/ld.so.conf.d/nvidia.conf
 RUN dnf install -y cpio
 
 ARG TARGETARCH
-ARG PACKAGE_DIST_RPM=centos7
+ARG PACKAGE_DIST_RPM=rhel8
 
 COPY --from=packaging /artifacts/packages/${PACKAGE_DIST_RPM} /rpm-packages
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -96,8 +96,7 @@ $(IMAGE_TARGETS): image-%: $(ARTIFACTS_ROOT)
 
 
 PACKAGE_DIST_DEB = ubuntu18.04
-# TODO: This needs to be set to centos8 for ppc64le builds
-PACKAGE_DIST_RPM = centos7
+PACKAGE_DIST_RPM = rhel8
 
 # Handle the default build target.
 .PHONY: build push
@@ -116,7 +115,7 @@ $(TEST_TARGETS): test-%:
 test-packaging: DIST = packaging
 test-packaging:
 	@echo "Testing package image contents"
-	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/centos7/aarch64" || echo "Missing centos7/aarch64"
-	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/centos7/x86_64" || echo "Missing centos7/x86_64"
+	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/rhel8/aarch64" || echo "Missing rhel8/aarch64"
+	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/rhel8/x86_64"  || echo "Missing rhel8/x86_64"
 	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/ubuntu18.04/amd64" || echo "Missing ubuntu18.04/amd64"
 	@$(DOCKER) run --rm $(IMAGE) test -d "/artifacts/packages/ubuntu18.04/arm64" || echo "Missing ubuntu18.04/arm64"

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -25,7 +25,7 @@ RUN set -eux; \
         aarch64 | arm64) ARCH='arm64' ;; \
         *) echo "unsupported architecture" ; exit 1 ;; \
     esac; \
-    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    wget -nv -O - https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH /go

--- a/docker/Dockerfile.opensuse-leap
+++ b/docker/Dockerfile.opensuse-leap
@@ -18,7 +18,7 @@ RUN set -eux; \
         aarch64 | arm64) ARCH='arm64' ;; \
         *) echo "unsupported architecture"; exit 1 ;; \
     esac; \
-    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    wget -nv -O - https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH /go
@@ -53,7 +53,7 @@ CMD arch=$(uname -m) && \
              -D "_topdir $PWD" \
              -D "release_date $(date +'%a %b %d %Y')" \
              -D "git_commit ${GIT_COMMIT}" \
-             -D "version ${PKG_VERS}" \
-             -D "release ${PKG_REV}" \
+             -D "_version ${PKG_VERS}" \
+             -D "_release ${PKG_REV}" \
              SPECS/nvidia-container-toolkit.spec && \
     mv RPMS/$arch/*.rpm /dist

--- a/docker/Dockerfile.rpm-yum
+++ b/docker/Dockerfile.rpm-yum
@@ -17,12 +17,16 @@
 ARG BASEIMAGE
 FROM ${BASEIMAGE}
 
-# centos:stream8 is EOL.
+# centos:7 is EOL.
 # We switch to the vault repositories for this base image.
-ARG BASEIMAGE
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
+ARG OS_VERSION
+RUN if [ "${OS_VERSION}" = "7" ]; then \
+        sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
             -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
-                /etc/yum.repos.d/CentOS-*
+                /etc/yum.repos.d/CentOS-*; \
+    else \
+        true; \
+    fi
 
 RUN yum install -y \
         ca-certificates \
@@ -43,7 +47,7 @@ RUN set -eux; \
         aarch64 | arm64) ARCH='arm64' ;; \
         *) echo "unsupported architecture"; exit 1 ;; \
     esac; \
-    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    wget -nv -O - https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH /go
@@ -78,7 +82,7 @@ CMD arch=$(uname -m) && \
              -D "_topdir $PWD" \
              -D "release_date $(date +'%a %b %d %Y')" \
              -D "git_commit ${GIT_COMMIT}" \
-             -D "version ${PKG_VERS}" \
-             -D "release ${PKG_REV}" \
+             -D "_version ${PKG_VERS}" \
+             -D "_release ${PKG_REV}" \
              SPECS/nvidia-container-toolkit.spec && \
     mv RPMS/$arch/*.rpm /dist

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -23,7 +23,7 @@ RUN set -eux; \
         aarch64 | arm64) ARCH='arm64' ;; \
         *) echo "unsupported architecture" ; exit 1 ;; \
     esac; \
-    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    wget -nv -O - https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH /go

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -94,7 +94,7 @@ docker-all: $(AMD64_TARGETS) $(X86_64_TARGETS) \
 # private centos target
 --centos%: OS := centos
 --centos%: DOCKERFILE = $(CURDIR)/docker/Dockerfile.rpm-yum
---centos8%: BASEIMAGE = quay.io/centos/centos:stream8
+--centos8%: BASEIMAGE = rockylinux/rockylinux:8
 
 # private amazonlinux target
 --amazonlinux%: OS := amazonlinux
@@ -109,8 +109,7 @@ docker-all: $(AMD64_TARGETS) $(X86_64_TARGETS) \
 --rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))
 --rhel%: ARTIFACTS_DIR = $(DIST_DIR)/rhel$(VERSION)/$(ARCH)
 --rhel%: DOCKERFILE = $(CURDIR)/docker/Dockerfile.rpm-yum
---rhel8%: BASEIMAGE = quay.io/centos/centos:stream8
-
+--rhel8%: BASEIMAGE = rockylinux/rockylinux:8
 
 docker-build-%:
 	@echo "Building for $(TARGET_PLATFORM)"
@@ -125,6 +124,7 @@ docker-build-%:
 	    --build-arg PKG_VERS="$(PACKAGE_VERSION)" \
 	    --build-arg PKG_REV="$(PACKAGE_REVISION)" \
 	    --build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--build-arg OS_VERSION="$(VERSION)" \
 	    --tag $(BUILDIMAGE) \
 	    --file $(DOCKERFILE) .
 	$(DOCKER) run \

--- a/hack/prepare-artifacts.sh
+++ b/hack/prepare-artifacts.sh
@@ -49,8 +49,8 @@ PACKAGE_VERSION=${PACKAGE_VERSION#v}
 
 tar -czvf ${PACKAGE_ROOT}/nvidia-container-toolkit_${VERSION#v}_deb_amd64.tar.gz ${PACKAGE_ROOT}/packages/ubuntu18.04/amd64/*_${PACKAGE_VERSION}-1_amd64.deb
 tar -czvf ${PACKAGE_ROOT}/nvidia-container-toolkit_${VERSION#v}_deb_arm64.tar.gz ${PACKAGE_ROOT}/packages/ubuntu18.04/arm64/*_${PACKAGE_VERSION}-1_arm64.deb
-tar -czvf ${PACKAGE_ROOT}/nvidia-container-toolkit_${VERSION#v}_rpm_aarch64.tar.gz ${PACKAGE_ROOT}/packages/centos7/aarch64/*-${PACKAGE_VERSION}-1.aarch64.rpm
-tar -czvf ${PACKAGE_ROOT}/nvidia-container-toolkit_${VERSION#v}_rpm_x86_64.tar.gz ${PACKAGE_ROOT}/packages/centos7/x86_64/*-${PACKAGE_VERSION}-1.x86_64.rpm
+tar -czvf ${PACKAGE_ROOT}/nvidia-container-toolkit_${VERSION#v}_rpm_aarch64.tar.gz ${PACKAGE_ROOT}/packages/rhel*/aarch64/*-${PACKAGE_VERSION}-1.aarch64.rpm
+tar -czvf ${PACKAGE_ROOT}/nvidia-container-toolkit_${VERSION#v}_rpm_x86_64.tar.gz ${PACKAGE_ROOT}/packages/rhel*/x86_64/*-${PACKAGE_VERSION}-1.x86_64.rpm
 
 is_command() (
   command -v "$1" >/dev/null

--- a/packaging/rpm/SPECS/nvidia-container-toolkit.spec
+++ b/packaging/rpm/SPECS/nvidia-container-toolkit.spec
@@ -1,6 +1,6 @@
 Name: nvidia-container-toolkit
-Version: %{version}
-Release: %{release}
+Version: %{_version}
+Release: %{_release}%{?dist}
 Group: Development Tools
 
 Vendor: NVIDIA CORPORATION

--- a/scripts/Dockerfile.sign.rpm
+++ b/scripts/Dockerfile.sign.rpm
@@ -1,3 +1,3 @@
-FROM quay.io/centos/centos:stream9
+FROM rockylinux/rockylinux:10
 
 RUN yum install -y createrepo rpm-sign pinentry

--- a/scripts/extract-packages.sh
+++ b/scripts/extract-packages.sh
@@ -103,5 +103,5 @@ mkdir -p "${ARTIFACTS_DIR}"
 copy-file "${PACKAGE_IMAGE}" "/artifacts/manifest.txt" "${ARTIFACTS_DIR}/manifest.txt"
 
 extract-all ubuntu18.04
-extract-all centos8
-extract-all centos7
+extract-all rhel8
+extract-all rhel7

--- a/scripts/packages-sign-all.sh
+++ b/scripts/packages-sign-all.sh
@@ -61,7 +61,7 @@ function sign() {
     case ${src_dist} in
     amazonlinux*) pkg_type=rpm
         ;;
-    centos* | rpm) pkg_type=rpm
+    centos* | rhel* | rpm) pkg_type=rpm
         ;;
     debian*) pkg_type=deb
         ;;
@@ -100,11 +100,11 @@ for target in ${TARGETS[@]}; do
     echo "checking target=${target}"
     by_package_type=
     case ${target} in
-    ubuntu18.04-* | centos7-*)
-        by_package_type="true"
-        ;;
-    centos8-ppc64le)
+    rhel8-ppc64le)
         by_package_type="false"
+        ;;
+    ubuntu18.04-* | centos* | rhel*)
+        by_package_type="true"
         ;;
     *)
         echo "Skipping target ${target}"

--- a/scripts/release-kitmaker-artifactory.sh
+++ b/scripts/release-kitmaker-artifactory.sh
@@ -214,10 +214,10 @@ function create_and_upload() {
 }
 
 # Create archive for x86_64 linux distributions
-create_and_upload "main" "x86_64" "ubuntu18.04-amd64" "centos7-x86_64"
+create_and_upload "main" "x86_64" "ubuntu18.04-amd64" "rhel7-x86_64" "rhel8-x86_64"
 
 # Create archive for sbsa linux distributions
-create_and_upload "main" "sbsa" "ubuntu18.04-arm64" "centos7-aarch64"
+create_and_upload "main" "sbsa" "ubuntu18.04-arm64" "rhel7-aarch64" "rhel8-aarch64"
 # Create archive for aarch64 linux distributions
 # NOTE: From the perspective of the NVIDIA Container Toolkit aarch64 is just a duplicate of sbsa
-create_and_upload "main" "aarch64" "ubuntu18.04-arm64" "centos7-aarch64"
+create_and_upload "main" "aarch64" "ubuntu18.04-arm64" "rhel7-aarch64" "rhel8-aarch64"

--- a/scripts/release-packages.sh
+++ b/scripts/release-packages.sh
@@ -95,7 +95,7 @@ function sync() {
     case ${src_dist} in
     amazonlinux*) pkg_type=rpm
         ;;
-    centos*) pkg_type=rpm
+    centos* | rhel*) pkg_type=rpm
         ;;
     debian*) pkg_type=deb
         ;;
@@ -162,11 +162,11 @@ for target in ${targets[@]}; do
     echo "checking target=${target}"
     by_package_type=
     case ${target} in
-    ubuntu18.04-* | centos7-*)
-        by_package_type="true"
-        ;;
     centos8-ppc64le)
         by_package_type="false"
+        ;;
+    ubuntu18.04-* | centos* | rhel*)
+        by_package_type="true"
         ;;
     *)
         echo "Skipping target ${target}"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -16,11 +16,11 @@
 # to the relevant repositories. This targets forwarded to the build-all-components script
 # can be overridden by specifying command line arguments.
 all=(
-    centos7-aarch64
-    centos7-x86_64
-    centos8-aarch64
-    centos8-ppc64le
-    centos8-x86_64
+    rhel7-aarch64
+    rhel7-x86_64
+    rhel8-aarch64
+    rhel8-ppc64le
+    rhel8-x86_64
     ubuntu18.04-amd64
     ubuntu18.04-arm64
     ubuntu18.04-ppc64le
@@ -33,7 +33,7 @@ function package_type() {
     case ${1} in
     amazonlinux*) pkg_type=rpm
         ;;
-    centos*) pkg_type=rpm
+    centos* | rhel*) pkg_type=rpm
         ;;
     debian*) pkg_type=deb
         ;;

--- a/tests/release/Makefile
+++ b/tests/release/Makefile
@@ -14,7 +14,7 @@
 
 WORKFLOW ?= nvidia-docker
 
-DISTRIBUTIONS := ubuntu20.04 ubuntu18.04 centos8 fedora35
+DISTRIBUTIONS := ubuntu20.04 ubuntu18.04 rhel8 fedora35
 
 IMAGE_TARGETS := $(patsubst %,image-%, $(DISTRIBUTIONS))
 RUN_TARGETS := $(patsubst %,run-%, $(DISTRIBUTIONS))
@@ -35,7 +35,7 @@ $(IMAGE_TARGETS): image-%: $(DOCKERFILE)
 
 %-ubuntu20.04: ARCH ?= amd64
 %-ubuntu18.04: ARCH ?= amd64
-%-centos8: ARCH ?= x86_64
+%-rhel8: ARCH ?= x86_64
 %-fedora35: ARCH ?= x86_64
 
 PLATFORM_ARGS = --platform=linux/${ARCH}

--- a/tests/release/docker/centos8/Dockerfile
+++ b/tests/release/docker/centos8/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=quay.io/centos/centos:stream8
+ARG BASEIMAGE=rockylinux/rockylinux:8
 FROM ${BASEIMAGE}
 
 RUN yum install -y \


### PR DESCRIPTION
This makes sure that RPMs have the fields that newer releases require.

Also:
- scrub centos from the release process, its dead
- update golang URLs to newer google endpoints
- replace all centos-stream:8 usage with rockylinux:8
- add "dist" tag to RPMs to distinguish el7 and el8 builds

This will fail CI until this libnvidia-container PR is merged. Come back and update this PR with new third_party pointer when that happens. https://github.com/NVIDIA/libnvidia-container/pull/329 