### PR TITLE
[NRI Plugin] get low-level runtime bin paths from previous install

### DIFF
--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -273,7 +273,19 @@ func (a *app) Run(ctx context.Context, c *cli.Command, o *options) error {
 
 	runtimeConfigurer := runtime.NewConfigurer(o.runtime, o.noRuntimeConfig, o.enableNRIPlugin)
 
-	if len(o.toolkitOptions.ContainerRuntimeRuntimes) == 0 {
+	if o.enableNRIPlugin {
+		// When NRI Plugin is enabled, the toolkit no longer interacts with the cri-o/containerd runtime config TOML and
+		// therefore can no longer source the list of low-level runtime binary paths used by the container runtime.
+		// This becomes an issue when migrating from non-NRI to NRI where the low-level runtime binary path previously
+		// referenced is still needed after enabling the NRI Plugin mode. To do this, we retrieve the toolkit config
+		// object from the previous toolkit install run and fetch the list of low-level runtimes used then to retain the context.
+		toolkitCfg, err := a.toolkit.GetInstalledConfig()
+		if err != nil {
+			a.logger.Warnf("failed to get installed toolkit config: %v", err)
+		} else {
+			o.toolkitOptions.ContainerRuntimeRuntimes = toolkitCfg.NVIDIAContainerRuntimeConfig.Runtimes
+		}
+	} else if len(o.toolkitOptions.ContainerRuntimeRuntimes) == 0 {
 		lowlevelRuntimePaths, err := runtimeConfigurer.GetLowlevelRuntimePaths(&o.runtimeOptions)
 		if err != nil {
 			return fmt.Errorf("unable to determine runtime options: %w", err)

--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
@@ -39,8 +39,6 @@ type executable struct {
 }
 
 func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, error) {
-	configFilePath := t.ConfigFilePath(destDir)
-
 	executables := []executable{
 		{
 			path: "nvidia-ctk",
@@ -49,6 +47,9 @@ func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, erro
 			path: "nvidia-cdi-hook",
 		},
 	}
+
+	configFilePath := filepath.Join(destDir, ".config", "nvidia-container-runtime", "config.toml")
+
 	for _, runtime := range operator.GetRuntimes() {
 		e := executable{
 			path:                 runtime.Path,

--- a/cmd/nvidia-ctk-installer/toolkit/installer/installer.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/installer.go
@@ -100,11 +100,6 @@ func (t *ToolkitInstaller) Install(destDir string) error {
 	return errs
 }
 
-func (t *ToolkitInstaller) ConfigFilePath(destDir string) string {
-	toolkitConfigDir := filepath.Join(destDir, ".config", "nvidia-container-runtime")
-	return filepath.Join(toolkitConfigDir, "config.toml")
-}
-
 type symlink struct {
 	linkname string
 	target   string

--- a/cmd/nvidia-ctk-installer/toolkit/toolkit.go
+++ b/cmd/nvidia-ctk-installer/toolkit/toolkit.go
@@ -219,6 +219,8 @@ type Installer struct {
 	sourceRoot string
 	// toolkitRoot specifies the destination path at which the toolkit is installed.
 	toolkitRoot string
+	// toolkitConfigFilePath specifies the file path of toolkit config file. It is derived from toolkitRoot.
+	toolkitConfigFilePath string
 }
 
 // NewInstaller creates an installer for the NVIDIA Container Toolkit.
@@ -230,6 +232,10 @@ func NewInstaller(opts ...Option) *Installer {
 
 	if i.logger == nil {
 		i.logger = logger.New()
+	}
+
+	if len(i.toolkitRoot) > 0 {
+		i.toolkitConfigFilePath = filepath.Join(i.toolkitRoot, ".config", "nvidia-container-runtime", "config.toml")
 	}
 
 	return i
@@ -332,7 +338,7 @@ func (t *Installer) Install(cli *cli.Command, opts *Options, runtime string) err
 		t.logger.Errorf("Ignoring error: %v", fmt.Errorf("could not install toolkit components: %w", err))
 	}
 
-	err = t.installToolkitConfig(cli, opts, toolkit.ConfigFilePath(t.toolkitRoot))
+	err = t.installToolkitConfig(cli, opts)
 	if err != nil && !opts.ignoreErrors {
 		return fmt.Errorf("error installing NVIDIA container toolkit config: %v", err)
 	} else if err != nil {
@@ -357,9 +363,21 @@ func (t *Installer) Install(cli *cli.Command, opts *Options, runtime string) err
 	return nil
 }
 
+func (t *Installer) GetInstalledConfig() (*config.Config, error) {
+	cfg, err := config.New(
+		config.WithConfigFile(t.toolkitConfigFilePath),
+		config.WithRequired(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error loading installed toolkit config file: %w", err)
+	}
+	return cfg.Config()
+}
+
 // installToolkitConfig installs the config file for the NVIDIA container toolkit ensuring
 // that the settings are updated to match the desired install and nvidia driver directories.
-func (t *Installer) installToolkitConfig(c *cli.Command, opts *Options, toolkitConfigPath string) error {
+func (t *Installer) installToolkitConfig(c *cli.Command, opts *Options) error {
+	toolkitConfigPath := t.toolkitConfigFilePath
 
 	t.logger.Infof("Installing NVIDIA container toolkit config '%v'", toolkitConfigPath)
 


### PR DESCRIPTION
This PR fixes the "nvidia-operator-validator pod stuck indefinitely in Terminating" issue observed in clusters that use `cri-o + crun`

### Problem

The toolkit by default sources a list of the absolute paths of low-level runtime binaries from the containerd/crio runtime config TOML file. This list is then prepended to the `runtimes= ["runc", "crun"]` list in the toolkit's config TOML file. Through this method, the toolkit binds the `nvidia-container-runtime` wrapper script to the correct low-level runtime binary. With the switch to the NRI Plugin mode, the toolkit no longer reads from the containerd/crio runtime config TOML file, so it does not have a way to inject the correct low-level runtime binary to the `nvidia-container-runtime` wrapper script. As a result, pods that were created with the `nvidia-container-runtime` bound to the low-level-runtime binary (sourced from the container runtime config TOML) before NRI Plugin enablement cannot be deleted afterwards as the wrapper-script just binds to `runc` instead (taken from the default list `runtimes = ["runc", "crun"]`. This discrepancy in `nvidia-container-runtime` before and after NRI Plugin enablement causes the `KillContainer` functions performed by the container runtime to fail leaving the pod stuck in Terminating permanently

### Solution

When NRI Plugin is enabled, we turn to the toolkit config toml file installed prior to the NRI plugin enablement. This way, we retrieve the list of low-level runtime binary paths used previously. This way, the toolkit is able to successfully terminate the containers that were created with`nvidia-container-runtime` and pointing to the correct low-level runtime binary in doing so. This unblocks migration from non-NRI to NRI plugin mode on an existing cluster
