### PR TITLE
[dependabot] bump open PR limit for go dep bumps in main to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     - "tests"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
     labels:
     - dependencies
     groups:


### PR DESCRIPTION
Dependabot is not able to open additional go dep bump PRs as it gone over the default limit of open PRs (which is 5).