### PR TITLE
Use rpmrebuild instead of fpm to rebuild rpm packages

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -53,35 +53,6 @@ ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
 RUN make PREFIX=/artifacts/bin cmd-nvidia-ctk-installer
 
-# The rpmdigests stage updates the existing rpm packages to have 256bit digests.
-# This is done using fpm.
-FROM nvcr.io/nvidia/cuda:13.0.1-base-ubi9 AS rpmdigests
-
-RUN dnf install -y \
-    rubygems \
-    ruby-devel \
-    yum-utils \
-    rpm-build \
-    && gem install --no-document fpm
-
-ARG ARTIFACTS_ROOT
-COPY ${ARTIFACTS_ROOT}/centos7 /artifacts/packages/centos7-src
-
-WORKDIR /artifacts/packages/centos7
-
-# For each architecture from the source we find all packages and update the
-# digests.
-RUN for arch in $(ls /artifacts/packages/centos7-src/); do \
-        mkdir -p /artifacts/packages/centos7/${arch}; \
-        cd /artifacts/packages/centos7/${arch}; \
-        # For each package in the source folder we recreate a package to update
-        # the digests to 256-bit since we're running in a ubi9 container.
-        for src_package in $(ls /artifacts/packages/centos7-src/${arch}/*.rpm); do \
-            fpm -s rpm -t rpm --rpm-digest=sha256 ${src_package}; \
-        done; \
-    done; \
-    rm -rf /artifacts/packages/centos7-src
-
 # The packaging stage collects the deb and rpm packages built for
 # supported architectures.
 FROM nvcr.io/nvidia/distroless/go:v4.0.0-dev AS packaging
@@ -92,7 +63,7 @@ RUN ln -s /busybox/sh /bin/sh
 
 ARG ARTIFACTS_ROOT
 COPY ${ARTIFACTS_ROOT}/ubuntu18.04 /artifacts/packages/ubuntu18.04
-COPY --from=rpmdigests /artifacts/packages/centos7 /artifacts/packages/centos7
+COPY ${ARTIFACTS_ROOT}/centos7 /artifacts/packages/centos7
 
 # build-args are added to the manifest.txt file below.
 ARG PACKAGE_VERSION

--- a/deployments/container/Dockerfile.rpmrebuild
+++ b/deployments/container/Dockerfile.rpmrebuild
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nvcr.io/nvidia/cuda:13.0.1-base-ubi9
+
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+    && \
+    dnf install -y rpmrebuild
+
+ARG arch
+ENV arch=${arch}
+CMD for src_package in $(ls *.rpm); do \
+        rpmrebuild -pn --directory=/updated --define "_build_id_links none" ${src_package}; \
+    done; \
+    cp -f /updated/${arch}/*.rpm /dist/

--- a/scripts/build-all-components.sh
+++ b/scripts/build-all-components.sh
@@ -71,3 +71,6 @@ make -C "${NVIDIA_CONTAINER_TOOLKIT_ROOT}" \
     LIBNVIDIA_CONTAINER_TAG="${NVIDIA_CONTAINER_TOOLKIT_TAG}" \
         "${TARGET}"
 fi
+
+# Repackage RPMs if required.
+"${SCRIPTS_DIR}/repackage-rpms.sh" "${TARGET}"

--- a/scripts/repackage-rpms.sh
+++ b/scripts/repackage-rpms.sh
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function assert_usage() {
+    echo "Missing argument $1"
+    echo "$(basename "${BASH_SOURCE[0]}") TARGET"
+    exit 1
+}
+
+set -e
+
+
+if [ -n "${SKIP_REPACKAGE_RPMS}" ]; then
+    exit 0
+fi
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../scripts && pwd )"
+PROJECT_ROOT="$( cd "${SCRIPTS_DIR}"/.. && pwd )"
+
+if [[ $# -ne 1 ]]; then
+    assert_usage "TARGET"
+fi
+
+TARGET=$1
+
+source "${SCRIPTS_DIR}"/utils.sh
+
+: "${DIST_DIR:=${PROJECT_ROOT}/dist}"
+export DIST_DIR
+
+case ${TARGET} in
+    centos7-aarch64) platform="linux/aarch64"
+        ;;
+    centos7-x86_64) platform="linux/x86_64"
+        ;;
+    *) exit 0
+        ;;
+esac
+
+arch="${TARGET/centos7-/}"
+platform="${TARGET/centos7-/linux/}"
+package_root="${DIST_DIR}/${TARGET/-//}"
+
+# We build and rpmrebuild:${arch} image with no context.
+docker build \
+    --platform=${platform} \
+    --build-arg arch="${arch}" \
+    --tag rpmrebuild:${arch} \
+    - < ${PROJECT_ROOT}/deployments/container/Dockerfile.rpmrebuild
+
+
+updated=$(mktemp -d)
+echo "Repackaging RPMs from ${package_root} to ${updated}:"
+docker run \
+    --platform=${platform} \
+    --rm \
+    -v ${package_root}:/dist \
+    -v ${updated}:/updated \
+    -w /dist \
+        rpmrebuild:${arch}


### PR DESCRIPTION
It was found that using `fpm` to regenerate the packages with SHA256 digests injects non-empty `pretrans` scriptlets (see #1550). This change switches to using `rpmrebuild` over `fpm` to ensure that the packages have the correct digests in oder to address this.

I tested the packages in a container running on a FIPS-enabled host to ensure that the packages can be installed.