### PR TITLE
Use fedora:43 image for rpmrebuild

### DIFF
--- a/deployments/container/Dockerfile.rpmrebuild
+++ b/deployments/container/Dockerfile.rpmrebuild
@@ -13,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/cuda:13.0.1-base-ubi9
+FROM fedora:43
 
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-    && \
-    dnf install -y rpmrebuild
+RUN dnf install -y rpmrebuild-2.21
 
 ARG arch
 ENV arch=${arch}


### PR DESCRIPTION
Due to a version mismatch between the ubi9 image and the epel repos, installing rpmrebuild fails. Here we switch to the fedora:43 image to ensure that rpmrebuild can be installed successfully.

This can be reverted once the issue has been resolved, but there also shouldn't be any downsides to using the image directly since it's CI-only and only affects the "repackaing" of RPM packages.