### PR TITLE
[no-relnote] Remove signing of (non-existent) centos8 ppc64le packages

### DIFF
--- a/scripts/extract-packages.sh
+++ b/scripts/extract-packages.sh
@@ -103,5 +103,4 @@ mkdir -p "${ARTIFACTS_DIR}"
 copy-file "${PACKAGE_IMAGE}" "/artifacts/manifest.txt" "${ARTIFACTS_DIR}/manifest.txt"
 
 extract-all ubuntu18.04
-extract-all centos8
 extract-all centos7

--- a/scripts/packages-sign-all.sh
+++ b/scripts/packages-sign-all.sh
@@ -103,9 +103,6 @@ for target in ${TARGETS[@]}; do
     ubuntu18.04-* | centos7-*)
         by_package_type="true"
         ;;
-    centos8-ppc64le)
-        by_package_type="false"
-        ;;
     *)
         echo "Skipping target ${target}"
         continue

--- a/scripts/release-packages.sh
+++ b/scripts/release-packages.sh
@@ -165,9 +165,6 @@ for target in ${targets[@]}; do
     ubuntu18.04-* | centos7-*)
         by_package_type="true"
         ;;
-    centos8-ppc64le)
-        by_package_type="false"
-        ;;
     *)
         echo "Skipping target ${target}"
         continue


### PR DESCRIPTION
The building of the packages was removed in #1339 but the logic to sign the packages and update the repo data was not removed from the release scripts.