### PR TITLE
fix: Remove dependency on multi-user.target

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -17,7 +17,6 @@ Description=Refresh NVIDIA CDI specification file
 ConditionPathExists=|/usr/bin/nvidia-smi
 ConditionPathExists=|/usr/sbin/nvidia-smi
 ConditionPathExists=/usr/bin/nvidia-ctk
-After=multi-user.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This change removes the dependency of the nvidia-cdi-refresh.service on the multi-user.target. Although this worked for some cases, it is too narrow to be generally applicable. Users with more complex configurations should define their own dependencies on the nvidia-cdi-refresh.service to ensure that CDI spec generation is triggered at the correct time during system boot.

Fixes #1735