### PR TITLE
chore: fix issues raised by govet and gocritic

### DIFF
--- a/cmd/nvidia-cdi-hook/disable-device-node-modification/params_other.go
+++ b/cmd/nvidia-cdi-hook/disable-device-node-modification/params_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /**
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd_other.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /**
 # Copyright 2023 NVIDIA CORPORATION

--- a/cmd/nvidia-ctk-installer/container/runtime/docker/docker_other.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/docker/docker_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /**
 # Copyright 2023 NVIDIA CORPORATION

--- a/internal/discover/hooks.go
+++ b/internal/discover/hooks.go
@@ -31,6 +31,7 @@ const (
 	AllHooks = HookName("all")
 
 	// A ChmodHook is used to set the file mode of the specified paths.
+	//
 	// Deprecated: The chmod hook is deprecated and will be removed in a future release.
 	ChmodHook = HookName("chmod")
 	// A CreateSymlinksHook is used to create symlinks in the container.


### PR DESCRIPTION
This fixes our Go lint jobs which are failing on main. E.g. https://github.com/NVIDIA/nvidia-container-toolkit/actions/runs/18923039141/job/54023789054