### PR TITLE
Fix generate tests when cdi hook exists in path

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate_test.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate_test.go
@@ -450,6 +450,9 @@ containerEdits:
 	}
 
 	for _, tc := range testCases {
+		// Apply overrides for all test cases:
+		tc.options.nvidiaCDIHookPath = "/usr/bin/nvidia-cdi-hook"
+
 		t.Run(tc.description, func(t *testing.T) {
 			c := command{
 				logger: logger,


### PR DESCRIPTION
The TestGenerateSpec unit tests resolve the path to the nvidia-cdi-hook binary if it exists on the system making the results dependent on system configuration.

This change sets the path to the binary explicitly to skip the resolution in the path.

Fixes #1388 