### PR TITLE
fix: Ensure consistent device permissions for CDI devices

### DIFF
--- a/internal/edits/device.go
+++ b/internal/edits/device.go
@@ -72,10 +72,11 @@ func (d device) fromPathOrDefault() *specs.DeviceNode {
 	}
 
 	return &specs.DeviceNode{
-		HostPath: d.HostPath,
-		Path:     d.Path,
-		Major:    dn.Major,
-		Minor:    dn.Minor,
-		FileMode: &dn.FileMode,
+		HostPath:    d.HostPath,
+		Path:        d.Path,
+		Major:       dn.Major,
+		Minor:       dn.Minor,
+		FileMode:    &dn.FileMode,
+		Permissions: string(dn.Permissions),
 	}
 }


### PR DESCRIPTION
It turns out permissions are hardcoded to "rwm" so they are synced (because not specifying anything ends up as setting rwm in the generated oci spec) but if someone ever changes rwm to sth else in the call to DeviceFromPath, it won't be effective 