### PR TITLE
[no-relnote] Ensure that fpm generates sha256 digests

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -77,7 +77,7 @@ RUN for arch in $(ls /artifacts/packages/centos7-src/); do \
         # For each package in the source folder we recreate a package to update
         # the digests to 256-bit since we're running in a ubi9 container.
         for src_package in $(ls /artifacts/packages/centos7-src/${arch}/*.rpm); do \
-            fpm -s rpm -t rpm ${src_package}; \
+            fpm -s rpm -t rpm --rpm-digest=sha256 ${src_package}; \
         done; \
     done; \
     rm -rf /artifacts/packages/centos7-src


### PR DESCRIPTION
Improves #1411

I have verified the following on a FIPS-enabled host:

1. The packages install in a `uibi9` container (after veryfying that the previous packages do not install).
2. The packages still install in a `centos7` container that does not support `sha256` digests by default.