### PR TITLE
chore: Run goimports on mocks

### DIFF
--- a/internal/oci/spec_mock.go
+++ b/internal/oci/spec_mock.go
@@ -4,8 +4,9 @@
 package oci
 
 import (
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"sync"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Ensure, that SpecMock does implement Spec.

--- a/pkg/nvcdi/namer_nvml_mock.go
+++ b/pkg/nvcdi/namer_nvml_mock.go
@@ -4,8 +4,9 @@
 package nvcdi
 
 import (
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"sync"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
 // Ensure, that nvmlUUIDerMock does implement nvmlUUIDer.


### PR DESCRIPTION
This ensures that running make generate does not introduce changes.