### PR TITLE
Ensure that the CSV files define the required devices when only a iGPU is present

### DIFF
--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -72,7 +72,12 @@ func (l *csvlib) usePureCSVDeviceSpecGenerator() bool {
 	}
 	defer asNvmlLib.tryShutdown()
 
-	return false
+	numDevices, ret := l.nvmllib.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return true
+	}
+
+	return numDevices <= 1
 }
 
 func (l *csvlib) purecsvDeviceSpecGenerators(ids ...string) (DeviceSpecGenerator, error) {


### PR DESCRIPTION
In oder to allow the dGPU to be *filtered*, one needs to ensure that the `/dev/nvidia1` device node is NOT injected into a container when only the iGPU is requested. This was added in #1461.

The change in this PR update that implementation to:
1. Fix a bug in the fallback CSV spec generator where the `/dev/nvidia1` device node was always being filtered out.
2. Update the logic to use the fallback CSV spec generator when only a single NVML device is present.

Note this does call out the fact that some applications that expect a filtered device node may not work as expected in containers when both iGPUs and dGPUs are present.