### PR TITLE
improve ssh key handling in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -93,7 +93,8 @@ jobs:
           E2E_SSH_HOST: ${{ steps.holodeck_public_dns_name.outputs.result }}
         run: |
           e2e_ssh_key=$(mktemp)
-          echo "${{ secrets.AWS_SSH_KEY }}" > "$e2e_ssh_key"
+          trap 'rm -f "$e2e_ssh_key"' EXIT
+          printf '%s' "${{ secrets.AWS_SSH_KEY }}" > "$e2e_ssh_key"
           chmod 600 "$e2e_ssh_key"
           export E2E_SSH_KEY="$e2e_ssh_key"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,7 +87,8 @@ jobs:
           E2E_SSH_HOST: ${{ steps.holodeck_public_dns_name.outputs.result }}
         run: |
           e2e_ssh_key=$(mktemp)
-          echo "${{ secrets.AWS_SSH_KEY }}" > "$e2e_ssh_key"
+          trap 'rm -f "$e2e_ssh_key"' EXIT
+          printf '%s' "${{ secrets.AWS_SSH_KEY }}" > "$e2e_ssh_key"
           chmod 600 "$e2e_ssh_key"
           export E2E_SSH_KEY="$e2e_ssh_key"
 


### PR DESCRIPTION
## Summary
- Use `trap` to ensure temp SSH key file is cleaned up on exit
- Use `printf '%s'` instead of `echo` for safer secret handling (avoids escape character interpretation)

## Test plan
- [ ] Verify e2e workflow runs successfully
- [ ] Confirm temp key file is removed after test completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)