### PR TITLE
fix failing test in TestGlobFiles

### DIFF
--- a/cmd/nvidia-cdi-hook/cudacompat/container-root_test.go
+++ b/cmd/nvidia-cdi-hook/cudacompat/container-root_test.go
@@ -507,7 +507,7 @@ func TestGlobFiles(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expected, got)
+			require.ElementsMatch(t, tc.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
This commit addresses a unit test failure observed in the "multiple matches" scenario where the expected and actual arrays match but don't have the same order. We fix this by only requiring that the elements in the slice match regardless of the order.