### PR TITLE
[nri-plugin] support injection of management CDI devices in multiple namespaces

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/nri/plugin.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/nri/plugin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -48,8 +49,8 @@ type Plugin struct {
 	ctx    context.Context
 	logger logger.Interface
 
-	namespace string
-	stub      stub.Stub
+	namespaces []string
+	stub       stub.Stub
 
 	// stopped is set before Stop() so OnClose does not reconnect during shutdown.
 	stopped atomic.Bool
@@ -58,11 +59,11 @@ type Plugin struct {
 }
 
 // NewPlugin creates a new NRI plugin for injecting CDI devices
-func NewPlugin(ctx context.Context, logger logger.Interface, namespace string) *Plugin {
+func NewPlugin(ctx context.Context, logger logger.Interface, namespaces []string) *Plugin {
 	return &Plugin{
-		ctx:       ctx,
-		logger:    logger,
-		namespace: namespace,
+		ctx:        ctx,
+		logger:     logger,
+		namespaces: namespaces,
 	}
 }
 
@@ -107,9 +108,9 @@ func (p *Plugin) parseCDIDevices(pod *api.PodSandbox, key, container string) []s
 	}
 
 	if strings.Contains(cdiDeviceNames, "management.nvidia.com/gpu") {
-		if p.namespace != pod.Namespace {
-			p.logger.Infof("pod %s/%s is requesting one or more management CDI devices, but it is outside of the toolkit's "+
-				"namespace %s. Skipping CDI device injection...", pod.Namespace, pod.Name, p.namespace)
+		if !slices.Contains(p.namespaces, pod.Namespace) {
+			p.logger.Infof("pod %s/%s is requesting one or more management CDI devices, but it is not in one of the allowed "+
+				"namespaces %s. Skipping CDI device injection...", pod.Namespace, pod.Name, strings.Join(p.namespaces, ", "))
 			return nil
 		}
 	}

--- a/cmd/nvidia-ctk-installer/container/runtime/nri/plugin_test.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/nri/plugin_test.go
@@ -1,0 +1,141 @@
+/**
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package nri
+
+import (
+	"testing"
+
+	"github.com/containerd/nri/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+// nullLogger satisfies logger.Interface without any output.
+type nullLogger struct{}
+
+func (nullLogger) Debugf(string, ...any)   {}
+func (nullLogger) Errorf(string, ...any)   {}
+func (nullLogger) Infof(string, ...any)    {}
+func (nullLogger) Warningf(string, ...any) {}
+func (nullLogger) Tracef(string, ...any)   {}
+
+func newTestPlugin(namespaces []string) *Plugin {
+	return &Plugin{
+		logger:     nullLogger{},
+		namespaces: namespaces,
+	}
+}
+
+func podWithAnnotation(namespace, annotation, value string) *api.PodSandbox {
+	return &api.PodSandbox{
+		Namespace:   namespace,
+		Annotations: map[string]string{annotation: value},
+	}
+}
+
+func TestParseCDIDevices(t *testing.T) {
+	const (
+		toolkitNamespace    = "gpu-operator"
+		additionalNamespace = "kube-system"
+		unknownNamespace    = "default"
+	)
+
+	testCases := []struct {
+		description string
+		namespaces  []string
+		pod         *api.PodSandbox
+		container   string
+		expected    []string
+	}{
+		{
+			description: "no annotations returns nil",
+			namespaces:  []string{toolkitNamespace},
+			pod:         &api.PodSandbox{Namespace: toolkitNamespace},
+			container:   "ctr",
+			expected:    nil,
+		},
+		{
+			description: "non-management CDI device is injected in any namespace",
+			namespaces:  []string{toolkitNamespace},
+			pod:         podWithAnnotation(unknownNamespace, nriCDIAnnotationDomain+"/pod", "nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    []string{"nvidia.com/gpu=0"},
+		},
+		{
+			description: "management CDI device injected when pod is in the toolkit namespace",
+			namespaces:  []string{toolkitNamespace},
+			pod:         podWithAnnotation(toolkitNamespace, nriCDIAnnotationDomain+"/pod", "management.nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    []string{"management.nvidia.com/gpu=0"},
+		},
+		{
+			description: "management CDI device blocked when pod is outside allowed namespaces",
+			namespaces:  []string{toolkitNamespace},
+			pod:         podWithAnnotation(unknownNamespace, nriCDIAnnotationDomain+"/pod", "management.nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    nil,
+		},
+		{
+			description: "management CDI device injected when pod is in an additional allowed namespace",
+			namespaces:  []string{toolkitNamespace, additionalNamespace},
+			pod:         podWithAnnotation(additionalNamespace, nriCDIAnnotationDomain+"/pod", "management.nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    []string{"management.nvidia.com/gpu=0"},
+		},
+		{
+			description: "management CDI device blocked even with additional namespaces when pod namespace not listed",
+			namespaces:  []string{toolkitNamespace, additionalNamespace},
+			pod:         podWithAnnotation(unknownNamespace, nriCDIAnnotationDomain+"/pod", "management.nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    nil,
+		},
+		{
+			description: "mixed management and non-management CDI devices are injected in allowed namespace",
+			namespaces:  []string{toolkitNamespace},
+			pod:         podWithAnnotation(toolkitNamespace, nriCDIAnnotationDomain+"/pod", "nvidia.com/gpu=0,management.nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    []string{"nvidia.com/gpu=0", "management.nvidia.com/gpu=0"},
+		},
+		{
+			description: "mixed management and non-management CDI devices are blocked in disallowed namespace",
+			namespaces:  []string{toolkitNamespace},
+			pod:         podWithAnnotation(unknownNamespace, nriCDIAnnotationDomain+"/pod", "nvidia.com/gpu=0,management.nvidia.com/gpu=0"),
+			container:   "ctr",
+			expected:    nil,
+		},
+		{
+			description: "container-scoped annotation takes precedence over pod-scoped",
+			namespaces:  []string{toolkitNamespace},
+			pod: &api.PodSandbox{
+				Namespace: toolkitNamespace,
+				Annotations: map[string]string{
+					nriCDIAnnotationDomain + "/pod":           "nvidia.com/gpu=0",
+					nriCDIAnnotationDomain + "/container.ctr": "management.nvidia.com/gpu=0",
+				},
+			},
+			container: "ctr",
+			expected:  []string{"management.nvidia.com/gpu=0"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			plugin := newTestPlugin(tc.namespaces)
+			got := plugin.parseCDIDevices(tc.pod, nriCDIAnnotationDomain, tc.container)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/cmd/nvidia-ctk-installer/main.go
+++ b/cmd/nvidia-ctk-installer/main.go
@@ -47,10 +47,11 @@ type options struct {
 	sourceRoot  string
 	packageType string
 
-	enableNRIPlugin bool
-	nriPluginIndex  uint
-	nriSocket       string
-	nriNamespace    string
+	enableNRIPlugin                  bool
+	nriPluginIndex                   uint
+	nriSocket                        string
+	nriNamespace                     string
+	nriManagementCDIDeviceNamespaces []string
 
 	toolkitOptions toolkit.Options
 
@@ -158,6 +159,13 @@ func (a app) build() *cli.Command {
 				Usage:       "Specify the kubernetes namespace the toolkit's NRI plugin is running in.",
 				Destination: &options.nriNamespace,
 				Sources:     cli.EnvVars("NRI_NAMESPACE"),
+			},
+			&cli.StringSliceFlag{
+				Name: "nri-management-cdi-device-namespaces",
+				Usage: "Specify the list of kubernetes namespaces (in addition to the nri-namespace) that are" +
+					" allowed to receive management CDI devices through the NRI plugin",
+				Destination: &options.nriManagementCDIDeviceNamespaces,
+				Sources:     cli.EnvVars("NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES"),
 			},
 			&cli.StringFlag{
 				Name:    "runtime",
@@ -383,7 +391,8 @@ func (a *app) waitForSignal() error {
 func (a *app) startNRIPluginServer(ctx context.Context, opts *options) (*nri.Plugin, error) {
 	a.logger.Infof("Starting the NRI Plugin server....")
 
-	plugin := nri.NewPlugin(ctx, a.logger, opts.nriNamespace)
+	nriNamespaces := append([]string{opts.nriNamespace}, opts.nriManagementCDIDeviceNamespaces...)
+	plugin := nri.NewPlugin(ctx, a.logger, nriNamespaces)
 	err := plugin.Start(ctx, opts.nriSocket, fmt.Sprintf("%02d", opts.nriPluginIndex))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit exposes a new CLI flag so that users can specify additional namespaces that are authorised for management CDI device injection via the NRI plugin. Currently, users can only inject management CDI devices to containers/pods that are in the same namespace as that of the toolkit pod. With this change, users can specify can additional namespaces whose pods may need management CDI device access.