### PR TITLE
Fix backport of #1569

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -282,11 +281,6 @@ func (m command) validateFlags(c *cli.Command, opts *options) error {
 		if hook == "all" {
 			return fmt.Errorf("enabling all hooks is not supported")
 		}
-	}
-
-	if slices.Contains(opts.deviceIDs, "none") && !opts.noAllDevice {
-		m.logger.Warning("Disabling generation of 'all' device")
-		opts.noAllDevice = true
 	}
 	return nil
 }

--- a/pkg/nvcdi/lib-nvml.go
+++ b/pkg/nvcdi/lib-nvml.go
@@ -67,7 +67,7 @@ func (l *nvmllib) getDeviceSpecGeneratorsForIDs(ids ...string) (DeviceSpecGenera
 	var identifiers []device.Identifier
 	for _, id := range ids {
 		if id == "none" {
-			return emptyDeviceSpecGenerator("none"), nil
+			return DeviceSpecGenerators{}, nil
 		}
 		if id == "all" {
 			return l.getDeviceSpecGeneratorsForAllDevices()
@@ -259,18 +259,4 @@ func (d *deviceSpecGeneratorsWithAndShutdown) GetDeviceSpecs() ([]specs.Device, 
 	defer d.tryShutdown()
 
 	return d.DeviceSpecGenerator.GetDeviceSpecs()
-}
-
-type emptyDeviceSpecGenerator string
-
-func (d emptyDeviceSpecGenerator) GetDeviceSpecs() ([]specs.Device, error) {
-	// Since the CDI specification does not allow devices to have no edits, we
-	// add a dummy envvar to the container edits for an "empty" device.
-	noneDevice := specs.Device{
-		Name: string(d),
-		ContainerEdits: specs.ContainerEdits{
-			Env: []string{"NVCT_EMPTY_DEVICE="},
-		},
-	}
-	return []specs.Device{noneDevice}, nil
 }


### PR DESCRIPTION
This removes the handling of the `nvidia.com/gpu=none` device backported in #1569