### PR TITLE
[tests/e2e] reduce requirements to run 'test-preinstalled' make target

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -77,16 +77,16 @@ var _ = BeforeSuite(func() {
 
 	localCacheDir = strings.TrimSpace(tmpdir)
 
-	toolkitInstaller, err = NewToolkitInstaller(
-		WithToolkitImage(nvidiaContainerToolkitImage),
-		WithCacheDir(localCacheDir),
-	)
-	Expect(err).ToNot(HaveOccurred())
-
-	_, _, err = toolkitInstaller.PrepareCache(runner)
-	Expect(err).ToNot(HaveOccurred())
-
 	if installCTK {
+		toolkitInstaller, err = NewToolkitInstaller(
+			WithToolkitImage(nvidiaContainerToolkitImage),
+			WithCacheDir(localCacheDir),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, _, err = toolkitInstaller.PrepareCache(runner)
+		Expect(err).ToNot(HaveOccurred())
+
 		_, _, err := toolkitInstaller.Install(runner)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -104,9 +104,11 @@ func getTestEnv() {
 
 	installCTK = getEnvVarOrDefault("E2E_INSTALL_CTK", false)
 
-	imageName := getRequiredEnvvar[string]("E2E_IMAGE_NAME")
-	imageTag := getRequiredEnvvar[string]("E2E_IMAGE_TAG")
-	nvidiaContainerToolkitImage = imageName + ":" + imageTag
+	if installCTK {
+		imageName := getRequiredEnvvar[string]("E2E_IMAGE_NAME")
+		imageTag := getRequiredEnvvar[string]("E2E_IMAGE_TAG")
+		nvidiaContainerToolkitImage = imageName + ":" + imageTag
+	}
 
 	sshHost = getEnvVarOrDefault("E2E_SSH_HOST", "")
 	if sshHost != "" {


### PR DESCRIPTION
Prior to this commit, it was required to define the E2E_IMAGE_NAME and E2E_IMAGE_TAG variables when invoking the 'test-preinstalled' make target even though they are never used. This commit removes this requirement to reduce friction when running e2e tests locally.