### PR TITLE
Add debug-level log option for ctk-installer

### DIFF
--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -33,10 +33,11 @@ const (
 	defaultNRIPluginIdx uint = 10
 )
 
-var defaultLowLevelRuntimes = []string{"runc", "crun"}
-
-var waitingForSignal = make(chan bool, 1)
-var signalReceived = make(chan bool, 1)
+var (
+	defaultLowLevelRuntimes = []string{"runc", "crun"}
+	waitingForSignal        = make(chan bool, 1)
+	signalReceived          = make(chan bool, 1)
+)
 
 // options stores the command line arguments
 type options struct {


### PR DESCRIPTION
Enable debug-level log for nvidia-ctk-installer cmd by `--debug` or `-d`.