### PR TITLE
Add libnvidia-egl-wayland2 to the graphics discoverer

### DIFF
--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -63,6 +63,7 @@ func NewGraphicsMountsDiscoverer(logger logger.Interface, driver *root.Driver, h
 			"glvnd/egl_vendor.d/10_nvidia.json",
 			"egl/egl_external_platform.d/15_nvidia_gbm.json",
 			"egl/egl_external_platform.d/10_nvidia_wayland.json",
+			"egl/egl_external_platform.d/09_nvidia_wayland2.json",
 			"nvidia/nvoptix.bin",
 			"X11/xorg.conf.d/10-nvidia.conf",
 			"X11/xorg.conf.d/nvidia-drm-outputclass.conf",
@@ -134,6 +135,7 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 			// have the RM version. Use the *.* pattern to match X.Y.Z versions.
 			"libnvidia-egl-gbm.so.*.*",
 			"libnvidia-egl-wayland.so.*.*",
+			"libnvidia-egl-wayland2.so.*.*",
 			// We include the following libraries to have them available for
 			// symlink creation below:
 			// If CDI injection is used, these should already be detected as:


### PR DESCRIPTION
Closes #1747 

### Testing

On a system with the NVIDIA driver installed:
```
$ sudo apt-get install libnvidia-egl-wayland21

$ ls -ltr /usr/lib/x86_64-linux-gnu/*egl-wayland2*
-rw-r--r-- 1 root root 89560 Mar  7 09:10 /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland2.so.1.0.1
lrwxrwxrwx 1 root root    31 Mar  7 09:10 /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland2.so.1 -> libnvidia-egl-wayland2.so.1.0.1

$ ls -ltr /usr/share/egl/egl_external_platform.d/*wayland2*
total 20
-rw-r--r-- 1 root root 116 Mar  6 16:07 09_nvidia_wayland2.json

$ ./nvidia-ctk cdi generate --output nvidia.yaml

$ cat nvidia.yaml
. . .
- hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland2.so.1.0.1
          containerPath: /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland2.so.1.0.1
          options:
            - ro
            - nosuid
            - nodev
            - rbind
            - rprivate
. . .
- hostPath: /usr/share/egl/egl_external_platform.d/09_nvidia_wayland2.json
          containerPath: /usr/share/egl/egl_external_platform.d/09_nvidia_wayland2.json
          options:
            - ro
            - nosuid
            - nodev
            - rbind
            - rprivate
. . .
```