### PR TITLE
fix systemd unit conditions to work on WSL2

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -16,6 +16,7 @@
 Description=Refresh NVIDIA CDI specification file
 ConditionPathExists=|/usr/bin/nvidia-smi
 ConditionPathExists=|/usr/sbin/nvidia-smi
+ConditionPathExists=|/usr/lib/wsl/lib/nvidia-smi
 ConditionPathExists=/usr/bin/nvidia-ctk
 
 [Service]
@@ -23,7 +24,7 @@ Type=oneshot
 # Values from Environment will be replaced if defined in EnvironmentFile
 Environment=NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml
 EnvironmentFile=-/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
-ExecCondition=/usr/bin/grep -qE '/(nvidia|nvidia-current)\\.ko' /lib/modules/%v/modules.dep
+ExecCondition=/bin/sh -c '/usr/bin/grep -qE "/(nvidia|nvidia-current)[.]ko" /lib/modules/%v/modules.dep || [ -e /dev/dxg ]'
 ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
 


### PR DESCRIPTION
On WSL2, nvidia-smi lives at /usr/lib/wsl/lib/nvidia-smi rather than /usr/bin or /usr/sbin, and the NVIDIA kernel modules (nvidia.ko / nvidia-current.ko) are not present since GPU access goes through the DirectX Graphics infrastructure (/dev/dxg).

Add /usr/lib/wsl/lib/nvidia-smi as a third OR ConditionPathExists and extend ExecCondition to succeed when /dev/dxg exists so the service runs on WSL2 without breaking the check on standard driver installs.