### PR TITLE
Use enable-cuda-compat hook when ldcache does not exist

### DIFF
--- a/cmd/nvidia-cdi-hook/cudacompat/cudacompat.go
+++ b/cmd/nvidia-cdi-hook/cudacompat/cudacompat.go
@@ -128,10 +128,6 @@ func (m command) getContainerForwardCompatDir(containerRoot containerRoot, hostD
 		m.logger.Debugf("No CUDA forward compatibility libraries directory in container")
 		return "", nil
 	}
-	if !containerRoot.hasPath("/etc/ld.so.cache") {
-		m.logger.Debugf("The container does not have an LDCache")
-		return "", nil
-	}
 
 	libs, err := containerRoot.globFiles(filepath.Join(cudaCompatPath, "libcuda.so.*.*"))
 	if err != nil {

--- a/cmd/nvidia-cdi-hook/cudacompat/cudacompat_test.go
+++ b/cmd/nvidia-cdi-hook/cudacompat/cudacompat_test.go
@@ -44,7 +44,8 @@ func TestCompatLibs(t *testing.T) {
 			contents: map[string]string{
 				"/usr/local/cuda/compat/libcuda.so.333.88.99": "",
 			},
-			hostDriverVersion: "222.55.66",
+			hostDriverVersion:                 "222.55.66",
+			expectedContainerForwardCompatDir: "/usr/local/cuda/compat",
 		},
 		{
 			description: "compat lib is newer; ldcache",


### PR DESCRIPTION
This change ensures that the cuda compat drop-in file is created in a container even if the ld.cache does not exist.

This allows for the creation of the ldcache in the subsequent invocation of the update-ldcache hook in container images where the cache does not pre-exist. Examples of such images are distroless images.

This was missed in #1326 