### PR TITLE
[no-relnote] fix e2e failures for nvidia-container-cli test cases

### DIFF
--- a/tests/e2e/runner.go
+++ b/tests/e2e/runner.go
@@ -29,12 +29,23 @@ import (
 )
 
 const (
+	// Newer versions of Ubuntu container images (starting with 26.04)
+	// introduced changes that broke nvidia-container-cli tests.
+	// In particular, the libcap shared library, the pivot_root binary,
+	// and /sbin/ldconfig.real are not included by default. This differs
+	// from prior releases. To account for this and fix the test failures,
+	// the libcap2 and utils-linux-extra (provided pivot_root) packages
+	// have been added as prerequisites. In addition, /sbin/ldconfig.real
+	// is made a symlink to /sbin/ldconfig if it doesn't exist.
 	installPrerequisitesScript = `
 set -e
 export DEBIAN_FRONTEND=noninteractive
 # Install prerequisites
 apt-get update
-apt-get install -y curl gnupg2
+apt-get install -y curl gnupg2 libcap2 util-linux-extra
+if [[ ! -f "/sbin/ldconfig.real" ]]; then
+    ln -s /sbin/ldconfig /sbin/ldconfig.real
+fi
 `
 )
 


### PR DESCRIPTION
Newer versions of Ubuntu container images (starting with 26.04) introduced changes that broke nvidia-container-cli tests. In particular, the libcap shared library, the pivot_root binary, and /sbin/ldconfig.real are not included by default. This differs from prior releases. To account for this and fix the test failures, the libcap2 and utils-linux-extra (provided pivot_root) packages have been added as prerequisites that get installed in the nested container runner used in our e2e tests. In addition, /sbin/ldconfig.real is made a symlink to /sbin/ldconfig if it doesn't exist.

The nvidia-container-cli tests create a nested container runner [here](https://github.com/NVIDIA/nvidia-container-toolkit/blob/c702a769c2b80f3ff0c1afc19e7feb3e1b116254/tests/e2e/nvidia-container-cli_test.go#L81) with the `ubuntu` image. I suspect the e2e tests started failing on main once `ubuntu:latest` started corresponding to `ubuntu:26.04`. Note the differences below between the `ubuntu:24.04` and `ubuntu:26.04` images.

```
$ docker run --rm -it ubuntu:24.04
root@587a8a3b954e:/# dpkg -l | grep libcap
ii  libcap-ng0:amd64        0.8.4-2build2                amd64        alternate POSIX capabilities library
ii  libcap2:amd64           1:2.66-5ubuntu2.2            amd64        POSIX 1003.1e capabilities (library)
root@587a8a3b954e:/# ls -ltr /sbin/ldconfig*
-rwxr-xr-x 1 root root 1051280 Jan 30 08:27 /sbin/ldconfig.real
-rwxr-xr-x 1 root root     387 Jan 30 08:27 /sbin/ldconfig
root@587a8a3b954e:/# which pivot_root
/usr/sbin/pivot_root
```

```
$ docker run --rm -it ubuntu:26.04
root@d113cb089dcc:/# dpkg -l | grep libcap
ii  libcap-ng0:amd64               0.8.5-4build5                    amd64        alternate POSIX capabilities library
root@d113cb089dcc:/# ls -ltr /sbin/ldconfig*
-rwxr-xr-x 1 root root 1083728 Mar 31 20:35 /sbin/ldconfig
root@d113cb089dcc:/# which pivot_root
root@d113cb089dcc:/#
```


Note, I have provisioned an Ubuntu 26.04 system and see both libcap2 and utils-linux-extra come by default with a standard ISO. I do notice that only `/sbin/ldconfig` exists (and not `/sbin/ldconfig.real`), but this does not cause any issues. I installed the NVIDIA Container Toolkit using our documentation, and `[nvidia-container-cli.ldconfig]` correctly gets set to `@/sbin/ldconfig` in `/etc/nvidia-container-runtime/config.toml`. I am able to run GPU containers without any issue (even when I force that the legacy nvidia-container-runtime-hook gets used).