### PR TITLE
Fix ldcache update when host and container distributions do not match

### DIFF
--- a/tests/e2e/nvidia-container-toolkit_test.go
+++ b/tests/e2e/nvidia-container-toolkit_test.go
@@ -570,4 +570,23 @@ EOF`)
 			Expect(output).To(Equal(expectedOutput))
 		})
 	})
+
+	When("running a ubi9 container", Ordered, func() {
+		var (
+			expectedOutput string
+		)
+		BeforeAll(func(ctx context.Context) {
+			_, _, err := runner.Run(`docker pull redhat/ubi9`)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedOutput, _, err = runner.Run(`docker run --rm --runtime=runc redhat/ubi9 bash -c "ldconfig -p | grep libc.so."`)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should include the system libraries when using the nvidia-container-runtime", func(ctx context.Context) {
+			output, _, err := runner.Run(`docker run --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all redhat/ubi9 bash -c "ldconfig -p | grep libc.so."`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output).To(Equal(expectedOutput))
+		})
+	})
 })


### PR DESCRIPTION
This change fixes the update of the ldcache when running a non-Debian-like (e.g. RHEL, Fedora) container on a Debian-like (e.g. Debian, Ubuntua) system. Here the ldcache in the container does not initially include system libraries from `/lib64` or `/usr/lib64` since this `ldconfig` from the host that is executed in the container's namespace does not process those paths by default.

## Testing

The expected behaviour when using `runc` directly:
```
$ docker run --rm --runtime=runc redhat/ubi9 bash -c "ldconfig -p | grep libc.so."
        libc.so.6 (libc6,AArch64, OS ABI: Linux 3.7.0) => /lib64/libc.so.6
```

The current behaviour:
```
$ docker run --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all redhat/ubi9 bash -c "ldconfig -p | grep libc.so."
```
(note that `libc.so.6` is not present in the ldcache since `/lib64` (linked to `/usr/lib64`) is not processed).

The updated behaviour:
```
$ docker run --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all redhat/ubi9 bash -c "ldconfig -p | grep libc.so."
        libc.so.6 (libc6,AArch64, OS ABI: Linux 3.7.0) => /lib64/libc.so.6
```