### PR TITLE
Add libnvidia-nvvm70.so library to CDI spec

### DIFF
--- a/pkg/nvcdi/driver-nvml.go
+++ b/pkg/nvcdi/driver-nvml.go
@@ -81,6 +81,10 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string) (discover.Discover
 	if err != nil {
 		return nil, err
 	}
+	legacyNVVMLibraryMounts, err := l.getLegacyNVVMLibraryMounts()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get legacy nvvm library mounts: %w", err)
+	}
 	explicitLibraryMounts, err := l.getExplicitDriverLibraryMounts()
 	if err != nil {
 		return nil, err
@@ -88,6 +92,7 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string) (discover.Discover
 
 	libraries := discover.Merge(
 		versionSuffixLibraryMounts,
+		legacyNVVMLibraryMounts,
 		explicitLibraryMounts,
 	)
 
@@ -181,6 +186,25 @@ func (l *nvcdilib) getExplicitDriverLibraryMounts() (discover.Discover, error) {
 
 	return mounts, nil
 
+}
+
+func (l *nvcdilib) getLegacyNVVMLibraryMounts() (discover.Discover, error) {
+	legacyNVMMLibrary := []string{
+		"libnvidia-nvvm70.so.*",
+	}
+
+	driverLibraryLocator, err := l.driver.DriverLibraryLocator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get driver library locator: %w", err)
+	}
+	mounts := discover.NewMounts(
+		l.logger,
+		driverLibraryLocator,
+		l.driver.Root,
+		legacyNVMMLibrary,
+	)
+
+	return mounts, nil
 }
 
 func getUTSRelease() (string, error) {


### PR DESCRIPTION
fixes https://github.com/NVIDIA/nvidia-container-toolkit/issues/1875

### Testing

```
$ ls -ltr /usr/lib/x86_64-linux-gnu/libnvidia-nvvm*
-rw-r--r-- 1 root root 24829456 Dec  8  2025 /usr/lib/x86_64-linux-gnu/libnvidia-nvvm70.so.4
-rw-r--r-- 1 root root 78117032 Dec  8  2025 /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.590.48.01
lrwxrwxrwx 1 root root       27 Dec  8  2025 /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.4 -> libnvidia-nvvm.so.590.48.01

$ ./nvidia-ctk --version
NVIDIA Container Toolkit CLI version 1.20.0-dev
commit: d8d7fecdc5d83b8b897188c0bd1f2c4bae5220bb-dirty

$ ./nvidia-ctk cdi generate --output ./nvidia.yaml 2>/dev/null

$ grep -A6 "libnvidia-nvvm70" nvidia.yaml
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-nvvm70.so.4
          containerPath: /usr/lib/x86_64-linux-gnu/libnvidia-nvvm70.so.4
          options:
            - ro
            - nosuid
            - nodev
            - rbind
            - rprivate

$ grep -A6 "libnvidia-nvvm.so.590.48.01$" nvidia.yaml
        - hostPath: /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.590.48.01
          containerPath: /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.590.48.01
          options:
            - ro
            - nosuid
            - nodev
            - rbind
            - rprivate
```