### PR TITLE
Add ability to disable CDI hooks in jit-cdi mode

### DIFF
--- a/api/config/v1/runtime.go
+++ b/api/config/v1/runtime.go
@@ -49,6 +49,8 @@ type cdiModeConfig struct {
 type jitCDIModeConfig struct {
 	// NVCDIFeatureFlags sets a list of nvcdi features explicitly.
 	NVCDIFeatureFlags []nvcdi.FeatureFlag `toml:"nvcdi-feature-flags,omitempty"`
+	// NVCDIDisableHooks sets a list of nvcdi hooks to disable
+	NVCDIDisableHooks []nvcdi.HookName `toml:"nvcdi-disable-hooks,omitempty"`
 }
 
 type csvModeConfig struct {

--- a/internal/modifier/cdi.go
+++ b/internal/modifier/cdi.go
@@ -199,6 +199,7 @@ func (f *Factory) newAutomaticCDISpecModifier(devices []string) (oci.SpecModifie
 			nvcdi.WithFeatureFlags(f.cfg.NVIDIAContainerRuntimeConfig.Modes.JitCDI.NVCDIFeatureFlags...),
 			nvcdi.WithCSVCompatContainerRoot(f.cfg.NVIDIAContainerRuntimeConfig.Modes.CSV.CompatContainerRoot),
 			nvcdi.WithCSVFiles(csvFiles),
+			nvcdi.WithDisabledHooks(f.cfg.NVIDIAContainerRuntimeConfig.Modes.JitCDI.NVCDIDisableHooks...),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct CDI library for mode %q: %w", mode, err)


### PR DESCRIPTION
The nvcdi package has a [disabledHooks](https://github.com/NVIDIA/nvidia-container-toolkit/blob/79477c95de6312792dddc3c1905bbb4d2d68685a/pkg/nvcdi/options.go#L54) option for disabling CDI hooks. The `nvidia-ctk cdi generate` CLI exposes this option via a `--disable-hooks` flag.

This PR adds the ability to disable CDI hooks in the CDI spec that gets generated by `nvidia-container-runtime` when it runs in `jit-cdi` mode.

### Testing
```
$ grep -A1 "nvidia-container-runtime.modes.jit-cdi" /etc/nvidia-container-runtime/config.toml
[nvidia-container-runtime.modes.jit-cdi]
nvcdi-disable-hooks = ["disable-device-node-modification"]

$ docker run -it --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all ubuntu /bin/bash -c "grep 'ModifyDeviceFile' /proc/driver/nvidia/params"
ModifyDeviceFiles: 1

$ sudo sed -i 's/nvcdi-disable-hooks/#nvcdi-disable-hooks/' /etc/nvidia-container-runtime/config.toml

$ docker run -it --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all ubuntu /bin/bash -c "grep 'ModifyDeviceFile' /proc/driver/nvidia/params"
ModifyDeviceFiles: 0
```