### PR TITLE
Update systemd unit conditions to execute nvidia-smi and re-add restart logic

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -18,6 +18,9 @@ ConditionPathExists=|/usr/bin/nvidia-smi
 ConditionPathExists=|/usr/sbin/nvidia-smi
 ConditionPathExists=|/usr/lib/wsl/lib/nvidia-smi
 ConditionPathExists=/usr/bin/nvidia-ctk
+# Limit the number of successive restarts to 5 in 10 seconds.
+StartLimitBurst=5
+StartLimitIntervalSec=10s
 
 [Service]
 Type=oneshot
@@ -28,6 +31,10 @@ ExecCondition=/bin/sh -c '/usr/bin/grep -qE "/(nvidia|nvidia-current)[.]ko" /lib
 ExecCondition=/bin/sh -c '/usr/bin/nvidia-smi -L || /usr/sbin/nvidia-smi -L || /usr/lib/wsl/lib/nvidia-smi -L'
 ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
+# We set the service to restart on failure to ensure that a CDI spec is
+# eventually generated.
+Restart=on-failure
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target

--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -25,6 +25,7 @@ Type=oneshot
 Environment=NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml
 EnvironmentFile=-/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
 ExecCondition=/bin/sh -c '/usr/bin/grep -qE "/(nvidia|nvidia-current)[.]ko" /lib/modules/%v/modules.dep || [ -e /dev/dxg ]'
+ExecCondition=/bin/sh -c '/usr/bin/nvidia-smi -L || /usr/sbin/nvidia-smi -L || /usr/lib/wsl/lib/nvidia-smi -L'
 ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
 


### PR DESCRIPTION
This ensures that the nvidia-cdi-refresh.service does not start until after the driver is loaded and available. The added benefit of running nvidia-smi is that it will load the module (if not already loaded) and create the device nodes (if not already created).

This PR also re-introduces the restart logic which was removed in https://github.com/NVIDIA/nvidia-container-toolkit/commit/5fe6b42eab11f144866de07df4f755845c4b94cf. Without the restart logic, it is possible that our service gets started too early in the boot process and executing "nvidia-smi" fails. With retries, the "nvidia-smi" invocation should eventually succeed, allowing us to generate a CDI spec.

Note, re-introducing the restart logic in the systemd service means we should re-open https://github.com/NVIDIA/nvidia-container-toolkit/issues/1624. I believe there are ways to address the use case in #1624 while still keeping the restart logic -- 1) Reducing the logs emitted by `nvidia-ctk cdi generate` and/or 2) Updating `nvidia-ctk cdi generate` to exit early with a zero exit code if no GPUs are detected on the system.