### PR TITLE
fix(cdi): include 32-bit libraries in discovery

### DIFF
--- a/pkg/lookup/ldcache.go
+++ b/pkg/lookup/ldcache.go
@@ -43,16 +43,21 @@ func (f *Factory) newLdcacheLocator() Locator {
 		f.logger.Warningf("Failed to load ldcache: %v", err)
 		return notFound
 	}
+	return f.newLdcacheLocatorFrom(cache)
+}
 
+func (f *Factory) newLdcacheLocatorFrom(cache ldcache.LDCache) Locator {
 	var libraries []string
-	_, libs64 := cache.List()
-	for _, library := range libs64 {
-		chain, err := symlinks.ResolveChain(library)
-		if err != nil {
-			f.logger.Warningf("Failed to resolve symlink chain for library %q: %v", library, err)
-			continue
+	libs32, libs64 := cache.List()
+	for _, libs := range [][]string{libs64, libs32} {
+		for _, library := range libs {
+			chain, err := symlinks.ResolveChain(library)
+			if err != nil {
+				f.logger.Warningf("Failed to resolve symlink chain for library %q: %v", library, err)
+				continue
+			}
+			libraries = append(libraries, chain...)
 		}
-		libraries = append(libraries, chain...)
 	}
 
 	l := &ldcacheLocator{

--- a/pkg/lookup/ldcache_test.go
+++ b/pkg/lookup/ldcache_test.go
@@ -1,12 +1,15 @@
 package lookup
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/ldcache"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
 )
 
@@ -74,4 +77,33 @@ func TestLDCacheLookup(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestLDCacheLookupIncludes32BitLibraries(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+	root := t.TempDir()
+
+	lib64 := filepath.Join(root, "usr/lib64/libcuda.so.999.88.77")
+	lib32 := filepath.Join(root, "usr/lib/libcuda.so.999.88.77")
+	require.NoError(t, os.MkdirAll(filepath.Dir(lib64), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(lib32), 0o755))
+	require.NoError(t, os.WriteFile(lib64, nil, 0o600))
+	require.NoError(t, os.WriteFile(lib32, nil, 0o600))
+
+	cache := &ldcache.LDCacheMock{
+		ListFunc: func() ([]string, []string) {
+			return []string{lib32}, []string{lib64}
+		},
+	}
+	l := NewFactory(
+		WithLogger(logger),
+		WithRoot(root),
+	).newLdcacheLocatorFrom(cache)
+
+	candidates, err := l.Locate("libcuda.so.*")
+	require.NoError(t, err)
+	for i := range candidates {
+		candidates[i] = strings.TrimPrefix(candidates[i], "/private")
+	}
+	require.Equal(t, []string{lib64, lib32}, candidates)
 }

--- a/pkg/lookup/library.go
+++ b/pkg/lookup/library.go
@@ -19,8 +19,13 @@ package lookup
 // NewLibraryLocator creates a library locator using the specified options.
 // If search paths (WithSearchPaths(path1, path2, ...)) are explicitly specified
 // a library locator using these as absolute paths are used. Otherwise the
-// library is constructed by combining results from a set of predefined search
-// paths and the ldcache.
+// library locator combines unique matches from the following sources, in
+// precedence order:
+//   - predefined search paths
+//   - 64-bit entries from the ldcache
+//   - 32-bit entries from the ldcache
+//
+// If multiple sources return the same path, the first occurrence is kept.
 func NewLibraryLocator(opts ...Option) Locator {
 	f := NewFactory(opts...)
 

--- a/pkg/lookup/library.go
+++ b/pkg/lookup/library.go
@@ -19,11 +19,8 @@ package lookup
 // NewLibraryLocator creates a library locator using the specified options.
 // If search paths (WithSearchPaths(path1, path2, ...)) are explicitly specified
 // a library locator using these as absolute paths are used. Otherwise the
-// library is constructed using the following ordering, returning the first
-// successful result:
-//   - attempt to locate the library / pattern using dlopen
-//   - attempt to locate the library from a set of predefined search paths.
-//   - attempt to locate the library from the ldcache.
+// library is constructed by combining results from a set of predefined search
+// paths and the ldcache.
 func NewLibraryLocator(opts ...Option) Locator {
 	f := NewFactory(opts...)
 
@@ -50,9 +47,9 @@ func NewLibraryLocator(opts ...Option) Locator {
 			"/lib/aarch64-linux-gnu/nvidia/current",
 		}...),
 	)
-	l := First(
+	l := AsUnique(Merge(
 		NewSymlinkLocator(opts...),
 		f.newLdcacheLocator(),
-	)
+	))
 	return l
 }

--- a/pkg/lookup/merge.go
+++ b/pkg/lookup/merge.go
@@ -21,6 +21,7 @@ import (
 )
 
 type first []Locator
+type merged []Locator
 
 type unique struct {
 	locator Locator
@@ -38,6 +39,18 @@ func First(locators ...Locator) Locator {
 	return f
 }
 
+// Merge returns a locator that combines the matches from all supplied locators.
+func Merge(locators ...Locator) Locator {
+	var m merged
+	for _, l := range locators {
+		if l == nil {
+			continue
+		}
+		m = append(m, l)
+	}
+	return m
+}
+
 // Locate returns the results for the first locator that returns a non-empty non-error result.
 func (f first) Locate(pattern string) ([]string, error) {
 	var allErrors []error
@@ -53,6 +66,26 @@ func (f first) Locate(pattern string) ([]string, error) {
 		if len(candidates) > 0 {
 			return candidates, nil
 		}
+	}
+
+	return nil, errors.Join(allErrors...)
+}
+
+// Locate returns the combined results from all locators that return matches.
+func (m merged) Locate(pattern string) ([]string, error) {
+	var candidates []string
+	var allErrors []error
+	for _, l := range m {
+		matches, err := l.Locate(pattern)
+		if err != nil {
+			allErrors = append(allErrors, err)
+			continue
+		}
+		candidates = append(candidates, matches...)
+	}
+
+	if len(candidates) > 0 {
+		return candidates, nil
 	}
 
 	return nil, errors.Join(allErrors...)

--- a/pkg/lookup/merge.go
+++ b/pkg/lookup/merge.go
@@ -39,7 +39,10 @@ func First(locators ...Locator) Locator {
 	return f
 }
 
-// Merge returns a locator that combines the matches from all supplied locators.
+// Merge returns a locator that combines matches from all supplied locators in
+// argument order. Nil locators are ignored. If at least one locator returns a
+// match, errors from the other locators are ignored; otherwise, all locator
+// errors are joined and returned.
 func Merge(locators ...Locator) Locator {
 	var m merged
 	for _, l := range locators {

--- a/pkg/lookup/merge_test.go
+++ b/pkg/lookup/merge_test.go
@@ -1,0 +1,58 @@
+/**
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package lookup
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	first := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return []string{"first"}, nil
+		},
+	}
+	second := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return []string{"second"}, nil
+		},
+	}
+
+	candidates, err := Merge(first, second).Locate("libcuda.so.*")
+	require.NoError(t, err)
+	require.Equal(t, []string{"first", "second"}, candidates)
+}
+
+func TestMergeReturnsMatchesWhenAnotherLocatorFails(t *testing.T) {
+	failing := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return nil, fmt.Errorf("lookup failed")
+		},
+	}
+	matching := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return []string{"match"}, nil
+		},
+	}
+
+	candidates, err := Merge(failing, matching).Locate("libcuda.so.*")
+	require.NoError(t, err)
+	require.Equal(t, []string{"match"}, candidates)
+}


### PR DESCRIPTION
## Summary

CDI generation omitted the host's 32-bit NVIDIA driver stack on multilib systems; this combines predefined-path and linker-cache discovery so generated specs include both native and compat32 libraries.

## Why This Exists

`ldcache.List()` returns separate 32-bit and 64-bit library sets, but the CDI lookup path discarded the 32-bit set. The default library locator also stopped after finding libraries in a predefined native path, which prevented the linker cache from contributing libraries installed in a separate compat32 directory.

The resulting CDI spec could expose the 64-bit NVIDIA stack while leaving a 32-bit Vulkan application such as a Steam or Proton title without the matching vendor libraries. In that state, the application can select software rendering even though compatible ELF32 NVIDIA libraries are installed on the host.

This is related to #563, which tracks broader graphics-library coverage.

## Resolution

The default library locator now merges predefined-path and linker-cache results and deduplicates the combined list. Linker-cache discovery consumes both architecture lists, with native libraries first so existing version-inference precedence remains stable.

This keeps architecture discovery in the host linker cache rather than adding distribution-specific compat32 paths to CDI generation.

## Reviewer Considerations

- Please confirm that an exported `lookup.Merge` combinator is the preferred shape for combining locator results; it mirrors the existing exported `lookup.First` behavior while retaining successful matches when another locator fails.
- The default locator now returns all unique matches instead of the first successful source. This is intentional because CDI needs every driver-library directory, but callers that infer a driver version still see native libraries first.
- Multilib hosts will generate larger CDI specs because valid ELF32 driver libraries are now included. Hosts without 32-bit linker-cache entries should be unchanged.
- This PR is limited to discovery and regression coverage. It does not add distribution-specific paths or modify runtime selection policy.

## Behavior Changes

- CDI specs generated on multilib hosts include matching 32-bit NVIDIA driver libraries exposed through the host linker cache.
- Native library ordering is preserved for callers that use the first match.
- Duplicate paths found through predefined directories and the linker cache are emitted once.

## Implementation Summary

- Consume both values returned by `ldcache.List()`.
- Add a locator combinator that merges successful results across lookup sources.
- Use the merged, unique locator for default library discovery.
- Add regression tests for mixed 32-bit/64-bit linker-cache entries, ordering, result merging, and partial lookup failure.

## Verification

- `make test` passed.
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --timeout 5m ./...` passed with 0 issues.
- `go vet ./pkg/lookup` passed.
- `git diff --check` passed.
- Real-host comparison on an x86_64 linux-based system with NVIDIA 595.84:
  - toolkit 1.19.1 generated 40 `/usr/lib64` library mounts and 0 `/usr/lib` library mounts;
  - patched `main` generated 41 `/usr/lib64` library mounts and 25 `/usr/lib` library mounts;
  - the newly discovered `/usr/lib` entries were verified as ELF32 and included `libcuda`, `libnvidia-ml`, and `libGLX_nvidia`.
- The host's live CDI specification was not replaced during validation.
- The commit has a matching DCO sign-off and a GitHub-verified SSH signature.

## Risk

Low to moderate. The discovery set intentionally grows on multilib hosts, and the primary compatibility risk is a caller assuming only one architecture is returned. Native-first ordering, deduplication, package tests, the full upstream test suite, and real-host CDI generation cover that behavior.
