### PR TITLE
[nri plugin] move cdi inject info log to debug level

### DIFF
--- a/cmd/nvidia-ctk-installer/container/runtime/nri/plugin.go
+++ b/cmd/nvidia-ctk-installer/container/runtime/nri/plugin.go
@@ -88,7 +88,7 @@ func (p *Plugin) injectCDIDevices(pod *api.PodSandbox, ctr *api.Container, a *ap
 		return nil
 	}
 
-	pluginLogger.Infof(ctx, "%s: injecting CDI devices %v...", containerName(pod, ctr), devices)
+	pluginLogger.Debugf(ctx, "%s: injecting CDI devices %v...", containerName(pod, ctr), devices)
 	for _, name := range devices {
 		a.AddCDIDevice(
 			&api.CDIDevice{


### PR DESCRIPTION
We are moving this info log line up to the debug log level in order to reduce the noise in the toolkit daemonset logs. We have observed that the logs in the toolkit daemonset pod gets especially noisy when a GPU pod requests an invalid CDI device in its annotations. The screenshot shared below illustrates this:

<img width="1579" height="642" alt="Screenshot 2026-07-07 at 12 09 38 PM" src="https://github.com/user-attachments/assets/b5643826-cf85-42a0-93be-452f5c29339d" />
