### PR TITLE
add Talos glibc library search paths

### DIFF
--- a/internal/lookup/library.go
+++ b/internal/lookup/library.go
@@ -32,6 +32,9 @@ func NewLibraryLocator(opts ...Option) Locator {
 	opts = append(opts,
 		WithSearchPaths([]string{
 			"/",
+			"/usr/local/glibc/usr/lib",
+			"/usr/local/glibc/lib",
+			"/usr/local/glibc/lib64",
 			"/usr/lib64",
 			"/usr/lib/x86_64-linux-gnu",
 			"/usr/lib/aarch64-linux-gnu",


### PR DESCRIPTION
This is a required change to get the k8s-dra-driver to work on Talos (or other OS's that use `/usr/local/glibc/`)

as discussed https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/695