### PR TITLE
Don't read cdi generate mode from runtime mode

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -132,7 +132,6 @@ func (m command) build() *cli.Command {
 				Destination: &opts.mode,
 				Sources: cli.NewValueSourceChain(
 					cli.EnvVar("NVIDIA_CTK_CDI_GENERATE_MODE"),
-					m.config.ValueFrom("nvidia-container-runtime.mode"),
 				),
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
Although there is overlap, the runtime modes (auto, legacy, csv, cdi, jit-cdi, wsl) are not directly usable as nvidia-ctk cdi generate modes as these don't include (legacy, cdi, jit-cdi).

This change removes reading the CDI generate mode from the config file as this prevents automatic CDI spec generation in cases where a user has updated their config to override the mode (e.g. explicitly set it to legacy or cdi).

This changes the behaviour added in #1107.

Fixes #1376