### PR TITLE
Simplify logger.Interface

### DIFF
--- a/cmd/nvidia-ctk-installer/toolkit/toolkit.go
+++ b/cmd/nvidia-ctk-installer/toolkit/toolkit.go
@@ -255,7 +255,7 @@ func (t *Installer) ValidateOptions(opts *Options) error {
 	opts.CDI.class = class
 
 	if opts.CDI.Enabled && opts.CDI.outputDir == "" {
-		t.logger.Warning("Skipping CDI spec generation (no output directory specified)")
+		t.logger.Warningf("Skipping CDI spec generation (no output directory specified)")
 		opts.CDI.Enabled = false
 	}
 
@@ -270,7 +270,7 @@ func (t *Installer) ValidateOptions(opts *Options) error {
 		}
 	}
 	if !opts.CDI.Enabled && !isDisabled {
-		t.logger.Info("disabling device node creation since --cdi-enabled=false")
+		t.logger.Infof("disabling device node creation since --cdi-enabled=false")
 		isDisabled = true
 	}
 	if isDisabled {
@@ -510,7 +510,7 @@ func (t *Installer) generateCDISpec(opts *Options, nvidiaCDIHookPath string) err
 	if !opts.CDI.Enabled {
 		return nil
 	}
-	t.logger.Info("Generating CDI spec for management containers")
+	t.logger.Infof("Generating CDI spec for management containers")
 	cdilib, err := nvcdi.New(
 		nvcdi.WithLogger(t.logger),
 		nvcdi.WithMode(nvcdi.ModeManagement),

--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -302,7 +302,7 @@ func (m command) validateFlags(c *cli.Command, opts *options) error {
 	}
 
 	if slices.Contains(opts.deviceIDs, "none") && !opts.noAllDevice {
-		m.logger.Warning("Disabling generation of 'all' device")
+		m.logger.Warningf("Disabling generation of 'all' device")
 		opts.noAllDevice = true
 	}
 	return nil

--- a/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
+++ b/cmd/nvidia-ctk/system/create-dev-char-symlinks/create-dev-char-symlinks.go
@@ -116,12 +116,12 @@ func (m command) build() *cli.Command {
 
 func (m command) validateFlags(cfg *config) error {
 	if cfg.loadKernelModules && !cfg.createAll {
-		m.logger.Warning("load-kernel-modules is only applicable when create-all is set; ignoring")
+		m.logger.Warningf("load-kernel-modules is only applicable when create-all is set; ignoring")
 		cfg.loadKernelModules = false
 	}
 
 	if cfg.createDeviceNodes && !cfg.createAll {
-		m.logger.Warning("create-device-nodes is only applicable when create-all is set; ignoring")
+		m.logger.Warningf("create-device-nodes is only applicable when create-all is set; ignoring")
 		cfg.createDeviceNodes = false
 	}
 

--- a/internal/edits/edits.go
+++ b/internal/edits/edits.go
@@ -108,7 +108,7 @@ func (e *edits) Modify(spec *ociSpecs.Spec) error {
 		return nil
 	}
 
-	e.logger.Info("Mounts:")
+	e.logger.Infof("Mounts:")
 	for _, mount := range e.Mounts {
 		e.logger.Infof("Mounting %v at %v", mount.HostPath, mount.ContainerPath)
 	}

--- a/internal/logger/api.go
+++ b/internal/logger/api.go
@@ -20,9 +20,7 @@ package logger
 type Interface interface {
 	Debugf(string, ...interface{})
 	Errorf(string, ...interface{})
-	Info(...interface{})
 	Infof(string, ...interface{})
-	Warning(...interface{})
 	Warningf(string, ...interface{})
 	Tracef(string, ...interface{})
 }

--- a/internal/logger/lib.go
+++ b/internal/logger/lib.go
@@ -34,14 +34,8 @@ func (l *NullLogger) Debugf(string, ...interface{}) {}
 // Errorf is a no-op for the null logger
 func (l *NullLogger) Errorf(string, ...interface{}) {}
 
-// Info is a no-op for the null logger
-func (l *NullLogger) Info(...interface{}) {}
-
 // Infof is a no-op for the null logger
 func (l *NullLogger) Infof(string, ...interface{}) {}
-
-// Warning is a no-op for the null logger
-func (l *NullLogger) Warning(...interface{}) {}
 
 // Warningf is a no-op for the null logger
 func (l *NullLogger) Warningf(string, ...interface{}) {}

--- a/internal/runtime/logger.go
+++ b/internal/runtime/logger.go
@@ -53,7 +53,7 @@ func (l *Logger) Update(filename string, logLevel string, argv []string) {
 	level, logLevelError := configFromArgs.getLevel(logLevel)
 	defer func() {
 		if logLevelError != nil {
-			l.Warning(logLevelError)
+			l.Warningf("Error getting log level: %v", logLevelError)
 		}
 	}()
 

--- a/pkg/nvcdi/full-gpu-nvml.go
+++ b/pkg/nvcdi/full-gpu-nvml.go
@@ -92,7 +92,7 @@ func (l *fullGPUDeviceSpecGenerator) GetDeviceSpecs() ([]specs.Device, error) {
 
 	annotations, err := l.getDeviceAnnotations()
 	if err != nil {
-		l.logger.Warning("Ignoring error getting device annotations for device(s) %v: %v", names, err)
+		l.logger.Warningf("Ignoring error getting device annotations for device(s) %v: %v", names, err)
 		annotations = nil
 	}
 	var deviceSpecs []specs.Device


### PR DESCRIPTION
This change removes the Info and Warning functions from the logger Interface and replaces their uses with calls to Infof and Warningf.

This serves to simplify the interface to make migrations to other logging APIs simpler in future.