### PR TITLE
invoke the actual default low-level runtime in the nvidia-ctk wrapper script

### DIFF
--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -211,7 +211,7 @@ func (a *app) Run(c *cli.Command, o *options) error {
 		o.toolkitOptions.ContainerRuntimeRuntimes = lowlevelRuntimePaths
 	}
 
-	err = a.toolkit.Install(c, &o.toolkitOptions)
+	err = a.toolkit.Install(c, &o.toolkitOptions, o.runtime)
 	if err != nil {
 		return fmt.Errorf("unable to install toolkit: %v", err)
 	}

--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
@@ -102,6 +102,12 @@ func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, erro
 			w.Envvars[k] = v
 		}
 
+		if len(t.defaultRuntimeExecutablePath) > 0 {
+			w.DefaultRuntimeExecutablePath = t.defaultRuntimeExecutablePath
+		} else {
+			w.DefaultRuntimeExecutablePath = "runc"
+		}
+
 		installers = append(installers, w)
 
 		if executable.symlink == "" {
@@ -119,10 +125,11 @@ func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, erro
 }
 
 type wrapper struct {
-	Source            string
-	Envvars           map[string]string
-	WrappedExecutable string
-	CheckModules      bool
+	Source                       string
+	Envvars                      map[string]string
+	WrappedExecutable            string
+	CheckModules                 bool
+	DefaultRuntimeExecutablePath string
 }
 
 type render struct {
@@ -155,8 +162,8 @@ func (w *render) render() (io.Reader, error) {
 {{- if (.CheckModules) }}
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
 if [ "${?}" != "0" ]; then
-	echo "nvidia driver modules are not yet loaded, invoking runc directly"
-	exec runc "$@"
+	echo "nvidia driver modules are not yet loaded, invoking {{ .DefaultRuntimeExecutablePath }} directly"
+	exec {{ .DefaultRuntimeExecutablePath }} "$@"
 fi
 {{- end }}
 {{- range $key, $value := .Envvars }}

--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables_test.go
@@ -33,7 +33,8 @@ func TestWrapperRender(t *testing.T) {
 		{
 			description: "executable is added",
 			w: &wrapper{
-				WrappedExecutable: "some-runtime",
+				WrappedExecutable:            "some-runtime",
+				DefaultRuntimeExecutablePath: "runc",
 			},
 			expected: `#! /bin/sh
 	/dest-dir/some-runtime \
@@ -43,8 +44,9 @@ func TestWrapperRender(t *testing.T) {
 		{
 			description: "module check is added",
 			w: &wrapper{
-				WrappedExecutable: "some-runtime",
-				CheckModules:      true,
+				WrappedExecutable:            "some-runtime",
+				CheckModules:                 true,
+				DefaultRuntimeExecutablePath: "runc",
 			},
 			expected: `#! /bin/sh
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
@@ -63,6 +65,7 @@ fi
 				Envvars: map[string]string{
 					"PATH": "/foo/bar/baz",
 				},
+				DefaultRuntimeExecutablePath: "runc",
 			},
 			expected: `#! /bin/sh
 PATH=/foo/bar/baz \

--- a/cmd/nvidia-ctk-installer/toolkit/installer/installer.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/installer.go
@@ -41,6 +41,8 @@ type ToolkitInstaller struct {
 	artifactRoot *artifactRoot
 
 	ensureTargetDirectory Installer
+
+	defaultRuntimeExecutablePath string
 }
 
 var _ Installer = (*ToolkitInstaller)(nil)

--- a/cmd/nvidia-ctk-installer/toolkit/installer/installer_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/installer_test.go
@@ -113,9 +113,10 @@ func TestToolkitInstaller(t *testing.T) {
 		},
 	}
 	i := ToolkitInstaller{
-		logger:                logger,
-		artifactRoot:          r,
-		ensureTargetDirectory: createDirectory,
+		logger:                       logger,
+		artifactRoot:                 r,
+		ensureTargetDirectory:        createDirectory,
+		defaultRuntimeExecutablePath: "runc",
 	}
 
 	err := i.Install("/foo/bar/baz")

--- a/cmd/nvidia-ctk-installer/toolkit/installer/options.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/options.go
@@ -45,3 +45,9 @@ func WithSourceRoot(sourceRoot string) Option {
 		ti.sourceRoot = sourceRoot
 	}
 }
+
+func WithDefaultRuntimeExecutablePath(path string) Option {
+	return func(ti *ToolkitInstaller) {
+		ti.defaultRuntimeExecutablePath = path
+	}
+}

--- a/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
@@ -156,7 +156,7 @@ containerEdits:
 			)
 			require.NoError(t, ti.ValidateOptions(&options))
 
-			err := ti.Install(&cli.Command{}, &options)
+			err := ti.Install(&cli.Command{}, &options, "containerd")
 			if tc.expectedError == nil {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
Currently, the nvidia-container-runtime wrapper binary falls back to `runc` whenever it finds that the nvidia driver modules are no longer loaded. This will not work in clusters that have newer versions CRIO where only `crun` is installed and there is no `runc` binary present.

With this change, we pick the first element from the `opts.ContainerRuntimeRuntimes` list which is already populated with low level runtime binary paths extracted from the runtime config TOML. This makes for a more robust logic when choosing the fallback runtime as opposed to a hardcoded `"runc"`