### PR TITLE
drop the usage of the E2E_SSH_USER secret

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -85,7 +85,7 @@ jobs:
           E2E_INSTALL_CTK: "true"
           E2E_IMAGE_NAME: ghcr.io/nvidia/container-toolkit
           E2E_IMAGE_TAG: ${{ inputs.version }}
-          E2E_SSH_USER: ${{ secrets.E2E_SSH_USER }}
+          E2E_SSH_USER: "ubuntu"
           E2E_SSH_HOST: ${{ steps.holodeck_public_dns_name.outputs.result }}
         run: |
           e2e_ssh_key=$(mktemp)


### PR DESCRIPTION
"ubuntu" being the SSH user of AWS Ubuntu EC2 instances is a well-known fact. There is not much to gain from persisting this value as a secret.

Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/managing-users.html