### PR TITLE
ldconfig: Determine container "debian-ness" after root pivot

### DIFF
--- a/internal/ldconfig/ldconfig.go
+++ b/internal/ldconfig/ldconfig.go
@@ -98,11 +98,10 @@ func NewFromArgs(args ...string) (*Ldconfig, error) {
 	}
 
 	l := &Ldconfig{
-		ldconfigPath:          *ldconfigPath,
-		inRoot:                *containerRoot,
-		isDebianLikeHost:      *isDebianLikeHost,
-		isDebianLikeContainer: isDebian(),
-		directories:           fs.Args(),
+		ldconfigPath:     *ldconfigPath,
+		inRoot:           *containerRoot,
+		isDebianLikeHost: *isDebianLikeHost,
+		directories:      fs.Args(),
 	}
 	return l, nil
 }
@@ -112,6 +111,9 @@ func (l *Ldconfig) UpdateLDCache() error {
 	if err != nil {
 		return err
 	}
+
+	// `prepareRoot` pivots to the container root, so can now set the container "debian-ness".
+	l.isDebianLikeContainer = isDebian()
 
 	// Explicitly specify using /etc/ld.so.conf since the host's ldconfig may
 	// be configured to use a different config file by default.


### PR DESCRIPTION
@elezar @cdesiniotis

Might impact https://github.com/NVIDIA/nvidia-container-toolkit/pull/1444