### PR TITLE
Fix containerd drop-in config path

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/containerd/containerd.go
@@ -34,7 +34,7 @@ const (
 	Name = "containerd"
 
 	DefaultConfig       = "/etc/containerd/config.toml"
-	DefaultDropInConfig = "/etc/containerd/config.d/99-nvidia.toml"
+	DefaultDropInConfig = "/etc/containerd/conf.d/99-nvidia.toml"
 
 	DefaultSocket      = "/run/containerd/containerd.sock"
 	DefaultRestartMode = "signal"

--- a/cmd/nvidia-ctk-installer/main_test.go
+++ b/cmd/nvidia-ctk-installer/main_test.go
@@ -286,7 +286,7 @@ swarm-resource = ""
 [nvidia-ctk]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-ctk"
 `,
-			expectedRuntimeConfig: `imports = ["{{ .testRoot }}/config.d/*.toml"]
+			expectedRuntimeConfig: `imports = ["{{ .testRoot }}/conf.d/*.toml"]
 version = 2
 `,
 			expectedDropInRuntimeConfig: `version = 2
@@ -375,7 +375,7 @@ swarm-resource = ""
 [nvidia-ctk]
   path = "{{ .toolkitRoot }}/toolkit/nvidia-ctk"
 `,
-			expectedRuntimeConfig: `imports = ["{{ .testRoot }}/config.d/*.toml"]
+			expectedRuntimeConfig: `imports = ["{{ .testRoot }}/conf.d/*.toml"]
 version = 2
 `,
 			expectedDropInRuntimeConfig: `version = 2
@@ -425,7 +425,7 @@ version = 2
 
 			cdiOutputDir := filepath.Join(testRoot, "/var/run/cdi")
 			runtimeConfigFile := filepath.Join(testRoot, "config.file")
-			runtimeDropInConfigFile := filepath.Join(testRoot, "config.d/config.toml")
+			runtimeDropInConfigFile := filepath.Join(testRoot, "conf.d/config.toml")
 
 			toolkitRoot := filepath.Join(testRoot, "toolkit-test")
 			toolkitConfigFile := filepath.Join(toolkitRoot, "toolkit/.config/nvidia-container-runtime/config.toml")

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -46,7 +46,7 @@ const (
 	defaultCrioConfigFilePath       = "/etc/crio/crio.conf"
 	defaultDockerConfigFilePath     = "/etc/docker/daemon.json"
 
-	defaultContainerdDropInConfigFilePath = "/etc/containerd/config.d/99-nvidia.toml"
+	defaultContainerdDropInConfigFilePath = "/etc/containerd/conf.d/99-nvidia.toml"
 	defaultCrioDropInConfigFilePath       = "/etc/crio/conf.d/99-nvidia.toml"
 
 	defaultConfigSource = configSourceFile

--- a/cmd/nvidia-ctk/runtime/configure/configure_test.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure_test.go
@@ -78,7 +78,7 @@ version = 2
 			args: []string{
 				"--runtime", "containerd",
 				"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-				"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+				"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 			},
 			assertConditions: func(t *testing.T, testRoot string) error {
 				// Verify main config was created with imports
@@ -91,7 +91,7 @@ version = 2
 				require.Contains(t, string(content), "version = 2")
 
 				// Verify drop-in was created
-				dropIn := filepath.Join(testRoot, "etc/containerd/config.d/99-nvidia.toml")
+				dropIn := filepath.Join(testRoot, "etc/containerd/conf.d/99-nvidia.toml")
 				require.FileExists(t, dropIn)
 
 				dropInContent, err := os.ReadFile(dropIn)
@@ -107,7 +107,7 @@ version = 2
 			args: []string{
 				"--runtime", "containerd",
 				"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-				"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+				"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 				"--nvidia-set-as-default",
 			},
 			prepareEnvironment: func(t *testing.T, testRoot string) error {
@@ -138,7 +138,7 @@ version = 2
 				require.Contains(t, string(content), "imports")
 
 				// Verify drop-in was created with nvidia as default
-				dropIn := filepath.Join(testRoot, "etc/containerd/config.d/99-nvidia.toml")
+				dropIn := filepath.Join(testRoot, "etc/containerd/conf.d/99-nvidia.toml")
 				require.FileExists(t, dropIn)
 
 				dropInContent, err := os.ReadFile(dropIn)
@@ -158,7 +158,7 @@ version = 2
 						args: []string{
 							"--runtime", "containerd",
 							"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-							"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+							"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 						},
 						prepareEnvironment: func(t *testing.T, testRoot string) error {
 							configPath := filepath.Join(testRoot, "etc/containerd/config.toml")
@@ -192,11 +192,11 @@ version = 2
 			args: []string{
 				"--runtime", "containerd",
 				"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-				"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+				"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 				"--cdi.enabled",
 			},
 			assertConditions: func(t *testing.T, testRoot string) error {
-				dropIn := filepath.Join(testRoot, "etc/containerd/config.d/99-nvidia.toml")
+				dropIn := filepath.Join(testRoot, "etc/containerd/conf.d/99-nvidia.toml")
 				content, err := os.ReadFile(dropIn)
 				require.NoError(t, err)
 				require.Contains(t, string(content), "enable_cdi = true")
@@ -208,12 +208,12 @@ version = 2
 			args: []string{
 				"--runtime", "containerd",
 				"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-				"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+				"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 				"--nvidia-runtime-name", "gpu",
 				"--nvidia-runtime-path", "/custom/path/nvidia-container-runtime",
 			},
 			assertConditions: func(t *testing.T, testRoot string) error {
-				dropIn := filepath.Join(testRoot, "etc/containerd/config.d/99-nvidia.toml")
+				dropIn := filepath.Join(testRoot, "etc/containerd/conf.d/99-nvidia.toml")
 				content, err := os.ReadFile(dropIn)
 				require.NoError(t, err)
 				require.Contains(t, string(content), "[plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.gpu]")
@@ -430,14 +430,14 @@ runtime_type = "oci"
 				"--dry-run",
 				"--runtime", "containerd",
 				"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-				"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+				"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 			},
 			assertConditions: func(t *testing.T, testRoot string) error {
 				// Verify no files were created
 				mainConfig := filepath.Join(testRoot, "etc/containerd/config.toml")
 				require.NoFileExists(t, mainConfig)
 
-				dropIn := filepath.Join(testRoot, "etc/containerd/config.d/99-nvidia.toml")
+				dropIn := filepath.Join(testRoot, "etc/containerd/conf.d/99-nvidia.toml")
 				require.NoFileExists(t, dropIn)
 
 				return nil
@@ -542,7 +542,7 @@ func TestConfigureCommandLineSource(t *testing.T) {
 				"--config-source", "command",
 				"--executable-path", "{{ .testRoot }}/bin/containerd",
 				"--config", "{{ .testRoot }}/etc/containerd/config.toml",
-				"--drop-in-config", "{{ .testRoot }}/etc/containerd/config.d/99-nvidia.toml",
+				"--drop-in-config", "{{ .testRoot }}/etc/containerd/conf.d/99-nvidia.toml",
 			},
 			prepareEnvironment: func(t *testing.T, testRoot string) error {
 				// Create a mock containerd executable that outputs config
@@ -581,7 +581,7 @@ fi
 			},
 			assertConditions: func(t *testing.T, testRoot string) error {
 				// Should create drop-in with nvidia runtime
-				dropIn := filepath.Join(testRoot, "etc/containerd/config.d/99-nvidia.toml")
+				dropIn := filepath.Join(testRoot, "etc/containerd/conf.d/99-nvidia.toml")
 				require.FileExists(t, dropIn)
 
 				content, err := os.ReadFile(dropIn)

--- a/pkg/config/engine/containerd/config_drop_in.go
+++ b/pkg/config/engine/containerd/config_drop_in.go
@@ -147,7 +147,7 @@ func (c *topLevelConfig) importPattern(dropInFilename string) string {
 	// TODO: If we make output to STDOUT a property of the config itself, then
 	// we can actually generate the correct import statement.
 	if dropInFilename == engine.SaveToSTDOUT {
-		return "/etc/containerd/config.d/*.toml"
+		return "/etc/containerd/conf.d/*.toml"
 	}
 	return c.asHostPath(filepath.Dir(dropInFilename)) + "/*.toml"
 }


### PR DESCRIPTION
This changes the default drop-in config file path for containerd from: /etc/containerd/config.d/99-nvidia.toml
to:   /etc/containerd/conf.d/99-nvidia.toml

The default containerd drop-in config path for containerd does not align with the upstream value. (Which was added after these changes were made to the toolkit).

Fixes #1404