### PR TITLE
fix: Allow config options to be set to default values

### DIFF
--- a/cmd/nvidia-ctk/config/config_test.go
+++ b/cmd/nvidia-ctk/config/config_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestSetFlagToKeyValue(t *testing.T) {
-	// TODO: We need to enable this test again since switching to reflect.
 	testCases := []struct {
 		description      string
 		setFlag          string

--- a/internal/config/toml_test.go
+++ b/internal/config/toml_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,7 +36,7 @@ func TestTomlSave(t *testing.T) {
 				t, _ := defaultToml()
 				// TODO: We handle the ldconfig path specifically, since this is platform
 				// dependent.
-				(*toml.Tree)(t).Set("nvidia-container-cli.ldconfig", "OVERRIDDEN")
+				t.Set("nvidia-container-cli.ldconfig", "OVERRIDDEN")
 				return t
 			}(),
 			expected: `
@@ -242,9 +241,8 @@ func TestTomlContents(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			tree, err := toml.TreeFromMap(tc.contents)
+			cfg, err := TreeFromMap(tc.contents)
 			require.NoError(t, err)
-			cfg := (*Toml)(tree)
 			contents, err := cfg.contents()
 			require.NoError(t, err)
 
@@ -318,7 +316,7 @@ func TestConfigFromToml(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			tomlCfg := fromMap(tc.contents)
+			tomlCfg, _ := TreeFromMap(tc.contents)
 			config, err := tomlCfg.Config()
 			require.ErrorIs(t, err, tc.expectedError)
 			require.EqualValues(t, tc.expectedConfig, config)
@@ -326,11 +324,7 @@ func TestConfigFromToml(t *testing.T) {
 	}
 }
 
-func fromMap(c map[string]interface{}) *Toml {
-	tree, _ := toml.TreeFromMap(c)
-	return (*Toml)(tree)
-}
-
 func createEmpty() *Toml {
-	return fromMap(nil)
+	t, _ := TreeFromMap(nil)
+	return t
 }


### PR DESCRIPTION
This change fixes a bug, where when using the nvidia-ctk config --set
command to set a config option (e.g. nvidia-container-runtime.debug) to
its default value does not change the rendered config.

Fixes ##1626

For example, before this change:
```
$ ./nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=false | grep accept-nvidia
#accept-nvidia-visible-devices-as-volume-mounts = false
#accept-nvidia-visible-devices-envvar-when-unprivileged = true
$ ./nvidia-ctk config --set nvidia-container-runtime.debug=/var/log/nvidia-container-runtime.log | grep debug
#debug = "/var/log/nvidia-container-toolkit.log"
#debug = "/var/log/nvidia-container-runtime.log"
```
With this change:
```
$ ./nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=false | grep accept-nvidia
accept-nvidia-visible-devices-as-volume-mounts = false
#accept-nvidia-visible-devices-envvar-when-unprivileged = true
$ ./nvidia-ctk config --set nvidia-container-runtime.debug=/var/log/nvidia-container-runtime.log | grep debug
#debug = "/var/log/nvidia-container-toolkit.log"
debug = "/var/log/nvidia-container-runtime.log"
```

