### PR TITLE
test: Add to package with Ptr function

### DIFF
--- a/api/config/v1/config_test.go
+++ b/api/config/v1/config_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/test/to"
 )
 
 func TestGetConfigWithCustomConfig(t *testing.T) {
@@ -215,7 +217,7 @@ func TestGetConfig(t *testing.T) {
 					Path: "nvidia-ctk",
 				},
 				Features: features{
-					AllowLDConfigFromContainer: ptr(feature(true)),
+					AllowLDConfigFromContainer: to.Ptr(feature(true)),
 				},
 			},
 		},
@@ -433,7 +435,7 @@ func TestAssertValid(t *testing.T) {
 					Ldconfig: "/non/host/path",
 				},
 				Features: features{
-					AllowLDConfigFromContainer: ptr(feature(true)),
+					AllowLDConfigFromContainer: to.Ptr(feature(true)),
 				},
 			},
 		},
@@ -460,11 +462,6 @@ func setGetDistIDLikeForTest(ids []string) func() {
 	return func() {
 		getDistIDLike = original
 	}
-}
-
-// prt returns a reference to whatever type is passed into it
-func ptr[T any](x T) *T {
-	return &x
 }
 
 func setGetLdConfigPathForTest() func() {

--- a/api/config/v1/toml_test.go
+++ b/api/config/v1/toml_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/test/to"
 )
 
 func TestTomlSave(t *testing.T) {
@@ -308,7 +310,7 @@ func TestConfigFromToml(t *testing.T) {
 			expectedConfig: func() *Config {
 				c, _ := GetDefault()
 				c.NVIDIAContainerCLIConfig.Ldconfig = "/some/ldconfig/path"
-				c.Features.AllowLDConfigFromContainer = ptr(feature(true))
+				c.Features.AllowLDConfigFromContainer = to.Ptr(feature(true))
 				return c
 			}(),
 		},

--- a/internal/test/to/to.go
+++ b/internal/test/to/to.go
@@ -1,0 +1,23 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package to
+
+// Ptr returns a pointer to a value of any type.
+func Ptr[T any](x T) *T {
+	return &x
+}

--- a/pkg/nvcdi/lib-csv_test.go
+++ b/pkg/nvcdi/lib-csv_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/devices"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/test/to"
 )
 
 func TestDeviceSpecGenerators(t *testing.T) {
@@ -145,7 +146,7 @@ func TestDeviceSpecGenerators(t *testing.T) {
 						DeviceNodes: []*specs.DeviceNode{
 							{Path: "/dev/nvidia0", HostPath: "/dev/nvidia0"},
 							{Path: "/dev/nvidiactl", HostPath: "/dev/nvidiactl"},
-							{Path: "/dev/nvmap", HostPath: "/dev/nvmap", FileMode: ptr(os.FileMode(0400)), Permissions: "rwm", GID: ptr[uint32](44)},
+							{Path: "/dev/nvmap", HostPath: "/dev/nvmap", FileMode: to.Ptr(os.FileMode(0400)), Permissions: "rwm", GID: to.Ptr[uint32](44)},
 							{Path: "/dev/nvidia2", HostPath: "/dev/nvidia2"},
 						},
 					},
@@ -156,7 +157,7 @@ func TestDeviceSpecGenerators(t *testing.T) {
 						DeviceNodes: []*specs.DeviceNode{
 							{Path: "/dev/nvidia1", HostPath: "/dev/nvidia1"},
 							{Path: "/dev/nvidiactl", HostPath: "/dev/nvidiactl"},
-							{Path: "/dev/nvmap", HostPath: "/dev/nvmap", FileMode: ptr(os.FileMode(0400)), Permissions: "rwm", GID: ptr[uint32](44)},
+							{Path: "/dev/nvmap", HostPath: "/dev/nvmap", FileMode: to.Ptr(os.FileMode(0400)), Permissions: "rwm", GID: to.Ptr[uint32](44)},
 						},
 					},
 				},
@@ -299,8 +300,4 @@ func mockIGXServer() nvml.Interface {
 			return nil, nvml.ERROR_INVALID_ARGUMENT
 		},
 	}
-}
-
-func ptr[T any](x T) *T {
-	return &x
 }


### PR DESCRIPTION
Instead of duplicating the ptr function for getting the pointer to a constant in testing, this change adds a to package with a Ptr function and uses this in the tests.

Inspired by https://youtu.be/RZe8ojn7goo?si=eEFTd_jypfRIcS8W&t=1323