### PR TITLE
chore: Fix release tooling to support annotated tags

### DIFF
--- a/hack/prepare-artifacts.sh
+++ b/hack/prepare-artifacts.sh
@@ -28,7 +28,7 @@ if [[ -z ${VERSION} ]]; then
   exit 1
 fi
 
-SHA=$(git rev-parse --short=8 ${VERSION})
+SHA=$(git rev-parse --short=8 ${VERSION}^{commit})
 
 IMAGE_NAME="ghcr.io/nvidia/container-toolkit"
 IMAGE_TAG=${SHA}-packaging


### PR DESCRIPTION
Annotated tags are git objects themselves and we should therefore get the git reference from their commit and not the tag itself.

For example:
```
$ git log
commit c57370920f32c0d78af2de5cc89a67f06da32134 (HEAD -> main, tag: v1.19.0-rc.4, upstream/main, upstream/HEAD)
```

```
$  git rev-parse v1.19.0-rc.4
86606c7758ae01f58777317eca89afd8135dffdb
```

```
$ git rev-parse v1.19.0-rc.4^{commit}
c57370920f32c0d78af2de5cc89a67f06da32134
```

which is the same SHA as `main`.
