### PR TITLE
docs: fix README and test comment typos

### DIFF
--- a/cmd/nvidia-ctk/README.md
+++ b/cmd/nvidia-ctk/README.md
@@ -67,7 +67,7 @@ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 ```
 (Note that `sudo` is used to ensure the correct permissions to write to the `/etc/cdi` folder)
 
-With the specification generated, a GPU can be requested by specifying the fully-qualified CDI device name. With `podman` as an exmaple:
+With the specification generated, a GPU can be requested by specifying the fully-qualified CDI device name. With `podman` as an example:
 ```bash
 podman run --rm -ti --device=nvidia.com/gpu=gpu0 ubuntu nvidia-smi -L
 ```

--- a/tests/e2e/runner.go
+++ b/tests/e2e/runner.go
@@ -275,7 +275,7 @@ func (r remoteRunner) Run(script string) (string, string, error) {
 	return stdout.String(), "", nil
 }
 
-// Run runs teh specified script in the container using the docker exec command.
+// Run runs the specified script in the container using the docker exec command.
 // The script is is run as the root user.
 func (r nestedContainerRunner) Run(script string) (string, string, error) {
 	return r.runner.Run(`docker exec -u root "` + r.containerName + `" bash -c '` + script + `'`)


### PR DESCRIPTION
## Summary

Fixes two spelling typos in README text and an e2e test runner comment.

## Files changed

- `cmd/nvidia-ctk/README.md`: `exmaple` -> `example`
- `tests/e2e/runner.go`: `teh` -> `the`

## Before / after

Before, the README and test comment contained spelling typos. After, the text is corrected with no behavior change.

## Verification

- Inspected the diff to confirm these are README/comment-only changes.
- Ran `rg "teh specified script|exmaple" tests/e2e/runner.go cmd/nvidia-ctk/README.md` and confirmed no matches.
- Did not run runtime tests because this does not change executable behavior.

## Competing PR check

Checked for existing PRs with:

- `gh pr list --repo NVIDIA/nvidia-container-toolkit --search "Run runs teh specified script" --state all --limit 10`
- `gh pr list --repo NVIDIA/nvidia-container-toolkit --search "podman as an exmaple" --state all --limit 10`

No matching PRs were returned.