### PR TITLE
fix: Correct container compat path for orin

### DIFF
--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -467,7 +467,7 @@ func (l *csvlib) cudaCompatDiscoverer() discover.Discover {
 		// TODO: Should this be overridable through a feature flag / config option?
 		if strings.Contains(name, "Orin (nvgpu)") {
 			// TODO: This should probably be a constant or configurable.
-			cudaCompatContainerRoot = "/usr/local/cuda/compat-orin"
+			cudaCompatContainerRoot = "/usr/local/cuda/compat_orin"
 			break
 		}
 	}

--- a/pkg/nvcdi/lib-csv_test.go
+++ b/pkg/nvcdi/lib-csv_test.go
@@ -115,7 +115,7 @@ func TestDeviceSpecGenerators(t *testing.T) {
 						{
 							HookName: "createContainer",
 							Path:     "/usr/bin/nvidia-cdi-hook",
-							Args:     []string{"nvidia-cdi-hook", "enable-cuda-compat", "--host-driver-version=540.3.0", "--cuda-compat-container-root=/usr/local/cuda/compat-orin"},
+							Args:     []string{"nvidia-cdi-hook", "enable-cuda-compat", "--host-driver-version=540.3.0", "--cuda-compat-container-root=/usr/local/cuda/compat_orin"},
 							Env:      []string{"NVIDIA_CTK_DEBUG=false"},
 						},
 						{


### PR DESCRIPTION
The orin compat path in the container should be `/usr/local/cuda/compat_orin`.