### PR TITLE
Also consider libnvidia-ml.so for extracting driver version

### DIFF
--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -120,7 +120,7 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver version: %w", err)
 	}
-	cudaLibRoot, err := driver.GetLibcudaParentDir()
+	cudaLibRoot, err := driver.GetDriverLibDirectory()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get libcuda.so parent directory: %w", err)
 	}

--- a/internal/lookup/root/cuda_test.go
+++ b/internal/lookup/root/cuda_test.go
@@ -47,7 +47,13 @@ func TestLocate(t *testing.T) {
 		{
 			description:   "no-ldcache searches /usr/lib64",
 			libcudaPath:   "/usr/lib64/libcuda.so.123.34",
-			expected:      "/usr/lib64/libcuda.so.123.34",
+			expected:      "/usr/lib64",
+			expectedError: nil,
+		},
+		{
+			description:   "no-ldcache searches /usr/lib64 for libnvidia-ml.so.",
+			libcudaPath:   "/usr/lib64/libnvidia-ml.so.123.34",
+			expected:      "/usr/lib64",
 			expectedError: nil,
 		},
 	}
@@ -62,11 +68,11 @@ func TestLocate(t *testing.T) {
 				WithDriverRoot(driverRoot),
 			)
 
-			libcudasoPath, err := l.GetLibcudasoPath()
+			driverLibraryPath, err := l.GetDriverLibDirectory()
 			require.ErrorIs(t, err, tc.expectedError)
 
 			// NOTE: We need to strip `/private` on MacOs due to symlink resolution
-			stripped := strings.TrimPrefix(libcudasoPath, "/private")
+			stripped := strings.TrimPrefix(driverLibraryPath, "/private")
 
 			require.Equal(t, tc.expected, stripped)
 		})

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -42,7 +42,7 @@ func (l *nvcdilib) newDriverVersionDiscoverer() (discover.Discover, error) {
 		return nil, fmt.Errorf("failed to determine driver version (%q): %w", version, err)
 	}
 
-	libcudasoParentDirPath, err := l.driver.GetLibcudaParentDir()
+	libcudasoParentDirPath, err := l.driver.GetDriverLibDirectory()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get libcuda.so parent path: %w", err)
 	}
@@ -110,13 +110,13 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
 	disableDeviceNodeModification := l.hookCreator.Create(DisableDeviceNodeModificationHook)
 	discoverers = append(discoverers, disableDeviceNodeModification)
 
-	libCudaSoParentDirectoryPath, err := l.driver.GetLibcudaParentDir()
+	driverLibDirectory, err := l.driver.GetDriverLibDirectory()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get libcuda.so parent directory path: %w", err)
 	}
 	environmentVariable := &discover.EnvVar{
 		Name:  "NVIDIA_CTK_LIBCUDA_DIR",
-		Value: libCudaSoParentDirectoryPath,
+		Value: driverLibDirectory,
 	}
 	discoverers = append(discoverers, environmentVariable)
 


### PR DESCRIPTION
On some systems, it MAY be that `libcuda.so` is not available to determine the RM version from the file suffix. (See for example https://github.com/containers/toolbox/issues/1694 where ONLY display functionality is required, for example).

This change also considers the `libnvidia-ml.so.RM_VERSION` suffix when inferring the RM version when generating CDI specs. Since `libnvidia-ml.so` is a requirement for enumerating devices, it is expected to be present on the system.