### PR TITLE
[no-relnote] Update artifactory URL used in internal CI pipelines

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -38,7 +38,7 @@ variables:
   # Define the public staging registry
   STAGING_REGISTRY: ghcr.io/nvidia
   STAGING_VERSION: ${CI_COMMIT_SHORT_SHA}
-  ARTIFACTORY_REPO_BASE: "https://urm.nvidia.com/artifactory/sw-gpu-cloudnative"
+  ARTIFACTORY_REPO_BASE: "${ARTIFACTORY_ROOT_URL}/artifactory/sw-gpu-cloudnative"
   KITMAKER_RELEASE_FOLDER: "kitmaker"
   PACKAGE_ARCHIVE_RELEASE_FOLDER: "releases"
 


### PR DESCRIPTION
The root Artifactory URL has changed. This commit hides the URL behind a CI/CD variable and updates the location to the new one.