### PR TITLE
feat(nvcdi): Allow IPC sockets to not be discovered.

### DIFF
--- a/pkg/nvcdi/api.go
+++ b/pkg/nvcdi/api.go
@@ -96,4 +96,8 @@ const (
 	// FeatureNoAdditionalGIDsForDeviceNodes disables the injection of additional GIDs
 	// for a device node when the node is not readable and writable by the user.
 	FeatureNoAdditionalGIDsForDeviceNodes = FeatureFlag("no-additional-gids-for-device-nodes")
+
+	// FeatureDisableIPCDiscoverer disables the inclusion of IPC sockets
+	// (nvidia-persistenced, nvidia-fabricmanager, MPS) in the CDI spec.
+	FeatureDisableIPCDiscoverer = FeatureFlag("disable-ipc-discoverer")
 )

--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -51,7 +51,7 @@ func (l *nvcdilib) newDriverVersionDiscoverer() (discover.Discover, error) {
 		return nil, fmt.Errorf("failed to create discoverer for driver libraries: %v", err)
 	}
 
-	ipcs, err := discover.NewIPCDiscoverer(l.logger, l.driver.Root)
+	ipcs, err := l.newIPCDiscoverer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for IPC sockets: %v", err)
 	}
@@ -71,6 +71,13 @@ func (l *nvcdilib) newDriverVersionDiscoverer() (discover.Discover, error) {
 	)
 
 	return d, nil
+}
+
+func (l *nvcdilib) newIPCDiscoverer() (discover.Discover, error) {
+	if l.featureFlags[FeatureDisableIPCDiscoverer] {
+		return nil, nil
+	}
+	return discover.NewIPCDiscoverer(l.logger, l.driver.Root)
 }
 
 // NewDriverLibraryDiscoverer creates a discoverer for the libraries associated with the specified driver version.


### PR DESCRIPTION
There are cases we are dealing with where the containers should not have access to any NVIDIA IPC sockets like fabricmanager/persistenced. We want the ability to disable this.

This commit adds a feature flag `disable-ipc-discoverer` that if provided will cause the IPC discoverer.Discoverer to be nil. Ultimately, this is needed so that the CDI spec file generated by k8s-device-plugin does not include these sockets.