### PR TITLE
Write system paths to lexicographically last ld.so.conf.d drop-in

### DIFF
--- a/internal/ldconfig/ldconfig_test.go
+++ b/internal/ldconfig/ldconfig_test.go
@@ -118,7 +118,7 @@ include INCLUDED_PATTERN*
 			l := &Ldconfig{
 				isDebianLikeContainer: true,
 			}
-			filtered, _, err := l.filterDirectories(topLevelConfPath, tc.input...)
+			filtered, err := l.filterDirectories(topLevelConfPath, tc.input...)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, filtered)


### PR DESCRIPTION
This is a followup patch that builds on #1444. It covers more cases by having a slightly wider set of system paths.

@elezar @cdesiniotis 