### PR TITLE
Add enable-cuda-compat hook to management CDI specs

### DIFF
--- a/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/toolkit_test.go
@@ -105,6 +105,14 @@ containerEdits:
           path: {{ .toolkitRoot }}/nvidia-cdi-hook
           args:
             - nvidia-cdi-hook
+            - enable-cuda-compat
+            - --host-driver-version=999.88.77
+          env:
+            - NVIDIA_CTK_DEBUG=false
+        - hookName: createContainer
+          path: {{ .toolkitRoot }}/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
             - update-ldcache
             - --folder
             - /lib/x86_64-linux-gnu

--- a/pkg/nvcdi/lib_test.go
+++ b/pkg/nvcdi/lib_test.go
@@ -206,6 +206,12 @@ func TestNew(t *testing.T) {
 						{
 							HookName: "createContainer",
 							Path:     "/usr/bin/nvidia-cdi-hook",
+							Args:     []string{"nvidia-cdi-hook", "enable-cuda-compat", "--host-driver-version=999.88.77"},
+							Env:      []string{"NVIDIA_CTK_DEBUG=false"},
+						},
+						{
+							HookName: "createContainer",
+							Path:     "/usr/bin/nvidia-cdi-hook",
 							Args:     []string{"nvidia-cdi-hook", "update-ldcache", "--folder", "/lib/x86_64-linux-gnu", "--folder", "/lib/x86_64-linux-gnu/vdpau"},
 							Env:      []string{"NVIDIA_CTK_DEBUG=false"},
 						},
@@ -250,6 +256,12 @@ func TestNew(t *testing.T) {
 							HookName: "createContainer",
 							Path:     "/usr/bin/nvidia-cdi-hook",
 							Args:     []string{"nvidia-cdi-hook", "create-symlinks", "--link", "libcuda.so.1::/lib/x86_64-linux-gnu/libcuda.so"},
+							Env:      []string{"NVIDIA_CTK_DEBUG=false"},
+						},
+						{
+							HookName: "createContainer",
+							Path:     "/usr/bin/nvidia-cdi-hook",
+							Args:     []string{"nvidia-cdi-hook", "enable-cuda-compat", "--host-driver-version=999.88.77"},
 							Env:      []string{"NVIDIA_CTK_DEBUG=false"},
 						},
 						{

--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -114,9 +114,8 @@ func populateOptions(opts ...Option) *options {
 	}
 
 	if o.mode == ModeManagement {
-		// For management mode we explicitly disable the hooks that enable CUDA
-		// compatibility and disable device node modifications.
-		o.disabledHooks = append(o.disabledHooks, HookEnableCudaCompat, DisableDeviceNodeModificationHook)
+		// For management mode we explicitly disable the hook that disables device node modifications.
+		o.disabledHooks = append(o.disabledHooks, DisableDeviceNodeModificationHook)
 	}
 
 	if o.editsFactory == nil {


### PR DESCRIPTION
Previously this was disabled since it was assumed that management applications would typically not need to leverage CUDA forward compatibility. However, a use case has arised in the GPU Operator where a management container runs a CUDA sample program. The 'enable-cuda-compat' hook would allow this CUDA sample program to work on a wider range of NVIDIA driver versions.