### PR TITLE
import text/template instead of html/template

### DIFF
--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
@@ -20,10 +20,10 @@ package installer
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	log "github.com/sirupsen/logrus"
 


### PR DESCRIPTION
This commit replaces the "html/template" library with "text/template" as the former is not the right fit for the container-toolkit's use case. With "html/template" we face the risk of encountering bugs from HTML-escaping performed by "html/template"