### PR TITLE
use the driver version explicitly to match libraries

### DIFF
--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -111,14 +111,17 @@ func newVulkanConfigsDiscover(logger logger.Interface, driver *root.Driver) Disc
 
 type graphicsDriverLibraries struct {
 	Discover
-	logger      logger.Interface
-	hookCreator HookCreator
+	logger        logger.Interface
+	hookCreator   HookCreator
+	driverVersion string
 }
 
 var _ Discover = (*graphicsDriverLibraries)(nil)
 
 func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver, hookCreator HookCreator) (Discover, error) {
-	cudaVersionPattern, err := driver.Version()
+	// We use the driver version as a suffix for matching libraries that are
+	// part of the driver.
+	driverVersion, err := driver.Version()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver version: %w", err)
 	}
@@ -143,8 +146,8 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 			// * libnvidia-allocator.so.RM_VERSION
 			// * libnvidia-vulkan-producer.so.RM_VERSION
 			// but need to be handled for the legacy case too.
-			"libnvidia-allocator.so." + cudaVersionPattern,
-			"libnvidia-vulkan-producer.so." + cudaVersionPattern,
+			"libnvidia-allocator.so." + driverVersion,
+			"libnvidia-vulkan-producer.so." + driverVersion,
 		},
 	)
 
@@ -159,14 +162,15 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 		driver.Root,
 		[]string{
 			"nvidia_drv.so",
-			"libglxserver_nvidia.so." + cudaVersionPattern,
+			"libglxserver_nvidia.so." + driverVersion,
 		},
 	)
 
 	return &graphicsDriverLibraries{
-		Discover:    Merge(libraries, xorgLibraries),
-		logger:      logger,
-		hookCreator: hookCreator,
+		Discover:      Merge(libraries, xorgLibraries),
+		logger:        logger,
+		hookCreator:   hookCreator,
+		driverVersion: driverVersion,
 	}, nil
 }
 
@@ -234,10 +238,7 @@ func (d graphicsDriverLibraries) Hooks() ([]Hook, error) {
 
 // isDriverLibrary checks whether the specified filename is a specific driver library.
 func (d graphicsDriverLibraries) isDriverLibrary(filename string, libraryName string) bool {
-	// TODO: Instead of `.*.*` we could use the driver version.
-	pattern := strings.TrimSuffix(libraryName, ".") + ".*.*"
-	match, _ := filepath.Match(pattern, filename)
-	return match
+	return filename == strings.TrimSuffix(libraryName, ".")+"."+d.driverVersion
 }
 
 // buildXOrgSearchPaths returns search paths from all roots

--- a/internal/discover/graphics_test.go
+++ b/internal/discover/graphics_test.go
@@ -109,6 +109,25 @@ func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 			},
 		},
 		{
+			description: "libnvidia-allocator not filtered out when version does not equal driver version",
+			libraries: &DiscoverMock{
+				MountsFunc: func() ([]Mount, error) {
+					mounts := []Mount{
+						{
+							Path: "/usr/lib64/libnvidia-allocator.so.999.99.99",
+						},
+					}
+					return mounts, nil
+				},
+			},
+			expectedMounts: []Mount{
+				{
+					Path: "/usr/lib64/libnvidia-allocator.so.999.99.99",
+				},
+			},
+			expectedHooks: nil,
+		},
+		{
 			description: "libnvidia-allocator and libnvidia-vulkan-producer discovered",
 			libraries: &DiscoverMock{
 				MountsFunc: func() ([]Mount, error) {
@@ -145,9 +164,10 @@ func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			d := &graphicsDriverLibraries{
-				Discover:    tc.libraries,
-				logger:      logger,
-				hookCreator: hookCreator,
+				Discover:      tc.libraries,
+				logger:        logger,
+				hookCreator:   hookCreator,
+				driverVersion: "123.45.67",
 			}
 
 			devices, err := d.Devices()
@@ -247,5 +267,47 @@ func TestDrmDevicesByPath(t *testing.T) {
 
 			require.EqualValues(t, tc.expectedHooks, hooks)
 		})
+	}
+}
+
+func TestIsDriverLibrary(t *testing.T) {
+	testCases := []struct {
+		description    string
+		filename       string
+		libraryName    string
+		driverVersion  string
+		expectedResult bool
+	}{
+		{
+			description:    "driver library file matched",
+			libraryName:    "libnvidia-vulkan-producer.so",
+			filename:       "libnvidia-vulkan-producer.so.123.45.67",
+			driverVersion:  "123.45.67",
+			expectedResult: true,
+		},
+		{
+			description:    "driver library file matched with extraneous \".\"",
+			libraryName:    "libnvidia-vulkan-producer.so.",
+			filename:       "libnvidia-vulkan-producer.so.123.45.67",
+			driverVersion:  "123.45.67",
+			expectedResult: true,
+		},
+		{
+			description:    "driver library file not matched due to mismatching driver version",
+			libraryName:    "libnvidia-vulkan-producer.so",
+			filename:       "libnvidia-vulkan-producer.so.123.45.67",
+			driverVersion:  "999.99.99",
+			expectedResult: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			gdl := graphicsDriverLibraries{
+				driverVersion: tc.driverVersion,
+			}
+			result := gdl.isDriverLibrary(tc.filename, tc.libraryName)
+			require.Equal(t, tc.expectedResult, result)
+		})
+
 	}
 }


### PR DESCRIPTION
This is intended to replace the PR https://github.com/NVIDIA/nvidia-container-toolkit/pull/1578. 

It addresses some of the minor review comments and adds tests. The original author has been attributed and added as co-author.



> Previous Behavior
The discovery logic used a generic *.* wildcard pattern to identify driver libraries. This was less precise and could potentially match unrelated files or incorrect versions.
```
 pattern := strings.TrimSuffix(libraryName, ".") + ".*.*"
```
> Current Behavior
The update modifies  graphicsDriverLibraries to explicitly use the detected driver version when constructing the match pattern. This ensures that only libraries matching the active driver version are processed, preventing false positives and ensuring consistency.

```
pattern := strings.TrimSuffix(libraryName, ".") + "." + d.driverVersion
```