### PR TITLE
[no-relnote] Bump total operations allowed for stale GH action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,6 +1,7 @@
 name: Stale issues and pull requests
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: "21 4 * * *"
 
@@ -26,4 +27,4 @@ jobs:
         days-before-issue-close: 30
         days-before-pr-close: 30
         remove-stale-when-updated: true
-        operations-per-run: 300
+        operations-per-run: 1000


### PR DESCRIPTION
As currently configured, the stale GitHub action is not able to process all of our open issues / PRs. This commit bumps the total GitHub API calls the GitHub action can take so that it can process more issues per run. This commit also allows one to manually invoke the stale GitHub workflow.