### PR TITLE
Update rpm package to have 256bit digests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 /shared-*
+release-v*/**

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -53,6 +53,35 @@ ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
 RUN make PREFIX=/artifacts/bin cmd-nvidia-ctk-installer
 
+# The rpmdigests stage updates the existing rpm packages to have 256bit digests.
+# This is done using fpm.
+FROM nvcr.io/nvidia/cuda:13.0.1-base-ubi9 AS rpmdigests
+
+RUN dnf install -y \
+    rubygems \
+    ruby-devel \
+    yum-utils \
+    rpm-build \
+    && gem install --no-document fpm
+
+ARG ARTIFACTS_ROOT
+COPY ${ARTIFACTS_ROOT}/centos7 /artifacts/packages/centos7-src
+
+WORKDIR /artifacts/packages/centos7
+
+# For each architecture from the source we find all packages and update the
+# digests.
+RUN for arch in $(ls /artifacts/packages/centos7-src/); do \
+        mkdir -p /artifacts/packages/centos7/${arch}; \
+        cd /artifacts/packages/centos7/${arch}; \
+        # For each package in the source folder we recreate a package to update
+        # the digests to 256-bit since we're running in a ubi9 container.
+        for src_package in $(ls /artifacts/packages/centos7-src/${arch}/*.rpm); do \
+            fpm -s rpm -t rpm ${src_package}; \
+        done; \
+    done; \
+    rm -rf /artifacts/packages/centos7-src
+
 # The packaging stage collects the deb and rpm packages built for
 # supported architectures.
 FROM nvcr.io/nvidia/distroless/go:v3.2.0-dev AS packaging
@@ -62,9 +91,8 @@ SHELL ["/busybox/sh", "-c"]
 RUN ln -s /busybox/sh /bin/sh
 
 ARG ARTIFACTS_ROOT
-COPY ${ARTIFACTS_ROOT} /artifacts/packages/
-
-WORKDIR /artifacts
+COPY ${ARTIFACTS_ROOT}/ubuntu18.04 /artifacts/packages/ubuntu18.04
+COPY --from=rpmdigests /artifacts/packages/centos7 /artifacts/packages/centos7
 
 # build-args are added to the manifest.txt file below.
 ARG PACKAGE_VERSION


### PR DESCRIPTION
This change uses fpm to update the built rpm packages to have
256bit digests without changing their contents.

This is required in cases where `SHA1` or `MD5` digests are not supported such as FIPS or newer RPM-based distributions. (See #1307).

For the v1.18.0 packages:
```
$ docker run --rm -ti -v $(pwd)/release-v1.18.0-stable:/work -w /work rockylinux:9 bash -c "find . -name '*.rpm' -exec rpm --checksig --verbose {} \;"
./packages/centos7/aarch64/libnvidia-container-static-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/libnvidia-container-tools-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/libnvidia-container1-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/libnvidia-container-libseccomp2-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/nvidia-container-toolkit-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/libnvidia-container1-debuginfo-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/nvidia-container-toolkit-base-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/nvidia-container-toolkit-operator-extensions-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/aarch64/libnvidia-container-devel-1.18.0-1.aarch64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container1-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-libseccomp2-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/nvidia-container-toolkit-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container1-debuginfo-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/nvidia-container-toolkit-base-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-tools-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/nvidia-container-toolkit-operator-extensions-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-devel-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-static-1.18.0-1.x86_64.rpm:
    Header SHA1 digest: OK
    MD5 digest: OK
```

With these changes:
```
$  docker run --rm -ti -v $(pwd)/release-v1.19.0-dev-stable:/work -w /work rockylinux:9 bash -c "find . -name '*.rpm' -exec rpm --checksig --verbose {} \;"
./packages/centos7/x86_64/libnvidia-container-static-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-libseccomp2-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container1-debuginfo-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/nvidia-container-toolkit-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/nvidia-container-toolkit-operator-extensions-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-devel-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/nvidia-container-toolkit-base-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container-tools-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
./packages/centos7/x86_64/libnvidia-container1-1.19.0~dev-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
```