### PR TITLE
fix: Ensure that CUDA Compat Container path is set by default

### DIFF
--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -69,9 +69,6 @@ func populateOptions(opts ...Option) *options {
 		mode:              ModeAuto,
 		driverRoot:        "/",
 		nvidiaCDIHookPath: "/usr/bin/nvidia-cdi-hook",
-		csv: csvOptions{
-			CompatContainerRoot: defaultOrinCompatContainerRoot,
-		},
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -107,6 +104,10 @@ func populateOptions(opts ...Option) *options {
 
 	if o.mode == ModeCSV && len(o.csv.Files) == 0 {
 		o.csv.Files = csv.DefaultFileList()
+	}
+
+	if o.mode == ModeCSV && o.csv.CompatContainerRoot == "" {
+		o.csv.CompatContainerRoot = defaultOrinCompatContainerRoot
 	}
 
 	if o.mode == ModeManagement {


### PR DESCRIPTION
This change ensures that the CUDA Compat Container path is set on orin-based systems. Without this, the CUDA Compat libraries for SBSA are (incorrectly) used in a container.