### PR TITLE
fix: Allow nvidia-cdi-refresh.service to be restarted

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -17,6 +17,9 @@ Description=Refresh NVIDIA CDI specification file
 ConditionPathExists=|/usr/bin/nvidia-smi
 ConditionPathExists=|/usr/sbin/nvidia-smi
 ConditionPathExists=/usr/bin/nvidia-ctk
+# Limit the number of successive restarts to 5 in 10 seconds.
+StartLimitBurst=5
+StartLimitIntervalSec=10s
 
 [Service]
 Type=oneshot
@@ -26,6 +29,10 @@ EnvironmentFile=-/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
 ExecCondition=/usr/bin/grep -qE '/(nvidia|nvidia-current)\\.ko' /lib/modules/%v/modules.dep
 ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
+# We set the service to restart on failure to ensure that a CDI spec is
+# eventually generated.
+Restart=on-failure
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change adds Restart=on-failure to the nvidia-cdi-refresh.service. This should allow the service to deal with cases where the driver is not ready at the point where it is started.