### PR TITLE
fix: Set device node GID in CDI specs

### DIFF
--- a/internal/edits/device.go
+++ b/internal/edits/device.go
@@ -71,6 +71,22 @@ func (d device) fromPathOrDefault() *specs.DeviceNode {
 		}
 	}
 
+	// We construct a CDI spec DeviceNode with the information retrieved.
+	// Note that in addition to the fields that we specify here the following
+	// are not taken from the extracted information:
+	//
+	// * dn.Rule.Allow: This has no equivalent in the CDI spec and is used for
+	//					specifying cgroup rules in a container.
+	// * dn.Rule.Type:  This could be translated to the DeviceNode.Type, but is
+	//					not done. In the toolkit we only consider char devices
+	//					(Type = 'c') and these are the default for device nodes
+	//					in OCI compliant runtimes.
+	// * dn.UID:		This is ignored so as to allow the UID of the container
+	//					user to be applied when making modifications to the OCI
+	//					runtime specification. Note that for most NVIDIA devices
+	//					this would be 0 and as such the target UID pointer will
+	//					remain `nil`.
+	//					See: https://github.com/cncf-tags/container-device-interface/blob/e2632194760242fc74a30c3803107f9c1ba5718b/pkg/cdi/container-edits.go#L96-L100
 	return &specs.DeviceNode{
 		HostPath:    d.HostPath,
 		Path:        d.Path,
@@ -78,5 +94,13 @@ func (d device) fromPathOrDefault() *specs.DeviceNode {
 		Minor:       dn.Minor,
 		FileMode:    &dn.FileMode,
 		Permissions: string(dn.Permissions),
+		GID:         ptrIfNonZero(dn.Gid),
 	}
+}
+
+func ptrIfNonZero(id uint32) *uint32 {
+	if id == 0 {
+		return nil
+	}
+	return &id
 }


### PR DESCRIPTION
This change ensures that the GID for a device node is set in a generated CDI specification. This is important when a device node allows users of the non-root group to access the device node -- especially when running in non-root containers.

Testing:

## On the host:
```
$ ls -aln /dev/nvmap
cr--r----- 1 0 44 10, 123 Feb  5 18:45 /dev/nvmap
```
(where `44` is the GID of the `video` group)

## Without this change we have:
```
$ docker run --rm -ti --device=nvidia.com/gpu=0 -u 1000:1000 ubuntu ls -aln /dev/nvmap
cr--r----- 1 0 0 10, 123 Feb  5 20:54 /dev/nvmap
```
(indicating that the `/dev/nvmap` has the GID `0` associated with it).

Running `nvidia-smi` shows the following errors (and memory is not reported):
```
$ docker run --rm -ti --device=nvidia.com/gpu=0 -u 1000:1000 --group-add 44 ubuntu nvidia-smi -L
NvRmMemInitNvmap failed: error Permission denied
NvRmMemMgrInit failed: Memory Manager Not supported, line 333
NvRmMemMgrInit failed: error type 196626
libnvrm_gpu.so: NvRmGpuLibOpen failed, error=196625
NvRmMemInitNvmap failed: error Permission denied
NvRmMemMgrInit failed: Memory Manager Not supported, line 333
NvRmMemMgrInit failed: error type 196626
libnvrm_gpu.so: NvRmGpuLibOpen failed, error=196625
GPU 0: NVIDIA Thor (UUID: GPU-a7c66ad2-6dbb-0ab8-c1a2-37ba6dba3600)
```

## With this change:
```
$  docker run --rm -ti --device=test.nvidia.com/gpu=0 -u 1000:1000 ubuntu ls -aln /dev/nvmap
cr--r----- 1 0 44 10, 123 Feb  5 20:52 /dev/nvmap
```
(showing a `GID` of `44` matching the host):
and then:
```
docker run --rm -ti --device=test.nvidia.com/gpu=0 -u 1000:1000 --group-add 44 ubuntu nvidia-smi -L
GPU 0: NVIDIA Thor (UUID: GPU-a7c66ad2-6dbb-0ab8-c1a2-37ba6dba3600)
```

Note that the injection of additional GIDs (removing the need for `--group-add 44`) is covered in #630.