### PR TITLE
Add no-runtime-configure option to the toolkit installer

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/runtime.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/runtime.go
@@ -228,9 +228,13 @@ type Configurer interface {
 }
 
 type runtime string
+type noopRuntimeConfigurer struct{}
 
 // NewConfigurer is a factory method for creating a runtime configurer.
-func NewConfigurer(name string) Configurer {
+func NewConfigurer(name string, noConfigureRuntime bool, nriEnabled bool) Configurer {
+	if noConfigureRuntime || nriEnabled {
+		return &noopRuntimeConfigurer{}
+	}
 	return runtime(name)
 }
 
@@ -271,4 +275,16 @@ func (r runtime) GetLowlevelRuntimePaths(opts *Options) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("undefined runtime %v", r)
 	}
+}
+
+func (r noopRuntimeConfigurer) Cleanup(_ *cli.Command, _ *Options) error {
+	return nil
+}
+
+func (r noopRuntimeConfigurer) GetLowlevelRuntimePaths(_ *Options) ([]string, error) {
+	return nil, nil
+}
+
+func (r noopRuntimeConfigurer) Setup(_ *cli.Command, _ *Options) error {
+	return nil
 }


### PR DESCRIPTION
This change adds a `no-runtime-configure` option to the toolkit installer to enable use cases where the NVIDIA Container Toolkit is required without configuring the underlying runtime.

Fixes #1513