### PR TITLE
fix: Don't use driver version in ELF header for compat check

### DIFF
--- a/cmd/nvidia-cdi-hook/cudacompat/cuda-elf-header.go
+++ b/cmd/nvidia-cdi-hook/cudacompat/cuda-elf-header.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -119,16 +118,11 @@ func getCUDAFwdCompatibilitySection(lib *elf.File) *elf.Section {
 
 // UseCompat checks whether the CUDA compat libraries with the specified elf
 // header should be used given the specified host versions.
-// If the hostDriverVersion is specified and the ELF header includes a list of
-// driver verions, this is checked, otherwise the CUDA version specified in the
-// ELF section is checked.
-func (h *compatElfHeader) UseCompat(hostDriverMajor int, hostCUDAVersion string) bool {
+// This is done by comparing the host CUDA version with the CUDA version
+// specified in the ELF header.
+func (h *compatElfHeader) UseCompat(hostCUDAVersion string) bool {
 	if h == nil {
 		return false
-	}
-
-	if hostDriverMajor != 0 && len(h.Driver) > 0 {
-		return slices.Contains(h.Driver, hostDriverMajor)
 	}
 
 	return h.CUDAVersion.UseCompat(hostCUDAVersion)

--- a/cmd/nvidia-cdi-hook/cudacompat/cudacompat.go
+++ b/cmd/nvidia-cdi-hook/cudacompat/cudacompat.go
@@ -177,23 +177,28 @@ func (m command) getContainerForwardCompatDir(containerRoot containerRoot, o *op
 }
 
 func (m command) useCompatLibraries(libcudaCompatPath string, hostDriverVersion string, hostCUDAVersion string) (bool, error) {
+	// If the host CUDA version is specified, we need to inspect the ELF header
+	// of the compat libraries in the container to determine whether these
+	// should be used.
+	if hostCUDAVersion != "" {
+		cudaCompatHeader, _ := GetCUDACompatElfHeader(libcudaCompatPath)
+		if cudaCompatHeader != nil {
+			return cudaCompatHeader.UseCompat(hostCUDAVersion), nil
+		}
+		// If we were unable to read the CUDA header, we do not use the compat
+		// libraries.
+		return false, nil
+	}
+
+	// If neither a host driver version nor a host CUDA version is specified,
+	// we don't use the CUDA compat libraries in the container.
+	if hostDriverVersion == "" {
+		return false, nil
+	}
+
 	driverMajor, err := extractMajorVersion(hostDriverVersion)
 	if err != nil {
 		return false, fmt.Errorf("failed to extract major version from %q: %v", hostDriverVersion, err)
-	}
-
-	// First check the ELF header. If this is present, we use the ELF header to
-	// determine whether the CUDA compat libraries in the container should be
-	// used.
-	cudaCompatHeader, _ := GetCUDACompatElfHeader(libcudaCompatPath)
-	if cudaCompatHeader != nil {
-		return cudaCompatHeader.UseCompat(driverMajor, hostCUDAVersion), nil
-	}
-
-	// If no CUDA Compat ELF header is available, and NO host driver version
-	// was specified, we don't use the CUDA compat libraries in the container.
-	if hostDriverVersion == "" {
-		return false, nil
 	}
 
 	compatDriverVersion := strings.TrimPrefix(filepath.Base(libcudaCompatPath), "libcuda.so.")


### PR DESCRIPTION
This change reverts the inspection of the libcuda.so ELF header on non-Tegra systems. The expectations around this need to be better defined as certain host-container version combinations (e.g. Host: `580.126.16`, Container: `580.82.07`) causes simple examples to fail if the container version is used.