### PR TITLE
fix: Prevent config option from reverting modified configurations

### DIFF
--- a/api/config/v1/toml.go
+++ b/api/config/v1/toml.go
@@ -98,8 +98,31 @@ func (o options) loadConfigToml() (*Toml, error) {
 	}
 	defer tomlFile.Close()
 
-	return loadConfigTomlFrom(tomlFile)
+	t, err := loadConfigTomlFrom(tomlFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load specified config file: %w", err)
+	}
 
+	for _, key := range t.tree.Keys() {
+		t.markKeysSet(key, "")
+	}
+	return t, nil
+}
+
+func (t *Toml) markKeysSet(key string, prefix string) {
+	fullKey := key
+	if prefix != "" {
+		fullKey = prefix + "." + key
+	}
+
+	t.valuesSet[fullKey] = true
+
+	subTree := t.tree.Get(fullKey)
+	if nextTree, ok := subTree.(*toml.Tree); ok {
+		for _, nextKey := range nextTree.Keys() {
+			t.markKeysSet(nextKey, fullKey)
+		}
+	}
 }
 
 func defaultToml() (*Toml, error) {

--- a/api/config/v1/toml_test.go
+++ b/api/config/v1/toml_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -322,6 +323,74 @@ func TestConfigFromToml(t *testing.T) {
 			config, err := tomlCfg.Config()
 			require.ErrorIs(t, err, tc.expectedError)
 			require.EqualValues(t, tc.expectedConfig, config)
+		})
+	}
+}
+
+func TestLoadConfigToml(t *testing.T) {
+	cfgToml, err := defaultToml()
+	require.NoError(t, err)
+
+	cfgToml.Set("nvidia-container-cli.ldconfig", "OVERRIDDEN")
+	cfgToml.Set("nvidia-container-cli.debug", "/var/log/nvidia-container-toolkit.log")
+	cfgToml.Set("nvidia-container-runtime.debug", "/var/log/nvidia-container-runtime.log")
+
+	tmpFile, err := os.CreateTemp("", "config.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = cfgToml.Save(tmpFile)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	testCases := []struct {
+		description string
+		options     options
+		expected    string
+	}{
+		{
+			description: "empty filename returns default config",
+			options: options{
+				configFile: "",
+			},
+			expected: func() string {
+				cfgToml, _ := defaultToml()
+				buffer := new(bytes.Buffer)
+				_, err := cfgToml.Save(buffer)
+				require.NoError(t, err)
+				return buffer.String()
+			}(),
+		},
+		{
+			description: "save uncommented configuration items to file",
+			options: options{
+				configFile: tmpFile.Name(),
+			},
+			expected: func() string {
+				cfgToml, _ := defaultToml()
+				cfgToml.Set("nvidia-container-cli.ldconfig", "OVERRIDDEN")
+				cfgToml.Set("nvidia-container-cli.debug", "/var/log/nvidia-container-toolkit.log")
+				cfgToml.Set("nvidia-container-runtime.debug", "/var/log/nvidia-container-runtime.log")
+				buffer := new(bytes.Buffer)
+				_, err := cfgToml.Save(buffer)
+				require.NoError(t, err)
+				return buffer.String()
+			}(),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tomlCfg, err := tc.options.loadConfigToml()
+			require.NoError(t, err)
+
+			buffer := new(bytes.Buffer)
+			_, err = tomlCfg.Save(buffer)
+			require.NoError(t, err)
+
+			require.EqualValues(t,
+				strings.TrimSpace(tc.expected),
+				strings.TrimSpace(buffer.String()),
+			)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where uncommented default configuration options (such as `nvidia-container-runtime.debug`) were being automatically re-commented when running `nvidia-ctk config`(without the `--set` flag), even if the user had explicitly enabled them in the configuration file.

## Problem
The current implementation of `commentDefaults()` relies on a `valuesSet` map to track which configuration keys have been explicitly modified. However, when loading an existing configuration file from disk, the `valuesSet` map remained empty.

As a result, if a user manually uncommented a default setting without changing its value(e.g., `nvidia-container-runtime.debug = "/var/log/nvidia-container-runtime.log"`), or uncommented with the `--set` flag, the toolkit would:

- Fail to recognize the key as "user-set" during the loading phase.
- Match the value against the internal hardcoded defaults.
- Re-apply the `#` comment prefix during the `Save()` operation, effectively reverting the user's manual configuration.

## Changes
- Modified the configuration loading logic to differentiate between loading an existing file and generating a fresh default configuration.
- Updated `loadConfigToml()` to traverse the TOML tree after successfully reading from a file, populating the `valuesSet` map with all keys present in the file.

## Testing Performed
- Verified that running `nvidia-ctk config --in-place` no longer re-comments uncommented lines in `/etc/nvidia-container-runtime/config.toml`.
- Verified that `nvidia-ctk config default` still generates a standard template with the correct comments and default values.

### Before Fix

```bash
$ ./nvidia-ctk config default -o /etc/nvidia-container-runtime/config.toml 
$ ./nvidia-ctk config |grep debug
#debug = "/var/log/nvidia-container-toolkit.log"
#debug = "/var/log/nvidia-container-runtime.log"
$ ./nvidia-ctk config --set nvidia-container-runtime.debug=/var/log/nvidia-container-runtime.log --in-place
$ ./nvidia-ctk config |grep debug
#debug = "/var/log/nvidia-container-toolkit.log"
#debug = "/var/log/nvidia-container-runtime.log"
```
### After Fix
```bash
$ ./nvidia-ctk config default -o /etc/nvidia-container-runtime/config.toml 
$ ./nvidia-ctk config |grep debug
#debug = "/var/log/nvidia-container-toolkit.log"
#debug = "/var/log/nvidia-container-runtime.log"
$ ./nvidia-ctk config --set nvidia-container-runtime.debug=/var/log/nvidia-container-runtime.log --in-place
$ ./nvidia-ctk config |grep debug
#debug = "/var/log/nvidia-container-toolkit.log"
debug = "/var/log/nvidia-container-runtime.log"
```