### PR TITLE
fix: match the root at a path component boundary when transforming paths

### DIFF
--- a/pkg/nvcdi/transform/root/root.go
+++ b/pkg/nvcdi/transform/root/root.go
@@ -39,9 +39,21 @@ func New(opts ...Option) transform.Transformer {
 }
 
 func (t transformer) transformPath(path string) string {
-	if !strings.HasPrefix(path, t.root) {
+	// Ensure that the root ends with a path separator so that the prefix
+	// comparison below only matches at a path component boundary. Without this
+	// a root of /driver would also match a path such as /driver-backup/lib.so
+	// and transform it to {targetRoot}/-backup/lib.so.
+	root := t.root
+	if !strings.HasSuffix(root, string(filepath.Separator)) {
+		root += string(filepath.Separator)
+	}
+
+	// The path is compared with a trailing separator too so that a path equal
+	// to the root is also matched and transformed to the target root.
+	pathWithSeparator := path + string(filepath.Separator)
+	if !strings.HasPrefix(pathWithSeparator, root) {
 		return path
 	}
 
-	return filepath.Join(t.targetRoot, strings.TrimPrefix(path, t.root))
+	return filepath.Join(t.targetRoot, strings.TrimPrefix(pathWithSeparator, root))
 }

--- a/pkg/nvcdi/transform/root/root_test.go
+++ b/pkg/nvcdi/transform/root/root_test.go
@@ -1,0 +1,94 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformPath(t *testing.T) {
+	testCases := []struct {
+		description  string
+		root         string
+		targetRoot   string
+		path         string
+		expectedPath string
+	}{
+		{
+			description:  "path under root is transformed",
+			root:         "/run/nvidia/driver",
+			targetRoot:   "/",
+			path:         "/run/nvidia/driver/lib/libcuda.so",
+			expectedPath: "/lib/libcuda.so",
+		},
+		{
+			description:  "path equal to root is transformed",
+			root:         "/run/nvidia/driver",
+			targetRoot:   "/host",
+			path:         "/run/nvidia/driver",
+			expectedPath: "/host",
+		},
+		{
+			description:  "path outside root is unchanged",
+			root:         "/run/nvidia/driver",
+			targetRoot:   "/host",
+			path:         "/usr/lib/libcuda.so",
+			expectedPath: "/usr/lib/libcuda.so",
+		},
+		{
+			description:  "sibling of root with common prefix is unchanged",
+			root:         "/run/nvidia/driver",
+			targetRoot:   "/host",
+			path:         "/run/nvidia/driver-backup/lib/libcuda.so",
+			expectedPath: "/run/nvidia/driver-backup/lib/libcuda.so",
+		},
+		{
+			description:  "partial path component match is unchanged",
+			root:         "/run/nvidia/driver",
+			targetRoot:   "/host",
+			path:         "/run/nvidia/driverfoo",
+			expectedPath: "/run/nvidia/driverfoo",
+		},
+		{
+			description:  "root with trailing slash is transformed",
+			root:         "/run/nvidia/driver/",
+			targetRoot:   "/host",
+			path:         "/run/nvidia/driver/lib/libcuda.so",
+			expectedPath: "/host/lib/libcuda.so",
+		},
+		{
+			description:  "root of / is transformed",
+			root:         "/",
+			targetRoot:   "/host",
+			path:         "/usr/lib/libcuda.so",
+			expectedPath: "/host/usr/lib/libcuda.so",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tr := transformer{
+				root:       tc.root,
+				targetRoot: tc.targetRoot,
+			}
+			require.Equal(t, tc.expectedPath, tr.transformPath(tc.path))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`pkg/nvcdi/transform/root` decides whether a path is contained in the (from) root using a plain string prefix comparison:

```go
if !strings.HasPrefix(path, t.root) {
	return path
}

return filepath.Join(t.targetRoot, strings.TrimPrefix(path, t.root))
```

A path that shares a *textual* prefix with the root but is not actually inside it therefore matches, and is rewritten into a corrupted path.

With `root=/run/nvidia/driver` and `targetRoot=/host`:

| path | current | expected |
| --- | --- | --- |
| `/run/nvidia/driver/lib/libcuda.so` | `/host/lib/libcuda.so` | `/host/lib/libcuda.so` |
| `/run/nvidia/driver-backup/lib/libcuda.so` | `/host/-backup/lib/libcuda.so` | unchanged |
| `/run/nvidia/driverfoo` | `/host/foo` | unchanged |

The last two paths lie outside the root and must be left untouched.

## Reachability

`transformPath` is shared by `hostRootTransformer` and `containerRootTransformer`, so both host and container paths are affected. The roots are user-supplied:

* `nvidia-ctk cdi transform root --from <root> --to <target>`
* the driver root transform applied during CDI spec generation (`NewDriverTransformer`, driven by `--driver-root` / `--dev-root`)

## Fix

Require the prefix match to end at a path component boundary. Behaviour that was already correct is unchanged:

* a path equal to the root still maps to the target root
* a root with a trailing separator, including a root of `/`, still matches
* a path with no common prefix is still returned untouched

## Testing

Added `TestTransformPath` covering the two boundary cases plus five cases for the existing behaviour. I verified that the two new cases fail without the fix and pass with it, and that the other five pass either way.

Locally, on a machine with no NVIDIA GPU:

* `make test` — pass (44 packages)
* `golangci-lint run ./...` — 0 issues
* `golangci-lint fmt --diff ./...` — clean
* `go build ./...` — pass

Coverage for `pkg/nvcdi/transform/root`: 89.9% -> 90.2%.

## Out of scope

The same prefix-comparison pattern also appears in `internal/lookup/root.RelativeToRoot`, `internal/discover/mounts.go`, and `pkg/nvcdi/driver-nvml.go`. I have left those untouched to keep this change small and reviewable, but I am happy to follow up if you would like them addressed as well.
