### PR TITLE
refactor: Move update-ldcache argument processing into hook creator

### DIFF
--- a/internal/discover/hooks_test.go
+++ b/internal/discover/hooks_test.go
@@ -225,7 +225,7 @@ func TestCDIHookCreator_Create(t *testing.T) {
 			name:        "UpdateLDCacheHook with args",
 			hookCreator: NewHookCreator(WithNVIDIACDIHookPath(defaultNvidiaCDIHookPath)),
 			hookName:    UpdateLDCacheHook,
-			args:        []string{"--folder", "/usr/lib64"},
+			args:        []string{"/usr/lib64"},
 			expectedHook: &Hook{
 				Lifecycle: "createContainer",
 				Path:      defaultNvidiaCDIHookPath,

--- a/internal/discover/ldconfig_test.go
+++ b/internal/discover/ldconfig_test.go
@@ -31,7 +31,6 @@ const (
 
 func TestLDCacheUpdateHook(t *testing.T) {
 	logger, _ := testlog.NewNullLogger()
-	hookCreator := NewHookCreator(WithNVIDIACDIHookPath(testNvidiaCDIHookPath))
 
 	testCases := []struct {
 		description   string
@@ -115,12 +114,16 @@ func TestLDCacheUpdateHook(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			hookCreator := NewHookCreator(
+				WithNVIDIACDIHookPath(testNvidiaCDIHookPath),
+				WithLdconfigPath(tc.ldconfigPath),
+			)
 			mountMock := &DiscoverMock{
 				MountsFunc: func() ([]Mount, error) {
 					return tc.mounts, tc.mountError
 				},
 			}
-			d, err := NewLDCacheUpdateHook(logger, mountMock, hookCreator, tc.ldconfigPath)
+			d, err := NewLDCacheUpdateHook(logger, mountMock, hookCreator)
 			require.NoError(t, err)
 
 			hooks, err := d.Hooks()

--- a/internal/modifier/gated.go
+++ b/internal/modifier/gated.go
@@ -119,7 +119,6 @@ func getCudaCompatModeDiscoverer(logger logger.Interface, cfg *config.Config, dr
 		logger,
 		discover.None{},
 		hookCreator,
-		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct ldcache update discoverer: %w", err)

--- a/internal/platform-support/tegra/options.go
+++ b/internal/platform-support/tegra/options.go
@@ -28,7 +28,6 @@ type options struct {
 	driverRoot         string
 	devRoot            string
 	hookCreator        discover.HookCreator
-	ldconfigPath       string
 	librarySearchPaths []string
 
 	// The following can be overridden for testing
@@ -69,13 +68,6 @@ func WithDevRoot(devRoot string) Option {
 func WithHookCreator(hookCreator discover.HookCreator) Option {
 	return func(o *options) {
 		o.hookCreator = hookCreator
-	}
-}
-
-// WithLdconfigPath sets the path to the ldconfig program
-func WithLdconfigPath(ldconfigPath string) Option {
-	return func(o *options) {
-		o.ldconfigPath = ldconfigPath
 	}
 }
 

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -104,7 +104,7 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
 	cudaCompatLibHookDiscoverer := discover.NewCUDACompatHookDiscoverer(l.logger, l.hookCreator, version, "")
 	discoverers = append(discoverers, cudaCompatLibHookDiscoverer)
 
-	updateLDCache, _ := discover.NewLDCacheUpdateHook(l.logger, libraries, l.hookCreator, l.ldconfigPath)
+	updateLDCache, _ := discover.NewLDCacheUpdateHook(l.logger, libraries, l.hookCreator)
 	discoverers = append(discoverers, updateLDCache)
 
 	disableDeviceNodeModification := l.hookCreator.Create(DisableDeviceNodeModificationHook)

--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -39,7 +39,7 @@ var requiredDriverStoreFiles = []string{
 }
 
 // newWSLDriverDiscoverer returns a Discoverer for WSL2 drivers.
-func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator, ldconfigPath string) (discover.Discover, error) {
+func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator) (discover.Discover, error) {
 	if err := dxcore.Init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize dxcore: %w", err)
 	}
@@ -79,7 +79,7 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCrea
 		hookCreator: hookCreator,
 	}
 
-	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, driverStoreMounts, hookCreator, ldconfigPath)
+	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, driverStoreMounts, hookCreator)
 
 	d := discover.Merge(
 		driverStoreMounts,

--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -163,7 +163,6 @@ func (l *csvDeviceGenerator) deviceNodeDiscoverer() (discover.Discover, error) {
 		tegra.WithDriverRoot(l.driverRoot),
 		tegra.WithDevRoot(l.devRoot),
 		tegra.WithHookCreator(l.hookCreator),
-		tegra.WithLdconfigPath(l.ldconfigPath),
 		tegra.WithLibrarySearchPaths(l.librarySearchPaths...),
 		tegra.WithMountSpecs(l.deviceNodeMountSpecs()),
 	)
@@ -398,7 +397,6 @@ func (l *csvlib) driverDiscoverer() (discover.Discover, error) {
 		tegra.WithDriverRoot(l.driverRoot),
 		tegra.WithDevRoot(l.devRoot),
 		tegra.WithHookCreator(l.hookCreator),
-		tegra.WithLdconfigPath(l.ldconfigPath),
 		tegra.WithLibrarySearchPaths(l.librarySearchPaths...),
 		tegra.WithMountSpecs(mountSpecs),
 	)
@@ -408,7 +406,7 @@ func (l *csvlib) driverDiscoverer() (discover.Discover, error) {
 
 	cudaCompatDiscoverer := l.cudaCompatDiscoverer()
 
-	ldcacheUpdateHook, err := discover.NewLDCacheUpdateHook(l.logger, driverDiscoverer, l.hookCreator, l.ldconfigPath)
+	ldcacheUpdateHook, err := discover.NewLDCacheUpdateHook(l.logger, driverDiscoverer, l.hookCreator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ldcache update hook discoverer: %w", err)
 	}

--- a/pkg/nvcdi/lib-wsl.go
+++ b/pkg/nvcdi/lib-wsl.go
@@ -51,7 +51,7 @@ func (l *wsllib) GetDeviceSpecs() ([]specs.Device, error) {
 
 // GetCommonEdits generates a CDI specification that can be used for ANY devices
 func (l *wsllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
-	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.hookCreator, l.ldconfigPath)
+	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.hookCreator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for WSL driver: %v", err)
 	}

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -149,6 +149,7 @@ func New(opts ...Option) (Interface, error) {
 		discover.WithNVIDIACDIHookPath(l.nvidiaCDIHookPath),
 		discover.WithDisabledHooks(l.disabledHooks...),
 		discover.WithEnabledHooks(l.enabledHooks...),
+		discover.WithLdconfigPath(l.ldconfigPath),
 	)
 
 	w := wrapper{


### PR DESCRIPTION
Instead of keeping track of the ldconfig path for hook creation, we encapsulate this value in the HookCreator options. This means that this value can be set once and reused when creating these hooks.