### PR TITLE
WIP: Add sandbox mode

### DIFF
--- a/pkg/nvcdi/lib-sandbox.go
+++ b/pkg/nvcdi/lib-sandbox.go
@@ -1,0 +1,56 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package nvcdi
+
+import (
+	"fmt"
+
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
+)
+
+type sandboxlib struct {
+	*nvcdilib
+	emptyDeviceSpecGenerator
+}
+
+var _ deviceSpecGeneratorFactory = (*sandboxlib)(nil)
+
+func (l *sandboxlib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
+	return l, nil
+}
+
+func (l *sandboxlib) GetCommonEdits() (*cdi.ContainerEdits, error) {
+	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(l.logger, l.driver, l.hookCreator)
+	if err != nil {
+		l.logger.Warningf("failed to create discoverer for graphics mounts: %v", err)
+	}
+
+	driver, err := l.newDriverVersionDiscoverer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create driver library discoverer: %v", err)
+	}
+
+	edits, err := l.editsFactory.FromDiscoverer(discover.Merge(graphicsMounts, driver))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create edits from discoverer: %v", err)
+	}
+
+	return edits, nil
+}

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -89,6 +89,11 @@ func New(opts ...Option) (Interface, error) {
 			nvcdilib: l,
 			mode:     o.mode,
 		}
+	case ModeSandbox:
+		factory = &sandboxlib{
+			nvcdilib:                 l,
+			emptyDeviceSpecGenerator: "all",
+		}
 	case ModeImex:
 		factory = (*imexlib)(l)
 	default:

--- a/pkg/nvcdi/mode.go
+++ b/pkg/nvcdi/mode.go
@@ -46,6 +46,8 @@ const (
 	ModeImex = Mode("imex")
 	// ModeNvswitch configures the CDI spec generator to generate a spec for the available nvswitch devices.
 	ModeNvswitch = Mode("nvswitch")
+	// ModeSandbox
+	ModeSandbox = Mode("sandbox")
 )
 
 type modeConstraint interface {
@@ -72,6 +74,7 @@ func getModes() modes {
 			ModeMofed,
 			ModeNvml,
 			ModeNvswitch,
+			ModeSandbox,
 			ModeWsl,
 		}
 		lookup := make(map[Mode]bool)

--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -126,6 +126,11 @@ func populateOptions(opts ...Option) *options {
 		)
 	}
 
+	if o.mode == ModeSandbox {
+		// For sandbox mode we explicitly disable all hooks.
+		o.disabledHooks = append(o.disabledHooks, AllHooks)
+	}
+
 	return o
 }
 


### PR DESCRIPTION
For example:
```
$ ./nvidia-ctk cdi generate --mode=nvml 2>/dev/null | grep hostPath
        - hostPath: /run/nvidia-persistenced/socket
        - hostPath: /usr/bin/nvidia-cuda-mps-control
        - hostPath: /usr/bin/nvidia-cuda-mps-server
        - hostPath: /usr/bin/nvidia-debugdump
        - hostPath: /usr/bin/nvidia-persistenced
        - hostPath: /usr/bin/nvidia-smi
        - hostPath: /etc/vulkan/icd.d/nvidia_icd.json
        - hostPath: /etc/vulkan/implicit_layer.d/nvidia_layers.json
        - hostPath: /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libGLESv1_CM_nvidia.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libGLESv2_nvidia.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libcuda.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libcudadebugger.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvcuvid.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-egl-gbm.so.1.1.3
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland.so.1.1.20
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-eglcore.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-encode.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-fbc.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-glsi.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-glvkspirv.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-gpucomp.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-gtk2.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-gtk3.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-ngx.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11-openssl3.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-present.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-rtcore.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-sandboxutils.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-tls.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-vksc-core.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-wayland-client.so.580.126.09
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvoptix.so.580.126.09
        - hostPath: /usr/share/nvidia/nvoptix.bin
        - hostPath: /lib/firmware/nvidia/580.126.09/gsp_ga10x.bin
        - hostPath: /lib/firmware/nvidia/580.126.09/gsp_tu10x.bin
        - hostPath: /usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.580.126.09
        - hostPath: /usr/share/X11/xorg.conf.d/nvidia-drm-outputclass.conf
        - hostPath: /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
        - hostPath: /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
        - hostPath: /usr/share/glvnd/egl_vendor.d/10_nvidia.json
        - hostPath: /usr/lib/xorg/modules/drivers/nvidia_drv.so
        - hostPath: /usr/lib/xorg/modules/extensions/libglxserver_nvidia.so.580.126.09
```