### PR TITLE
docs: fix nvidia-container-runtime usage example

### DIFF
--- a/cmd/nvidia-container-runtime/README.md
+++ b/cmd/nvidia-container-runtime/README.md
@@ -204,7 +204,15 @@ curl -sS http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-bas
 nvidia-container-runtime spec
 sed -i 's;"sh";"nvidia-smi";' config.json
 sed -i 's;\("TERM=xterm"\);\1, "NVIDIA_VISIBLE_DEVICES=0";' config.json
+sed -i 's;"terminal":true;"terminal":false;' config.json
 
-# Run the container
-sudo nvidia-container-runtime run nvidia_smi
+# Create and start the container
+sudo nvidia-container-runtime create nvidia_smi > nvidia_smi.log 2>&1
+sudo nvidia-container-runtime start nvidia_smi
+
+# View the nvidia-smi output
+cat nvidia_smi.log
+
+# Delete the container
+sudo nvidia-container-runtime delete nvidia_smi
 ```


### PR DESCRIPTION
This updates the `nvidia-container-runtime` usage example so it follows the runtime path described earlier in the README: the NVIDIA runtime modifies the OCI spec when a `create` command is detected, then the container can be started.

The old example used `run`, which skips the modifier path and leaves the generated `config.json` unchanged, as reported in #781.

Fixes #781

Validation:
- Confirmed the old `nvidia-container-runtime run nvidia_smi` example is no longer present.
- Confirmed the replacement example uses `create`, `start`, and cleanup with `delete`.

AI assistance disclosure:
- I used AI assistance to identify the stale example and prepare this small documentation update.
