### PR TITLE
feat: add sth close to the no-cgroups legacy feature in CDI mode [WIP/Draft]

### DIFF
--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -27,6 +27,8 @@ type RuntimeConfig struct {
 	Runtimes []string    `toml:"runtimes"`
 	Mode     string      `toml:"mode"`
 	Modes    modesConfig `toml:"modes"`
+	// Close to the "no-cgroups" bool when using the legacy mode with the hooks.
+	MknodOnly bool `toml:"mknod-only"`
 }
 
 // modesConfig defines (optional) per-mode configs

--- a/internal/modifier/cdi.go
+++ b/internal/modifier/cdi.go
@@ -74,6 +74,7 @@ func NewCDIModifier(logger logger.Interface, cfg *config.Config, image image.CUD
 		cdi.WithLogger(logger),
 		cdi.WithDevices(devices...),
 		cdi.WithSpecDirs(cfg.NVIDIAContainerRuntimeConfig.Modes.CDI.SpecDirs...),
+		cdi.WithMknodOnly(cfg.NVIDIAContainerRuntimeConfig.MknodOnly),
 	)
 }
 
@@ -197,6 +198,7 @@ func newAutomaticCDISpecModifier(logger logger.Interface, cfg *config.Config, de
 		cdiDeviceRequestor, err := cdi.New(
 			cdi.WithLogger(logger),
 			cdi.WithSpec(spec.Raw()),
+			cdi.WithMknodOnly(cfg.NVIDIAContainerRuntimeConfig.MknodOnly),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct CDI modifier for mode %q: %w", mode, err)

--- a/internal/modifier/cdi/builder.go
+++ b/internal/modifier/cdi/builder.go
@@ -27,10 +27,11 @@ import (
 )
 
 type builder struct {
-	logger   logger.Interface
-	specDirs []string
-	devices  []string
-	cdiSpec  *specs.Spec
+	logger    logger.Interface
+	specDirs  []string
+	devices   []string
+	cdiSpec   *specs.Spec
+	mknodOnly bool
 }
 
 // Option represents a functional option for creating a CDI mofifier.
@@ -56,7 +57,8 @@ func (m builder) build() (oci.SpecModifier, error) {
 
 	if m.cdiSpec != nil {
 		modifier := fromCDISpec{
-			cdiSpec: &cdi.Spec{Spec: m.cdiSpec},
+			cdiSpec:   &cdi.Spec{Spec: m.cdiSpec},
+			mknodOnly: m.mknodOnly,
 		}
 		return modifier, nil
 	}
@@ -69,6 +71,7 @@ func (m builder) build() (oci.SpecModifier, error) {
 		return nil, fmt.Errorf("failed to create CDI registry: %v", err)
 	}
 
+	// FIXME: cannot edit, vendor lib, mknodOnly has no effect in this case
 	modifier := fromRegistry{
 		logger:   m.logger,
 		registry: registry,
@@ -103,5 +106,12 @@ func WithDevices(devices ...string) Option {
 func WithSpec(spec *specs.Spec) Option {
 	return func(b *builder) {
 		b.cdiSpec = spec
+	}
+}
+
+// WithSpec sets the mknodOnly for the CDI modifier builder.
+func WithMknodOnly(mknodOnly bool) Option {
+	return func(b *builder) {
+		b.mknodOnly = mknodOnly
 	}
 }

--- a/internal/modifier/csv.go
+++ b/internal/modifier/csv.go
@@ -72,6 +72,7 @@ func NewCSVModifier(logger logger.Interface, cfg *config.Config, container image
 	return cdi.New(
 		cdi.WithLogger(logger),
 		cdi.WithSpec(spec.Raw()),
+		cdi.WithMknodOnly(cfg.NVIDIAContainerRuntimeConfig.MknodOnly),
 	)
 }
 


### PR DESCRIPTION
Related: https://github.com/NVIDIA/nvidia-container-toolkit/issues/1542

Use case: same as the no-cgroups flags in legacy mode (= with the hook) -> create dev nodes, setup environment, mount shared libraries but do not give access to devices yet