### PR TITLE
internal/discover: use explicit driver version for matching libraries

### DIFF
--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -111,17 +111,22 @@ func newVulkanConfigsDiscover(logger logger.Interface, driver *root.Driver) Disc
 
 type graphicsDriverLibraries struct {
 	Discover
-	logger      logger.Interface
-	hookCreator HookCreator
+	logger        logger.Interface
+	hookCreator   HookCreator
+	// driverVersionSuffix is the version of the driver that is being used
+	// prefixed with a '.'
+	driverVersionSuffix string
 }
 
 var _ Discover = (*graphicsDriverLibraries)(nil)
 
 func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver, hookCreator HookCreator) (Discover, error) {
-	cudaVersionPattern, err := driver.Version()
+	driverVersion, err := driver.Version()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver version: %w", err)
 	}
+	// We use the driver version as a pattern for matching libraries.
+	// This pattern is used to identify libraries that are part of the driver.
 	cudaLibRoots, err := driver.GetDriverLibDirectories()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get libcuda.so parent directory: %w", err)
@@ -143,8 +148,8 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 			// * libnvidia-allocator.so.RM_VERSION
 			// * libnvidia-vulkan-producer.so.RM_VERSION
 			// but need to be handled for the legacy case too.
-			"libnvidia-allocator.so." + cudaVersionPattern,
-			"libnvidia-vulkan-producer.so." + cudaVersionPattern,
+			"libnvidia-allocator.so." + driverVersion,
+			"libnvidia-vulkan-producer.so." + driverVersion,
 		},
 	)
 
@@ -159,14 +164,15 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 		driver.Root,
 		[]string{
 			"nvidia_drv.so",
-			"libglxserver_nvidia.so." + cudaVersionPattern,
+			"libglxserver_nvidia.so." + driverVersion,
 		},
 	)
 
 	return &graphicsDriverLibraries{
-		Discover:    Merge(libraries, xorgLibraries),
-		logger:      logger,
-		hookCreator: hookCreator,
+		Discover:            Merge(libraries, xorgLibraries),
+		logger:              logger,
+		hookCreator:         hookCreator,
+		driverVersionSuffix: "." + driverVersion,
 	}, nil
 }
 
@@ -234,8 +240,7 @@ func (d graphicsDriverLibraries) Hooks() ([]Hook, error) {
 
 // isDriverLibrary checks whether the specified filename is a specific driver library.
 func (d graphicsDriverLibraries) isDriverLibrary(filename string, libraryName string) bool {
-	// TODO: Instead of `.*.*` we could use the driver version.
-	pattern := strings.TrimSuffix(libraryName, ".") + ".*.*"
+	pattern := libraryName + d.driverVersionSuffix
 	match, _ := filepath.Match(pattern, filename)
 	return match
 }


### PR DESCRIPTION
Previous Behavior
The discovery logic used a generic *.* wildcard pattern to identify driver libraries. This was less precise and could potentially match unrelated files or incorrect versions.
```
pattern := strings.TrimSuffix(libraryName, ".") + ".*.*"
```
Current Behavior
The update modifies  graphicsDriverLibraries to explicitly use the detected driver version when constructing the match pattern. This ensures that only libraries matching the active driver version are processed, preventing false positives and ensuring consistency.

```
pattern := strings.TrimSuffix(libraryName, ".") + "." + d.driverVersion
```