### PR TITLE
Fix bug in create-dev-char-symlinks command

### DIFF
--- a/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
+++ b/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
@@ -115,10 +115,6 @@ func (m command) build() *cli.Command {
 }
 
 func (m command) validateFlags(cfg *config) error {
-	if cfg.createAll {
-		return fmt.Errorf("create-all and watch are mutually exclusive")
-	}
-
 	if cfg.loadKernelModules && !cfg.createAll {
 		m.logger.Warning("load-kernel-modules is only applicable when create-all is set; ignoring")
 		cfg.loadKernelModules = false


### PR DESCRIPTION
The `create-dev-char-symlinks` command is broken when the `--create-all` flag is specified. The flag validation was not updated when the `watch` option was removed in #861