### PR TITLE
[wsl2] discover all .so, .bin, and .dll files at nvidia driver store path

### DIFF
--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -19,6 +19,7 @@ package nvcdi
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/dxcore"
@@ -26,13 +27,20 @@ import (
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/lookup"
 )
 
+const (
+	libcudaSo = "libcuda.so.1.1"
+)
+
+var dxcoreLibraries = []string{
+	"libdxcore.so", /* Core library for dxcore support */
+}
+
 var requiredDriverStoreFiles = []string{
 	"libcuda.so.1.1",                /* Core library for cuda support */
 	"libcuda_loader.so",             /* Core library for cuda support on WSL */
 	"libnvidia-ptxjitcompiler.so.1", /* Core library for PTX Jit support */
 	"libnvidia-ml.so.1",             /* Core library for nvml */
 	"libnvidia-ml_loader.so",        /* Core library for nvml on WSL */
-	"libdxcore.so",                  /* Core library for dxcore support */
 	"libnvdxgdmal.so.1",             /* dxgdmal library for cuda */
 	"nvcubins.bin",                  /* Binary containing GPU code for cuda */
 	"nvidia-smi",                    /* nvidia-smi binary*/
@@ -56,16 +64,33 @@ func (l *wsllib) newWSLDriverDiscoverer() (discover.Discover, error) {
 	if len(driverStorePaths) > 1 {
 		l.logger.Warningf("Found multiple driver store paths: %v", driverStorePaths)
 	}
-	l.logger.Infof("Using WSL driver store paths: %v", driverStorePaths)
 
-	driverStorePaths = append(driverStorePaths, "/usr/lib/wsl/lib")
+	nvDriverStorePath, err := l.getNVIDIADriverStorePath(driverStorePaths)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find NVIDIA driver store path: %w", err)
+	}
 
-	driverStoreMounts := discover.NewMounts(
+	l.logger.Infof("Using WSL driver store path: %v", nvDriverStorePath)
+
+	dxcoreMounts := discover.NewMounts(
 		l.logger,
 		lookup.NewFileLocator(
 			lookup.WithLogger(l.logger),
 			lookup.WithSearchPaths(
-				driverStorePaths...,
+				"/usr/lib/wsl/lib",
+			),
+			lookup.WithCount(1),
+		),
+		l.driver.Root,
+		dxcoreLibraries,
+	)
+
+	requiredDriverStoreMounts := discover.NewMounts(
+		l.logger,
+		lookup.NewFileLocator(
+			lookup.WithLogger(l.logger),
+			lookup.WithSearchPaths(
+				nvDriverStorePath,
 			),
 			lookup.WithCount(1),
 		),
@@ -73,21 +98,97 @@ func (l *wsllib) newWSLDriverDiscoverer() (discover.Discover, error) {
 		requiredDriverStoreFiles,
 	)
 
+	additionalDriverStoreMounts, err := l.getAdditionalMountsFromDriverStore(nvDriverStorePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get additional mounts from driver store: %w", err)
+	}
+
 	symlinkHook := nvidiaSMISimlinkHook{
 		logger:      l.logger,
-		mountsFrom:  driverStoreMounts,
+		mountsFrom:  requiredDriverStoreMounts,
 		hookCreator: l.hookCreator,
 	}
 
-	ldcacheHook, _ := discover.NewLDCacheUpdateHook(l.logger, driverStoreMounts, l.hookCreator)
+	ldcacheHook, _ := discover.NewLDCacheUpdateHook(l.logger, discover.Merge(requiredDriverStoreMounts, dxcoreMounts), l.hookCreator)
 
 	d := discover.Merge(
-		driverStoreMounts,
+		dxcoreMounts,
+		requiredDriverStoreMounts,
+		additionalDriverStoreMounts,
 		symlinkHook,
 		ldcacheHook,
 	)
 
 	return d, nil
+}
+
+// getNVIDIADriverStorePath returns the driver store path associated with NVIDIA GPUs
+func (l *wsllib) getNVIDIADriverStorePath(driverStorePaths []string) (string, error) {
+	fileLocator := lookup.NewFileLocator(
+		lookup.WithLogger(l.logger),
+		lookup.WithSearchPaths(
+			driverStorePaths...,
+		),
+		lookup.WithCount(1),
+	)
+	matches, err := fileLocator.Locate(libcudaSo)
+	if err != nil {
+		return "", fmt.Errorf("failed to locate %s at WSL driver store paths: %w", libcudaSo, err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("could not locate %s at WSL driver store paths", libcudaSo)
+	}
+
+	return filepath.Dir(matches[0]), nil
+}
+
+// getAdditionalMountsFromDriverStore discovers additional NVIDIA libraries (.so files) from the
+// driver store that are not in the required list of libraries.
+func (l *wsllib) getAdditionalMountsFromDriverStore(driverStore string) (discover.Discover, error) {
+	additionalLibs, err := l.getAdditionalFilesFromDriverStore(driverStore, requiredDriverStoreFiles)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup additional files in driver store: %w", err)
+	}
+
+	mounts := discover.NewMounts(
+		l.logger,
+		lookup.NewFileLocator(
+			lookup.WithLogger(l.logger),
+			lookup.WithRoot(l.driver.Root),
+		),
+		l.driver.Root,
+		additionalLibs,
+	)
+
+	return mounts, nil
+}
+
+func (l *wsllib) getAdditionalFilesFromDriverStore(driverStore string, excludeFiles []string) ([]string, error) {
+	fileLocator := lookup.AsOptional(
+		lookup.NewFileLocator(
+			lookup.WithLogger(l.logger),
+			lookup.WithSearchPaths(driverStore),
+			lookup.WithFilter(func(s string) error {
+				if slices.Contains(excludeFiles, filepath.Base(s)) {
+					return fmt.Errorf("file %s is excluded", s)
+				}
+				return nil
+			}),
+		))
+
+	libs, err := fileLocator.Locate("*.so*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find additional '.so' files in driver store: %w", err)
+	}
+	bins, err := fileLocator.Locate("*.bin")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find additional '.bin' files in driver store: %w", err)
+	}
+	dlls, err := fileLocator.Locate("*.dll")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find additional '.dll' files in driver store: %w", err)
+	}
+	return slices.Concat(libs, bins, dlls), nil
 }
 
 type nvidiaSMISimlinkHook struct {


### PR DESCRIPTION
We currently define a hardcoded list of required files that must be discovered at the driver store. This commit extends this logic to also search for additional .so, .bin, and .dll files that may be present in the nvidia driver store path.

fixes https://github.com/NVIDIA/nvidia-container-toolkit/issues/1864

### Testing

Before this change, generating a CDI spec would discover the following:
```
$ nvidia-ctk cdi generate --output ./nvidia.yaml
WARN[0000] Ignoring error in locating libnvidia-sandboxutils.so.1: libnvidia-sandboxutils.so.1: not found
libnvidia-sandboxutils.so.1: not found
WARN[0000] Failed to init nvsandboxutils: ERROR_LIBRARY_LOAD; ignoring
INFO[0000] Using /usr/lib/wsl/lib/libnvidia-ml.so.1
INFO[0000] Auto-detected mode as 'wsl'
INFO[0000] Selecting /dev/dxg as /dev/dxg
WARN[0000] Found multiple driver store paths: [/usr/lib/wsl/drivers/u0420529.inf_amd64_94ad5a6c4d1a04e2 /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783]
INFO[0000] Using WSL driver store paths: [/usr/lib/wsl/drivers/u0420529.inf_amd64_94ad5a6c4d1a04e2 /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783]
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda.so.1.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda.so.1.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda_loader.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda_loader.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ptxjitcompiler.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ptxjitcompiler.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml_loader.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml_loader.so
INFO[0000] Selecting /usr/lib/wsl/lib/libdxcore.so as /usr/lib/wsl/lib/libdxcore.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvdxgdmal.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvdxgdmal.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvcubins.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvcubins.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvidia-smi as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvidia-smi
INFO[0000] Generated CDI spec with version 0.3.0
```

After this change, the below gets discovered. Notably, 13 additional libraries are discovered and added to the generated CDI spec: `libcudadebugger.so.1 libnvcuvid.so.1 libnvdxdlkernels.so libnvidia-encode.so.1 libnvidia-gpucomp.so libnvidia-ngx.so.1 libnvidia-nvvm.so.4 libnvidia-nvvm70.so.4 libnvidia-opticalflow.so.1  libnvidia-tileiras.so libnvoptix_loader.so.1 libnvvamanager.so.1 libnvwgf2umx.so`. 5 additional '.bin' files are discovered and all '.dll' files in the driver store are included as well.
```
$ ./nvidia-ctk cdi generate --feature-flag enable-explicit-driver-libraries=true --output ./nvidia.yaml
WARN[0000] Ignoring error in locating libnvidia-sandboxutils.so.1: libnvidia-sandboxutils.so.1: not found
libnvidia-sandboxutils.so.1: not found
WARN[0000] Failed to init nvsandboxutils: ERROR_LIBRARY_LOAD; ignoring
INFO[0000] Using /usr/lib/wsl/lib/libnvidia-ml.so.1
INFO[0000] Auto-detected mode as 'wsl'
INFO[0000] Selecting /dev/dxg as /dev/dxg
WARN[0000] Found multiple driver store paths: [/usr/lib/wsl/drivers/u0420529.inf_amd64_94ad5a6c4d1a04e2 /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783]
INFO[0000] Using WSL driver store path: /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783
INFO[0000] Selecting /usr/lib/wsl/lib/libdxcore.so as /usr/lib/wsl/lib/libdxcore.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda.so.1.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda.so.1.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda_loader.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcuda_loader.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ptxjitcompiler.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ptxjitcompiler.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml_loader.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ml_loader.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvdxgdmal.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvdxgdmal.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvcubins.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvcubins.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvidia-smi as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvidia-smi
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcudadebugger.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libcudadebugger.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvcuvid.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvcuvid.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvdxdlkernels.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvdxdlkernels.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-encode.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-encode.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-gpucomp.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-gpucomp.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ngx.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-ngx.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-nvvm.so.4 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-nvvm.so.4
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-nvvm70.so.4 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-nvvm70.so.4
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-opticalflow.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-opticalflow.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-tileiras.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvidia-tileiras.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvoptix_loader.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvoptix_loader.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvvamanager.so.1 as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvvamanager.so.1
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvwgf2umx.so as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/libnvwgf2umx.so
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/gsp_ga10x.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/gsp_ga10x.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/gsp_tu10x.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/gsp_tu10x.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvcoproc.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvcoproc.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvdrsdb.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvdrsdb.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvoptix.bin as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/nvoptix.bin
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvFBC.dll as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvFBC.dll
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvFBC64.dll as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvFBC64.dll
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvIFR.dll as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvIFR.dll
INFO[0000] Selecting /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvIFR64.dll as /usr/lib/wsl/drivers/nv_dispsi.inf_amd64_7cc7738d8e428783/NvIFR64.dll
. . . 
snip (there are many .dll files)
. . .
INFO[0000] Generated CDI spec with version 0.3.0
```