### PR TITLE
Update .nvidia-ci.yml

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -44,6 +44,7 @@ variables:
 
 stages:
   - pull
+  - test
   - scan
   - release
   - ngc-publish


### PR DESCRIPTION
Hi maintainers, I noticed that the .integration template references a test stage, but test is not currently defined in the stages list. Is this template still expected to be used? If so, should the test stage be added?