### PR TITLE
trim extraneous whitespaces when parsing comma-separated config sources

### DIFF
--- a/cmd/nvidia-ctk-installer/container/container.go
+++ b/cmd/nvidia-ctk-installer/container/container.go
@@ -199,12 +199,12 @@ func (o Options) GetConfigLoaders(commandSourceFunc func(string, string) toml.Lo
 	var loaders []toml.Loader
 	for _, configSource := range o.ConfigSources {
 		parts := strings.SplitN(configSource, "=", 2)
-		source := parts[0]
+		source := strings.TrimSpace(parts[0])
 		switch source {
 		case "file":
 			fileSourcePath := o.TopLevelConfigPath
 			if len(parts) > 1 {
-				fileSourcePath = parts[1]
+				fileSourcePath = strings.TrimSpace(parts[1])
 			}
 			loaders = append(loaders, toml.FromFile(fileSourcePath))
 		case "command":


### PR DESCRIPTION
This change makes the input parsing of the `RUNTIME_CONFIG_SOURCES` a bit more forgiving. It is not impossible that users may specify a space when specifying comma separated list of container runtime config sources