### PR TITLE
Add --device-id flag to nvidia-ctk cdi generate command

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -74,6 +74,7 @@ type options struct {
 	}
 
 	noAllDevice bool
+	deviceIDs   []string
 
 	// the following are used for dependency injection during spec generation.
 	nvmllib nvml.Interface
@@ -240,6 +241,14 @@ func (m command) build() *cli.Command {
 				Destination: &opts.noAllDevice,
 				Sources:     cli.EnvVars("NVIDIA_CTK_CDI_GENERATE_NO_ALL_DEVICE"),
 			},
+			&cli.StringSliceFlag{
+				Name:        "device-id",
+				Aliases:     []string{"device-ids", "device", "devices"},
+				Usage:       "Restrict generation to the specified device identifiers",
+				Value:       []string{"all"},
+				Destination: &opts.deviceIDs,
+				Sources:     cli.EnvVars("NVIDIA_CTK_CDI_GENERATE_DEVICE_IDS"),
+			},
 		},
 	}
 
@@ -381,7 +390,7 @@ func (m command) generateSpecs(opts *options) ([]generatedSpecs, error) {
 		return nil, fmt.Errorf("failed to create CDI library: %v", err)
 	}
 
-	allDeviceSpecs, err := cdilib.GetDeviceSpecsByID("all")
+	allDeviceSpecs, err := cdilib.GetDeviceSpecsByID(opts.deviceIDs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device CDI specs: %v", err)
 	}


### PR DESCRIPTION
This change allows device IDs to be specified when generating CDI specs using
the nvidia-ctk cdi generate CDI. The command now accepts a (repeatable) CLI
flag allowing device IDs to be specified. These can be indices or uuids.