### PR TITLE
feat: drop `nvidia-cdi-hook` shell shim

### DIFF
--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
@@ -88,6 +88,13 @@ func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, erro
 			return nil, err
 		}
 
+		// do not create a shell wraper for nvidia-cdi-hook executable
+		if executable.path == "nvidia-cdi-hook" {
+			installers = append(installers, executableFile(executablePath))
+
+			continue
+		}
+
 		wrappedExecutableFilename := filepath.Base(executablePath)
 		dotRealFilename := wrappedExecutableFilename + ".real"
 
@@ -122,7 +129,17 @@ func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, erro
 	}
 
 	return installers, nil
+}
 
+// executableFile installs an executable directly, without a shell wrapper,
+// preserving its basename and mode.
+type executableFile string
+
+func (e executableFile) Install(destDir string) error {
+	dest := filepath.Join(destDir, filepath.Base(string(e)))
+	_, err := installFile(string(e), dest)
+
+	return err
 }
 
 type wrapper struct {
@@ -155,7 +172,7 @@ func (w *wrapper) Install(destDir string) error {
 		return fmt.Errorf("failed to render wrapper: %w", err)
 	}
 	wrapperFile := filepath.Join(destDir, filepath.Base(w.Source))
-	return installContent(content, wrapperFile, mode|0111)
+	return installContent(content, wrapperFile, mode|0o111)
 }
 
 func (w *render) render() (io.Reader, error) {

--- a/cmd/nvidia-ctk-installer/toolkit/installer/installer_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/installer_test.go
@@ -44,7 +44,7 @@ func TestToolkitInstaller(t *testing.T) {
 
 	installer := &fileInstallerMock{
 		installFileFunc: func(s1, s2 string) (os.FileMode, error) {
-			return 0666, nil
+			return 0o666, nil
 		},
 		installContentFunc: func(reader io.Reader, s string, fileMode fs.FileMode) error {
 			var b bytes.Buffer
@@ -143,7 +143,9 @@ func TestToolkitInstaller(t *testing.T) {
 			{"/artifacts/test/usr/bin/nvidia-container-runtime.legacy", "/foo/bar/baz/nvidia-container-runtime.legacy.real"},
 			{"/artifacts/test/usr/bin/nvidia-container-runtime", "/foo/bar/baz/nvidia-container-runtime.real"},
 			{"/artifacts/test/usr/bin/nvidia-ctk", "/foo/bar/baz/nvidia-ctk.real"},
-			{"/artifacts/test/usr/bin/nvidia-cdi-hook", "/foo/bar/baz/nvidia-cdi-hook.real"},
+			// nvidia-cdi-hook is installed unwrapped (as the real binary) so it can be
+			// executed by the container runtime as a CDI hook on hosts without /bin/sh.
+			{"/artifacts/test/usr/bin/nvidia-cdi-hook", "/foo/bar/baz/nvidia-cdi-hook"},
 			{"/artifacts/test/usr/bin/nvidia-container-cli", "/foo/bar/baz/nvidia-container-cli.real"},
 			{"/artifacts/test/usr/bin/nvidia-container-runtime-hook", "/foo/bar/baz/nvidia-container-runtime-hook.real"},
 		},
@@ -166,7 +168,7 @@ func TestToolkitInstaller(t *testing.T) {
 		[]contentCall{
 			{
 				path: "/foo/bar/baz/nvidia-container-runtime",
-				mode: 0777,
+				mode: 0o777,
 				wrapper: `#! /bin/sh
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
 if [ "${?}" != "0" ]; then
@@ -181,7 +183,7 @@ PATH=/foo/bar/baz:$PATH \
 			},
 			{
 				path: "/foo/bar/baz/nvidia-container-runtime.cdi",
-				mode: 0777,
+				mode: 0o777,
 				wrapper: `#! /bin/sh
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
 if [ "${?}" != "0" ]; then
@@ -196,7 +198,7 @@ PATH=/foo/bar/baz:$PATH \
 			},
 			{
 				path: "/foo/bar/baz/nvidia-container-runtime.legacy",
-				mode: 0777,
+				mode: 0o777,
 				wrapper: `#! /bin/sh
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
 if [ "${?}" != "0" ]; then
@@ -211,25 +213,18 @@ PATH=/foo/bar/baz:$PATH \
 			},
 			{
 				path: "/foo/bar/baz/nvidia-ctk",
-				mode: 0777,
+				mode: 0o777,
 				wrapper: `#! /bin/sh
 PATH=/foo/bar/baz:$PATH \
 	/foo/bar/baz/nvidia-ctk.real \
 		"$@"
 `,
 			},
-			{
-				path: "/foo/bar/baz/nvidia-cdi-hook",
-				mode: 0777,
-				wrapper: `#! /bin/sh
-PATH=/foo/bar/baz:$PATH \
-	/foo/bar/baz/nvidia-cdi-hook.real \
-		"$@"
-`,
-			},
+			// nvidia-cdi-hook is installed unwrapped, so no wrapper content is rendered
+			// for it (it does not appear in contentCalls).
 			{
 				path: "/foo/bar/baz/nvidia-container-cli",
-				mode: 0777,
+				mode: 0o777,
 				wrapper: `#! /bin/sh
 LD_LIBRARY_PATH=/foo/bar/baz:$LD_LIBRARY_PATH \
 PATH=/foo/bar/baz:$PATH \
@@ -239,7 +234,7 @@ PATH=/foo/bar/baz:$PATH \
 			},
 			{
 				path: "/foo/bar/baz/nvidia-container-runtime-hook",
-				mode: 0777,
+				mode: 0o777,
 				wrapper: `#! /bin/sh
 NVIDIA_CTK_CONFIG_FILE_PATH=/foo/bar/baz/.config/nvidia-container-runtime/config.toml \
 PATH=/foo/bar/baz:$PATH \

--- a/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
@@ -168,7 +168,9 @@ containerEdits:
 			requireSymlink(t, toolkitRoot, "libnvidia-container.so.1", "libnvidia-container.so.99.88.77")
 			requireSymlink(t, toolkitRoot, "libnvidia-container-go.so.1", "libnvidia-container-go.so.99.88.77")
 
-			requireWrappedExecutable(t, toolkitRoot, "nvidia-cdi-hook")
+			// nvidia-cdi-hook is installed unwrapped (as the real binary) so it can be
+			// run by the container runtime as a CDI hook on hosts without /bin/sh.
+			requireUnwrappedExecutable(t, toolkitRoot, "nvidia-cdi-hook")
 			requireWrappedExecutable(t, toolkitRoot, "nvidia-container-cli")
 			requireWrappedExecutable(t, toolkitRoot, "nvidia-container-runtime")
 			requireWrappedExecutable(t, toolkitRoot, "nvidia-container-runtime-hook")
@@ -216,6 +218,13 @@ containerEdits:
 func requireWrappedExecutable(t *testing.T, toolkitRoot string, expectedExecutable string) {
 	requireExecutable(t, toolkitRoot, expectedExecutable)
 	requireExecutable(t, toolkitRoot, expectedExecutable+".real")
+}
+
+// requireUnwrappedExecutable checks that the executable is installed directly as the
+// real binary, without a shell wrapper and without a .real-suffixed copy.
+func requireUnwrappedExecutable(t *testing.T, toolkitRoot string, expectedExecutable string) {
+	requireExecutable(t, toolkitRoot, expectedExecutable)
+	require.NoFileExists(t, filepath.Join(toolkitRoot, expectedExecutable+".real"))
 }
 
 func requireExecutable(t *testing.T, toolkitRoot string, expectedExecutable string) {


### PR DESCRIPTION
This PR drops the `nvidia-cdi-hook` shell shim that exec's `nvidia-cdi-hook.real`, the shim was not doing anything extra in this case as like the legacy shims.

This allows using toolkit installation on hosts that don't have a shell at all, when using NRI mode runc exec's `nvidia-cdi-hook`.

This is part of fixing upstream discussion at https://github.com/NVIDIA/gpu-operator/discussions/2385