### PR TITLE
Use host CUDA version for all CSV compat checks

### DIFF
--- a/pkg/nvcdi/lib-csv.go
+++ b/pkg/nvcdi/lib-csv.go
@@ -457,15 +457,11 @@ func (l *csvlib) getEnableCUDACompatHookOptions() (*discover.EnableCUDACompatHoo
 		_ = l.nvmllib.Shutdown()
 	}()
 
-	if !l.hasOrinDevices() {
-		hostDriverVersion, ret := l.nvmllib.SystemGetDriverVersion()
-		if ret != nvml.SUCCESS {
-			return nil, fmt.Errorf("failed to get driver version: %v", ret)
-		}
-		f := &discover.EnableCUDACompatHookOptions{
-			HostDriverVersion: hostDriverVersion,
-		}
-		return f, nil
+	var cudaCompatContainerRoot string
+	if l.hasOrinDevices() {
+		// For Orin devices we need to use a different container compat root.
+		// We allow this to be overridden by the user.
+		cudaCompatContainerRoot = l.csv.CompatContainerRoot
 	}
 
 	hostCUDAVersion, err := l.getCUDAVersionString()
@@ -475,7 +471,7 @@ func (l *csvlib) getEnableCUDACompatHookOptions() (*discover.EnableCUDACompatHoo
 
 	f := &discover.EnableCUDACompatHookOptions{
 		HostCUDAVersion:         hostCUDAVersion,
-		CUDACompatContainerRoot: l.csv.CompatContainerRoot,
+		CUDACompatContainerRoot: cudaCompatContainerRoot,
 	}
 	return f, nil
 }

--- a/pkg/nvcdi/lib-csv_test.go
+++ b/pkg/nvcdi/lib-csv_test.go
@@ -207,7 +207,7 @@ func TestDeviceSpecGenerators(t *testing.T) {
 						{
 							HookName: "createContainer",
 							Path:     "/usr/bin/nvidia-cdi-hook",
-							Args:     []string{"nvidia-cdi-hook", "enable-cuda-compat", "--host-driver-version=540.3.0"},
+							Args:     []string{"nvidia-cdi-hook", "enable-cuda-compat", "--host-cuda-version=13.1"},
 							Env:      []string{"NVIDIA_CTK_DEBUG=false"},
 						},
 						{
@@ -359,6 +359,9 @@ func mockIGXServer() nvml.Interface {
 		},
 		SystemGetDriverVersionFunc: func() (string, nvml.Return) {
 			return "540.3.0", nvml.SUCCESS
+		},
+		SystemGetCudaDriverVersionFunc: func() (int, nvml.Return) {
+			return 13010, nvml.SUCCESS
 		},
 		DeviceGetCountFunc: func() (int, nvml.Return) {
 			return 2, nvml.SUCCESS


### PR DESCRIPTION
The host driver version returned on nvgpu (e.g. Thor) systems is unreliable in terms of determining whether CUDA compat should be used. Even though the "standard" compat libraries are used, we should still only consider the host CUDA version and not the host driver versions.

Running on a Thor-based system:
```
CUDA error at /usr/samples/Samples/0_Introduction/simpleStreams/../../../Common/helper_cuda.h:816 code=803(cudaErrorSystemDriverMismatch) "cudaGetDeviceCount(&device_count)"
```

Note that:
```
 ldconfig -p | grep libcuda.so.1
	libcuda.so.1 (libc6,AArch64) => /usr/local/cuda-13.0/compat/libcuda.so.1
	libcuda.so.1 (libc6,AArch64) => /usr/lib/aarch64-linux-gnu/nvidia/libcuda.so.1
```

After removing the compat libraries:
```
$ rm /etc/ld.so.conf.d/00-compat-888138641.conf && ldconfig
root@localhost:/usr/samples/Samples/0_Introduction/simpleStreams# ldconfig -p | grep libcuda.so.1
	libcuda.so.1 (libc6,AArch64) => /usr/lib/aarch64-linux-gnu/nvidia/libcuda.so.1
```

(or with this change) The test application succeeds.