### PR TITLE
Add no-disable-device-node-modification-hook nvcdi feature flag

### DIFF
--- a/pkg/nvcdi/api.go
+++ b/pkg/nvcdi/api.go
@@ -100,4 +100,8 @@ const (
 	// FeatureDisableIPCDiscoverer disables the inclusion of IPC sockets
 	// (nvidia-persistenced, nvidia-fabricmanager, MPS) in the CDI spec.
 	FeatureDisableIPCDiscoverer = FeatureFlag("disable-ipc-discoverer")
+
+	// FeatureNoDisableDeviceNodeModificationHook disables the
+	// disable-device-node-modification CDI hook.
+	FeatureNoDisableDeviceNodeModificationHook = FeatureFlag("no-disable-device-node-modification-hook")
 )

--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -119,6 +119,10 @@ func populateOptions(opts ...Option) *options {
 		o.disabledHooks = append(o.disabledHooks, HookEnableCudaCompat, DisableDeviceNodeModificationHook)
 	}
 
+	if o.featureFlags[FeatureNoDisableDeviceNodeModificationHook] {
+		o.disabledHooks = append(o.disabledHooks, DisableDeviceNodeModificationHook)
+	}
+
 	if o.editsFactory == nil {
 		o.editsFactory = edits.NewFactory(
 			edits.WithLogger(o.logger),


### PR DESCRIPTION
The `disable-device-node-modification` CDI hook bind-mounts a tmpfs file over `/proc/driver/nvidia/params` inside the container. With `procMount: Unmasked` (Kubernetes 1.34+), that overmount makes the kernel's `mount_too_revealing()` check reject any subsequent fresh procfs mount from a less-privileged namespace — for example a nested user namespace created by bubblewrap. Workloads that sandbox themselves inside a GPU container can no longer mount procfs:

```
bwrap: Can't mount proc on /newroot/proc: Operation not permitted
```

The hook can be skipped in static `cdi` mode via `nvidia-ctk cdi generate --disable-hooks`, but `jit-cdi` mode (the default since 1.18.0) has no way to suppress an individual hook.

Setting `NVreg_ModifyDeviceFiles=0` on the host (which the hook short-circuits on) is not viable on systems with NVSwitch: fabricmanager fails to initialize with `NV_ERR_INVALID_STATE` when the parameter is set, even with device nodes pre-created via udev or `mknod`. (Tested on H100 SXM with driver 570.195.03 — `/dev/nvidia*` and `/dev/nvidia-nvswitch*` device files were all present and correct, but `nv-fabricmanager` still returned `request to acquire required privileges to access NVSwitch devices failed`.)

This adds a `nvcdi` feature flag, following the `no-additional-gids-for-device-nodes` naming pattern, that suppresses the hook:

```toml
[nvidia-container-runtime.modes.jit-cdi]
nvcdi-feature-flags = ["no-disable-device-node-modification-hook"]
```

The hook's purpose is to prevent in-container `nvidia-smi`/`libnvidia-ml` from creating extra `/dev/nvidiaN` device nodes (#927). That prevention is already enforced by cgroup device controls in container runtimes, so disabling the hook does not affect device isolation in those environments. Because the hook does provide defense-in-depth where cgroup enforcement is absent or misconfigured, the flag is opt-in and off by default.

### Verification

On a Kubernetes 1.34 node with the patched runtime and the flag enabled, a pod with `procMount: Unmasked`:

- `/proc/self/mountinfo` shows no submount under `/proc/driver/nvidia` (the hook never ran)
- `/proc/driver/nvidia/params` reads the host's real value (`ModifyDeviceFiles: 1`)
- `bwrap --unshare-all --bind / / --proc /proc --dev /dev /bin/true` succeeds
- `nvidia-smi -L` returns the allocated GPU
- fabricmanager and persistenced unaffected

Without the flag, the same pod sees the hook's overmount and `bwrap` fails with `Operation not permitted`.

(Open to a different name if `no-disable-` reads too awkwardly — the inner hook name's `disable-` prefix makes most options collide.)