### PR TITLE
[containerd-config-toml] set default runtime_type value if not present

### DIFF
--- a/pkg/config/engine/containerd/config.go
+++ b/pkg/config/engine/containerd/config.go
@@ -68,6 +68,10 @@ func (c *Config) AddRuntimeWithOptions(name string, path string, setAsDefault bo
 		config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name, "container_annotations"}, annotations)
 	}
 
+	if runtimeType, _ := config.GetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name, "runtime_type"}).(string); runtimeType == "" && c.RuntimeType != "" {
+		config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name, "runtime_type"}, c.RuntimeType)
+	}
+
 	config.SetPath([]string{"plugins", c.CRIRuntimePluginName, "containerd", "runtimes", name, "options", "BinaryName"}, path)
 
 	if setAsDefault {

--- a/pkg/config/engine/containerd/config_test.go
+++ b/pkg/config/engine/containerd/config_test.go
@@ -73,6 +73,47 @@ func TestAddRuntime(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			description: "empty runtime_type copied from runc options is replaced with default",
+			config: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = ""
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+						BinaryName = "/usr/bin/runc"
+						SystemdCgroup = true
+			`,
+			expectedConfig: `
+			version = 2
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+				[plugins."io.containerd.grpc.v1.cri".containerd]
+				[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = ""
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+						BinaryName = "/usr/bin/runc"
+						SystemdCgroup = true
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test]
+					privileged_without_host_devices = false
+					runtime_engine = ""
+					runtime_root = ""
+					runtime_type = "io.containerd.runc.v2"
+					[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test.options]
+						BinaryName = "/usr/bin/test"
+						SystemdCgroup = true
+			`,
+		},
+		{
 			description: "options from runc are imported",
 			config: `
 			version = 2


### PR DESCRIPTION
Fixes #1956 

This PR addresses a scenario where valid albeit incomplete containerd config tomls may be provided as a base config. In this case, the `runtime_type` field was missing in the base config TOML, so the drop-in config TOML which defines the custom runtimes did not have the `runtime_type` populated. This led to errors starting up containers which used these custom runtimes.

```
error="rpc error: code = InvalidArgument desc = failed to start sandbox \"96ca033f576080a5cbf8365e57fad83184c690fd17ea9ffc3fa3c4bf8c6b220e\": failed to create containerd container: create container failed validation: container.Runtime.Name must be set: invalid argument"
```

This PR changes that by automatically populating the `runtime_type` field with the default value in the new runtime handler blocks should the `runtime_type` be empty
