### PR TITLE
Remove restart logic from nvidia-cdi-refresh.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # NVIDIA Container Toolkit Changelog
 
 ## v1.19.0-rc.3
+- Remove restart logic from nvidia-cdi-refresh.service.
 - fix: Set device node GID in CDI specs
 - fix: Log actual CDI spec version
 - Make internal/system packages public

--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -17,9 +17,7 @@ Description=Refresh NVIDIA CDI specification file
 ConditionPathExists=|/usr/bin/nvidia-smi
 ConditionPathExists=|/usr/sbin/nvidia-smi
 ConditionPathExists=/usr/bin/nvidia-ctk
-# Limit the number of successive restarts to 5 in 10 seconds.
-StartLimitBurst=5
-StartLimitIntervalSec=10s
+After=multi-user.target
 
 [Service]
 Type=oneshot
@@ -29,10 +27,6 @@ EnvironmentFile=-/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
 ExecCondition=/usr/bin/grep -qE '/(nvidia|nvidia-current)\\.ko' /lib/modules/%v/modules.dep
 ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
-# We set the service to restart on failure to ensure that a CDI spec is
-# eventually generated.
-Restart=on-failure
-RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Relying on restarts in the `nvidia-cdi-refresh.service` can cause significant noise in cases where there are errors. 

See for example:
* #1624
* #1611 

This change adds `After=multi-user.target` to the service to ensure that the service is started once the `multi-user.target` is started -- which should include the driver initialisation.