### PR TITLE
[no-relnote] update OCI image labels

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -85,6 +85,7 @@ ARG GIT_COMMIT
 ARG GIT_COMMIT_SHORT
 ARG SOURCE_DATE_EPOCH
 ARG VERSION
+ARG BUILD_TIMESTAMP
 
 # Create a manifest.txt file with the absolute paths of all deb and rpm packages in the container
 RUN echo "#IMAGE_EPOCH=$(date '+%s')" > /artifacts/manifest.txt && \
@@ -97,6 +98,15 @@ LABEL version="${VERSION}"
 LABEL release="N/A"
 LABEL summary="deb and rpm packages for the NVIDIA Container Toolkit"
 LABEL description="See summary"
+
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/nvidia-container-toolkit.git"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/container-toolkit"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.title="NVIDIA Container Toolkit Packages"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.base.name="nvcr.io/nvidia/distroless/go"
 
 COPY LICENSE /licenses/
 
@@ -177,13 +187,24 @@ WORKDIR /work
 ENV PATH=/work:$PATH
 
 ARG VERSION
-LABEL io.k8s.display-name="NVIDIA Container Runtime Config"
-LABEL name="NVIDIA Container Runtime Config"
+ARG GIT_COMMIT
+ARG BUILD_TIMESTAMP
+LABEL io.k8s.display-name="NVIDIA Container Toolkit Installer"
+LABEL name="NVIDIA Container Toolkit Installer"
 LABEL vendor="NVIDIA"
 LABEL version="${VERSION}"
 LABEL release="N/A"
-LABEL summary="Automatically Configure your Container Runtime for GPU support."
+LABEL summary="Enables GPU support in container runtimes"
 LABEL description="See summary"
+
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/nvidia-container-toolkit.git"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/container-toolkit"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.title="NVIDIA Container Toolkit Installer"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.base.name="nvcr.io/nvidia/distroless/go"
 
 COPY LICENSE /licenses/
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -90,6 +90,7 @@ $(IMAGE_TARGETS): image-%: $(ARTIFACTS_ROOT)
 		--build-arg GIT_COMMIT_SHORT="$(GIT_COMMIT_SHORT)" \
 		--build-arg GIT_BRANCH="$(GIT_BRANCH)" \
 		--build-arg SOURCE_DATE_EPOCH="$(SOURCE_DATE_EPOCH)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--build-arg GOPROXY="$(GOPROXY)" \
 		-f $(DOCKERFILE) \
 		$(CURDIR)


### PR DESCRIPTION
Before:
```
$ docker inspect  --format='{{json .Config.Labels}}' nvcr.io/nvidia/k8s/container-toolkit:v1.19.1-packaging | jq
{
  "description": "See summary",
  "name": "NVIDIA Container Toolkit Packages",
  "org.opencontainers.image.created": "2026-05-18T21:47:34Z",
  "org.opencontainers.image.documentation": "https://developer.download.nvidia.com/distroless-oss/docs.html",
  "org.opencontainers.image.revision": "11b4c4f6551bc720c7c2509330eb23e501cf831d",
  "org.opencontainers.image.title": "Golang Distroless Image",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.version": "v4.0.6",
  "release": "N/A",
  "summary": "deb and rpm packages for the NVIDIA Container Toolkit",
  "vendor": "NVIDIA",
  "version": "09ceee5d"
}
```
After:
```
$ docker inspect  --format='{{json .Config.Labels}}' ghcr.io/nvidia/container-toolkit:dcd0a425-packaging | jq   
{
  "description": "See summary",
  "name": "NVIDIA Container Toolkit Packages",
  "org.opencontainers.base.name": "nvcr.io/nvidia/distroless/go",
  "org.opencontainers.image.created": "2026-08-11T22:55:21Z",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/container-toolkit",
  "org.opencontainers.image.revision": "dcd0a425a599a456b916d9d65abd2b1ec8224e69",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/nvidia-container-toolkit.git",
  "org.opencontainers.image.title": "NVIDIA Container Toolkit Packages",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "dcd0a425",
  "release": "N/A",
  "summary": "deb and rpm packages for the NVIDIA Container Toolkit",
  "vendor": "NVIDIA",
  "version": "dcd0a425"
}

```