### PR TITLE
Validate imex channels for CDI/JIT-CDI mode

### DIFF
--- a/pkg/nvcdi/lib-imex.go
+++ b/pkg/nvcdi/lib-imex.go
@@ -18,6 +18,7 @@ package nvcdi
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -39,6 +40,11 @@ var _ deviceSpecGeneratorFactory = (*imexlib)(nil)
 
 const (
 	classImexChannel = "imex-channel"
+
+	// maxImexChannelID is the maximum valid IMEX channel ID.  Channel IDs must fit
+	// in the minor number of a dev_t (20 bits), matching the bound enforced by
+	// nvidia-container-cli in the legacy code path.
+	maxImexChannelID = (1 << 20) - 1
 )
 
 // GetCommonEdits returns an empty set of edits for IMEX devices.
@@ -73,9 +79,12 @@ func (l *imexlib) getChannelIDs(ids ...string) ([]string, error) {
 		if trimmed == "all" {
 			return l.getAllChannelIDs()
 		}
-		_, err := strconv.ParseUint(trimmed, 10, 64)
+		channelID, err := strconv.ParseUint(trimmed, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid channel ID %v: %w", id, err)
+			return nil, fmt.Errorf("invalid channel ID %s: %w", id, err)
+		}
+		if channelID > maxImexChannelID {
+			return nil, fmt.Errorf("invalid channel ID %s: must be in the range [0, %d]", id, maxImexChannelID)
 		}
 		channelIDs = append(channelIDs, trimmed)
 	}
@@ -107,13 +116,17 @@ func (l *imexlib) getAllChannelIDs() ([]string, error) {
 // GetDeviceSpecs returns the CDI device specs the specified IMEX channel.
 func (l *imexChannel) GetDeviceSpecs() ([]specs.Device, error) {
 	path := "/dev/nvidia-caps-imex-channels/channel" + l.id
+	hostPath := filepath.Join(l.devRoot, path)
+	if _, err := os.Stat(hostPath); err != nil {
+		return nil, fmt.Errorf("IMEX channel %s not found at %s: %w", l.id, hostPath, err)
+	}
 	deviceSpec := specs.Device{
 		Name: l.id,
 		ContainerEdits: specs.ContainerEdits{
 			DeviceNodes: []*specs.DeviceNode{
 				{
 					Path:     path,
-					HostPath: filepath.Join(l.devRoot, path),
+					HostPath: hostPath,
 				},
 			},
 		},

--- a/pkg/nvcdi/lib-imex_test.go
+++ b/pkg/nvcdi/lib-imex_test.go
@@ -79,3 +79,60 @@ containerEdits:
 	require.NoError(t, err)
 	require.Equal(t, expectedSpec, b.String())
 }
+
+func TestImexChannelValidation(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+
+	moduleRoot, err := test.GetModuleRoot()
+	require.NoError(t, err)
+	hostRoot := filepath.Join(moduleRoot, "testdata", "lookup", "rootfs-1")
+
+	testCases := []struct {
+		description string
+		ids         []string
+		expectedErr string
+	}{
+		{
+			description: "valid channel",
+			ids:         []string{"0"},
+		},
+		{
+			description: "valid channel with prefix",
+			ids:         []string{"channel0"},
+		},
+		{
+			description: "non-numeric channel is rejected",
+			ids:         []string{"bogus"},
+			expectedErr: "invalid channel ID",
+		},
+		{
+			description: "channel above maximum is rejected",
+			ids:         []string{"1048576"},
+			expectedErr: "must be in the range [0, 1048575]",
+		},
+		{
+			description: "non-existent channel node is rejected",
+			ids:         []string{"5"},
+			expectedErr: "not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			lib, err := New(
+				WithLogger(logger),
+				WithMode(ModeImex),
+				WithDriverRoot(hostRoot),
+			)
+			require.NoError(t, err)
+
+			_, err = lib.GetDeviceSpecsByID(tc.ids...)
+
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #1309

This patch updates the logic to return an error if:

* The channel specified is not in the range [0, 1<<20)
* The underlying device node does NOT exist on the host