### PR TITLE
refactor: Prefer cdilib methods over functions

### DIFF
--- a/pkg/nvcdi/device-wsl.go
+++ b/pkg/nvcdi/device-wsl.go
@@ -18,7 +18,6 @@ package nvcdi
 
 import (
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
-	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 )
 
 const (
@@ -26,10 +25,10 @@ const (
 )
 
 // newDXGDeviceDiscoverer returns a Discoverer for DXG devices under WSL2.
-func newDXGDeviceDiscoverer(logger logger.Interface, devRoot string) discover.Discover {
+func (l *wsllib) newDXGDeviceDiscoverer() discover.Discover {
 	deviceNodes := discover.NewCharDeviceDiscoverer(
-		logger,
-		devRoot,
+		l.logger,
+		l.devRoot,
 		[]string{dxgDeviceNode},
 	)
 

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
-	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/root"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/lookup"
 )
 
@@ -57,12 +56,12 @@ func (l *nvcdilib) newDriverVersionDiscoverer() (discover.Discover, error) {
 		return nil, fmt.Errorf("failed to create discoverer for IPC sockets: %v", err)
 	}
 
-	firmwares, err := NewDriverFirmwareDiscoverer(l.logger, l.driver.Root, version)
+	firmwares, err := l.newDriverFirmwareDiscoverer(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for GSP firmware: %v", err)
 	}
 
-	binaries := NewDriverBinariesDiscoverer(l.logger, l.driver.Root)
+	binaries := l.newDriverBinariesDiscoverer()
 
 	d := discover.Merge(
 		libraries,
@@ -126,7 +125,7 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
 }
 
 func (l *nvcdilib) getVersionSuffixDriverLibraryMounts(version string) (discover.Discover, error) {
-	versionSuffixLibraryPaths, err := getVersionLibs(l.logger, l.driver, version)
+	versionSuffixLibraryPaths, err := l.getVersionLibs(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get libraries for driver version: %v", err)
 	}
@@ -224,31 +223,31 @@ func getCustomFirmwareClassPath(logger logger.Interface) string {
 	return strings.TrimSpace(string(customFirmwareClassPath))
 }
 
-// NewDriverFirmwareDiscoverer creates a discoverer for GSP firmware associated with the specified driver version.
-func NewDriverFirmwareDiscoverer(logger logger.Interface, driverRoot string, version string) (discover.Discover, error) {
-	gspFirmwareSearchPaths, err := getFirmwareSearchPaths(logger)
+// newDriverFirmwareDiscoverer creates a discoverer for GSP firmware associated with the specified driver version.
+func (l *nvcdilib) newDriverFirmwareDiscoverer(version string) (discover.Discover, error) {
+	gspFirmwareSearchPaths, err := getFirmwareSearchPaths(l.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get firmware search paths: %v", err)
 	}
 	gspFirmwarePaths := filepath.Join("nvidia", version, "gsp*.bin")
 	return discover.NewMounts(
-		logger,
+		l.logger,
 		lookup.NewFileLocator(
-			lookup.WithLogger(logger),
-			lookup.WithRoot(driverRoot),
+			lookup.WithLogger(l.logger),
+			lookup.WithRoot(l.driverRoot),
 			lookup.WithSearchPaths(gspFirmwareSearchPaths...),
 		),
-		driverRoot,
+		l.driverRoot,
 		[]string{gspFirmwarePaths},
 	), nil
 }
 
-// NewDriverBinariesDiscoverer creates a discoverer for GSP firmware associated with the GPU driver.
-func NewDriverBinariesDiscoverer(logger logger.Interface, driverRoot string) discover.Discover {
+// newDriverBinariesDiscoverer creates a discoverer for GSP firmware associated with the GPU driver.
+func (l *nvcdilib) newDriverBinariesDiscoverer() discover.Discover {
 	return discover.NewMounts(
-		logger,
-		lookup.NewExecutableLocator(logger, driverRoot),
-		driverRoot,
+		l.logger,
+		lookup.NewExecutableLocator(l.logger, l.driverRoot),
+		l.driverRoot,
 		[]string{
 			"nvidia-smi",              /* System management interface */
 			"nvidia-debugdump",        /* GPU coredump utility */
@@ -264,10 +263,10 @@ func NewDriverBinariesDiscoverer(logger logger.Interface, driverRoot string) dis
 // getVersionLibs checks the LDCache for libraries ending in the specified driver version.
 // Although the ldcache at the specified driverRoot is queried, the paths are returned relative to this driverRoot.
 // This allows the standard mount location logic to be used for resolving the mounts.
-func getVersionLibs(logger logger.Interface, driver *root.Driver, version string) ([]string, error) {
-	logger.Infof("Using driver version %v", version)
+func (l *nvcdilib) getVersionLibs(version string) ([]string, error) {
+	l.logger.Infof("Using driver version %v", version)
 
-	libraries, err := driver.DriverLibraryLocator("vdpau")
+	libraries, err := l.driver.DriverLibraryLocator("vdpau")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver library locator: %w", err)
 	}
@@ -277,13 +276,13 @@ func getVersionLibs(logger logger.Interface, driver *root.Driver, version string
 		return nil, fmt.Errorf("failed to locate libraries for driver version %v: %v", version, err)
 	}
 
-	if driver.Root == "/" || driver.Root == "" {
+	if l.driver.Root == "/" || l.driver.Root == "" {
 		return libs, nil
 	}
 
 	var relative []string
-	for _, l := range libs {
-		relative = append(relative, strings.TrimPrefix(l, driver.Root))
+	for _, lib := range libs {
+		relative = append(relative, strings.TrimPrefix(lib, l.driver.Root))
 	}
 
 	return relative, nil

--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -39,13 +39,13 @@ var requiredDriverStoreFiles = []string{
 }
 
 // newWSLDriverDiscoverer returns a Discoverer for WSL2 drivers.
-func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCreator discover.HookCreator) (discover.Discover, error) {
+func (l *wsllib) newWSLDriverDiscoverer() (discover.Discover, error) {
 	if err := dxcore.Init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize dxcore: %w", err)
 	}
 	defer func() {
 		if err := dxcore.Shutdown(); err != nil {
-			logger.Warningf("failed to shutdown dxcore: %w", err)
+			l.logger.Warningf("failed to shutdown dxcore: %w", err)
 		}
 	}()
 
@@ -54,32 +54,32 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, hookCrea
 		return nil, fmt.Errorf("no driver store paths found")
 	}
 	if len(driverStorePaths) > 1 {
-		logger.Warningf("Found multiple driver store paths: %v", driverStorePaths)
+		l.logger.Warningf("Found multiple driver store paths: %v", driverStorePaths)
 	}
-	logger.Infof("Using WSL driver store paths: %v", driverStorePaths)
+	l.logger.Infof("Using WSL driver store paths: %v", driverStorePaths)
 
 	driverStorePaths = append(driverStorePaths, "/usr/lib/wsl/lib")
 
 	driverStoreMounts := discover.NewMounts(
-		logger,
+		l.logger,
 		lookup.NewFileLocator(
-			lookup.WithLogger(logger),
+			lookup.WithLogger(l.logger),
 			lookup.WithSearchPaths(
 				driverStorePaths...,
 			),
 			lookup.WithCount(1),
 		),
-		driverRoot,
+		l.driverRoot,
 		requiredDriverStoreFiles,
 	)
 
 	symlinkHook := nvidiaSMISimlinkHook{
-		logger:      logger,
+		logger:      l.logger,
 		mountsFrom:  driverStoreMounts,
-		hookCreator: hookCreator,
+		hookCreator: l.hookCreator,
 	}
 
-	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, driverStoreMounts, hookCreator)
+	ldcacheHook, _ := discover.NewLDCacheUpdateHook(l.logger, driverStoreMounts, l.hookCreator)
 
 	d := discover.Merge(
 		driverStoreMounts,

--- a/pkg/nvcdi/full-gpu-nvml.go
+++ b/pkg/nvcdi/full-gpu-nvml.go
@@ -170,10 +170,7 @@ func (l *fullGPUDeviceSpecGenerator) newFullGPUDiscoverer(d device.Device) (disc
 		return nil, fmt.Errorf("failed to create device discoverer: %v", err)
 	}
 
-	deviceFolderPermissionHooks := newDeviceFolderPermissionHookDiscoverer(
-		l.logger,
-		l.devRoot,
-		l.hookCreator,
+	deviceFolderPermissionHooks := (*nvcdilib)(l.nvmllib).newDeviceFolderPermissionHookDiscoverer(
 		deviceNodes,
 	)
 

--- a/pkg/nvcdi/lib-wsl.go
+++ b/pkg/nvcdi/lib-wsl.go
@@ -35,7 +35,7 @@ func (l *wsllib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
 
 // GetDeviceSpecs returns the CDI device specs for a single all device.
 func (l *wsllib) GetDeviceSpecs() ([]specs.Device, error) {
-	device := newDXGDeviceDiscoverer(l.logger, l.devRoot)
+	device := l.newDXGDeviceDiscoverer()
 	deviceEdits, err := edits.FromDiscoverer(device)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container edits for DXG device: %v", err)
@@ -51,7 +51,7 @@ func (l *wsllib) GetDeviceSpecs() ([]specs.Device, error) {
 
 // GetCommonEdits generates a CDI specification that can be used for ANY devices
 func (l *wsllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
-	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.hookCreator)
+	driver, err := l.newWSLDriverDiscoverer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for WSL driver: %v", err)
 	}

--- a/pkg/nvcdi/management.go
+++ b/pkg/nvcdi/management.go
@@ -109,10 +109,7 @@ func (l *managementlib) newManagementDeviceDiscoverer() (discover.Discover, erro
 		},
 	)
 
-	deviceFolderPermissionHooks := newDeviceFolderPermissionHookDiscoverer(
-		l.logger,
-		l.devRoot,
-		l.hookCreator,
+	deviceFolderPermissionHooks := (*nvcdilib)(l).newDeviceFolderPermissionHookDiscoverer(
 		deviceNodes,
 	)
 

--- a/pkg/nvcdi/workarounds-device-folder-permissions.go
+++ b/pkg/nvcdi/workarounds-device-folder-permissions.go
@@ -39,11 +39,11 @@ var _ discover.Discover = (*deviceFolderPermissions)(nil)
 // The nested devices that are applicable to the NVIDIA GPU devices are:
 //   - DRM devices at /dev/dri/*
 //   - NVIDIA Caps devices at /dev/nvidia-caps/*
-func newDeviceFolderPermissionHookDiscoverer(logger logger.Interface, devRoot string, hookCreator discover.HookCreator, devices discover.Discover) discover.Discover {
+func (l *nvcdilib) newDeviceFolderPermissionHookDiscoverer(devices discover.Discover) discover.Discover {
 	d := &deviceFolderPermissions{
-		logger:      logger,
-		devRoot:     devRoot,
-		hookCreator: hookCreator,
+		logger:      l.logger,
+		devRoot:     l.devRoot,
+		hookCreator: l.hookCreator,
 		devices:     devices,
 	}
 


### PR DESCRIPTION
This change converts a number of internal-only functions to methods on the (*|nvcdi)lib types. This allows for the stored references to the logger and driver, for example, to be reused instead of passing these as arguments.