### PR TITLE
fix: Log actual CDI spec version

### DIFF
--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -316,10 +316,12 @@ func (m command) run(opts *options) error {
 
 	var errs error
 	for _, spec := range specs {
-		m.logger.Infof("Generated CDI spec with version %v", spec.Raw().Version)
-
 		errs = errors.Join(errs, spec.Save(opts.output))
+		// We query the raw spec version after calling spec.Save since this may
+		// update the spec version to the minimum required version.
+		m.logger.Infof("Generated CDI spec with version %v", spec.Raw().Version)
 	}
+
 	return errs
 }
 


### PR DESCRIPTION
This change ensures that we log the ACTUAL CDI spec version generated and not the version associated with the imported go package.

Without this change:
```
INFO[0000] Generated CDI spec with version 1.1.0
```
With this change the logs include:
```
INFO[0000] Generated CDI spec with version 0.5.0
```