### PR TITLE
Mount nvidia.icd file needed by OpenCL

### DIFF
--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -67,6 +67,7 @@ func NewGraphicsMountsDiscoverer(logger logger.Interface, driver *root.Driver, h
 			"nvidia/nvoptix.bin",
 			"X11/xorg.conf.d/10-nvidia.conf",
 			"X11/xorg.conf.d/nvidia-drm-outputclass.conf",
+			"OpenCL/vendors/nvidia.icd",
 		},
 	)
 


### PR DESCRIPTION
This change ensures the NVIDIA ICD file needed by
OpenCL ICD loaders gets injected into containers.
The NVIDIA ICD file tells the OpenCL runtime where 
to find NVIDIA's OpenCL implementation.

fixes: https://github.com/NVIDIA/nvidia-container-toolkit/issues/682

### Testing

```
$ cat Dockerfile
FROM ubuntu:24.04
RUN apt-get update && apt-get install -y \
    clinfo \
    && rm -rf /var/lib/apt/lists/*
    
$ docker build -t opencl-sample .

$ docker run --rm -it --gpus all opencl-sample:latest bash
root@9e05c7e8c23f:/# clinfo
Number of platforms                               0

ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.3.2
  ICD loader Profile                              OpenCL 3.0
root@9e05c7e8c23f:/# ldconfig -p | grep libnvidia-opencl
	libnvidia-opencl.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libnvidia-opencl.so.1
	
$ docker run --rm -it --gpus all -v /etc/OpenCL/vendors/nvidia.icd:/etc/OpenCL/vendors/nvidia.icd opencl-sample:latest bash
root@083eb14fcb76:/# clinfo
Number of platforms                               1
  Platform Name                                   NVIDIA CUDA
  Platform Vendor                                 NVIDIA Corporation
  Platform Version                                OpenCL 3.0 CUDA 13.1.112

. . . snip . . .

ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.3.2
  ICD loader Profile                              OpenCL 3.0
  
// generate CDI spec using nvidia-ctk binary built from this PR
$ sudo ./nvidia-ctk cdi generate --output /var/run/cdi/nvidia.yaml 2>/dev/null

$ grep -A6 "nvidia\.icd" /var/run/cdi/nvidia.yaml
        - hostPath: /etc/OpenCL/vendors/nvidia.icd
          containerPath: /etc/OpenCL/vendors/nvidia.icd
          options:
            - ro
            - nosuid
            - nodev
            - rbind
            - rprivate
 
$ docker run --rm -it --gpus all opencl-sample:latest /bin/bash -c 'clinfo | grep "Number of platforms"'
Number of platforms                               1
```