### PR TITLE
[cri-o config] fix drop-in config directory used for config overrides

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/crio/crio.go
@@ -47,7 +47,7 @@ const (
 
 	// Config-based settings
 	DefaultConfig       = "/etc/crio/crio.conf"
-	DefaultDropInConfig = "/etc/crio/conf.d/99-nvidia.toml"
+	DefaultDropInConfig = "/etc/crio/crio.conf.d/99-nvidia.toml"
 
 	DefaultSocket      = "/var/run/crio/crio.sock"
 	DefaultRestartMode = "systemd"

--- a/cmd/nvidia-ctk/runtime/configure/configure.go
+++ b/cmd/nvidia-ctk/runtime/configure/configure.go
@@ -47,7 +47,7 @@ const (
 	defaultDockerConfigFilePath     = "/etc/docker/daemon.json"
 
 	defaultContainerdDropInConfigFilePath = "/etc/containerd/conf.d/99-nvidia.toml"
-	defaultCrioDropInConfigFilePath       = "/etc/crio/conf.d/99-nvidia.toml"
+	defaultCrioDropInConfigFilePath       = "/etc/crio/crio.conf.d/99-nvidia.toml"
 
 	defaultConfigSource = configSourceFile
 	configSourceCommand = "command"


### PR DESCRIPTION
As per the official CRI-O [documentation](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.d.5.md#configuration-precedence), the cri-o runtime configuration overrides via drop-in files only work if they are placed under the `/etc/crio/crio.conf.d` directory. The current default drop-in config directory `/etc/crio/conf.d` will not be recognised by CRI-O and therefore, the configs will not be applied