### PR TITLE
fix: Create NVIDIA control device nodes in nvidia-cdi-refresh.service

### DIFF
--- a/deployments/systemd/nvidia-cdi-refresh.env
+++ b/deployments/systemd/nvidia-cdi-refresh.env
@@ -18,3 +18,12 @@
 # For example, to change the for the generated CDI specification update and
 # uncomment the following line:
 # NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml
+
+# The service also runs
+#   nvidia-ctk system create-device-nodes --control-devices --load-kernel-modules
+# before generating the CDI specification. Its driver and device roots can be
+# overridden by uncommenting the following lines (nvidia-ctk cdi generate uses
+# the separate NVIDIA_CTK_DRIVER_ROOT and NVIDIA_CTK_DEV_ROOT variables):
+#
+# NVIDIA_DRIVER_ROOT=/
+# NVIDIA_DEV_ROOT=/

--- a/deployments/systemd/nvidia-cdi-refresh.service
+++ b/deployments/systemd/nvidia-cdi-refresh.service
@@ -29,6 +29,13 @@ Environment=NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml
 EnvironmentFile=-/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
 ExecCondition=/bin/sh -c '/usr/bin/grep -qE "/(nvidia|nvidia-current)[.]ko" /lib/modules/%v/modules.dep || [ -e /dev/dxg ]'
 ExecStart=/bin/sh -c '/usr/bin/nvidia-smi -L || /usr/sbin/nvidia-smi -L || /usr/lib/wsl/lib/nvidia-smi -L'
+# Create any missing NVIDIA control device nodes (loading the kernel modules
+# they require) before generating the CDI specification; nothing else is
+# guaranteed to create them. Best-effort, and skipped on WSL where /dev/dxg is
+# used instead, as well as on Tegra platforms using the nvgpu kernel module.
+# If module loading fails (for example while a driver upgrade has replaced the
+# on-disk modules) still create the nodes for the modules that are loaded.
+ExecStart=-/bin/sh -c '[ -e /dev/dxg ] || /usr/bin/grep -q "^nvgpu " /proc/modules || /usr/bin/nvidia-ctk system create-device-nodes --control-devices --load-kernel-modules || /usr/bin/nvidia-ctk system create-device-nodes --control-devices'
 ExecStart=/usr/bin/nvidia-ctk cdi generate
 CapabilityBoundingSet=CAP_SYS_MODULE CAP_SYS_ADMIN CAP_MKNOD
 # We set the service to restart on failure to ensure that a CDI spec is

--- a/deployments/udev/99-nvidia-cdi-refresh.rules
+++ b/deployments/udev/99-nvidia-cdi-refresh.rules
@@ -1,0 +1,22 @@
+# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The NVIDIA control device nodes (/dev/nvidiactl, /dev/nvidia-modeset, and
+# /dev/nvidia-uvm*) are created on demand by userspace and are not provided by
+# devtmpfs, so loading the NVIDIA kernel module does not guarantee that they
+# exist. Trigger nvidia-cdi-refresh.service on module load to create the
+# missing nodes and refresh the CDI specification.
+# Debian packages the kernel module as nvidia-current, which appears in sysfs
+# as nvidia_current.
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia|nvidia_current", TAG+="systemd", ENV{SYSTEMD_WANTS}+="nvidia-cdi-refresh.service"

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -56,6 +56,7 @@ RUN make PREFIX=${DIST_DIR} cmds
 WORKDIR $DIST_DIR
 COPY packaging/debian ./debian
 COPY deployments/systemd/ .
+COPY deployments/udev/ .
 
 RUN dch --create --package="${PKG_NAME}" \
         --newversion "${REVISION}" \

--- a/docker/Dockerfile.opensuse-leap
+++ b/docker/Dockerfile.opensuse-leap
@@ -48,6 +48,7 @@ RUN make PREFIX=${DIST_DIR} cmds
 WORKDIR $DIST_DIR/..
 COPY packaging/rpm .
 COPY deployments/systemd/ ${DIST_DIR}/
+COPY deployments/udev/ ${DIST_DIR}/
 
 CMD arch=$(uname -m) && \
     rpmbuild --clean --target=$arch -bb \

--- a/docker/Dockerfile.rpm-yum
+++ b/docker/Dockerfile.rpm-yum
@@ -76,6 +76,7 @@ RUN make PREFIX=${DIST_DIR} cmds
 WORKDIR $DIST_DIR/..
 COPY packaging/rpm .
 COPY deployments/systemd/ ${DIST_DIR}/
+COPY deployments/udev/ ${DIST_DIR}/
 
 CMD arch=$(uname -m) && \
     rpmbuild --clean --target=$arch -bb \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -54,6 +54,7 @@ RUN make PREFIX=${DIST_DIR} cmds
 WORKDIR $DIST_DIR
 COPY packaging/debian ./debian
 COPY deployments/systemd/ .
+COPY deployments/udev/ .
 
 RUN dch --create --package="${PKG_NAME}" \
         --newversion "${REVISION}" \

--- a/packaging/debian/nvidia-container-toolkit-base.install
+++ b/packaging/debian/nvidia-container-toolkit-base.install
@@ -4,3 +4,4 @@ nvidia-cdi-hook /usr/bin
 nvidia-cdi-refresh.service /lib/systemd/system/
 nvidia-cdi-refresh.path /lib/systemd/system/
 nvidia-cdi-refresh.env /etc/nvidia-container-toolkit/
+99-nvidia-cdi-refresh.rules /lib/udev/rules.d/

--- a/packaging/debian/nvidia-container-toolkit-base.postinst
+++ b/packaging/debian/nvidia-container-toolkit-base.postinst
@@ -5,6 +5,12 @@ set -e
 case "$1" in
     configure)
         /usr/bin/nvidia-ctk --quiet config --config-file=/etc/nvidia-container-runtime/config.toml --in-place
+
+        # Reload udev rules so that the nvidia-cdi-refresh rules take effect
+        # without a reboot.
+        if command -v udevadm >/dev/null 2>&1; then
+            udevadm control --reload-rules >/dev/null 2>&1 || true
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -16,3 +16,4 @@ override_dh_fixperms:
 	chmod 755 debian/$(shell dh_listpackages)/usr/bin/nvidia-cdi-hook || true
 	chmod 644 debian/$(shell dh_listpackages)/lib/systemd/system/nvidia-cdi-refresh.service || true
 	chmod 644 debian/$(shell dh_listpackages)/lib/systemd/system/nvidia-cdi-refresh.path || true
+	chmod 644 debian/$(shell dh_listpackages)/lib/udev/rules.d/99-nvidia-cdi-refresh.rules || true

--- a/packaging/rpm/SPECS/nvidia-container-toolkit.spec
+++ b/packaging/rpm/SPECS/nvidia-container-toolkit.spec
@@ -21,12 +21,17 @@ Source7: nvidia-cdi-refresh.service
 Source8: nvidia-cdi-refresh.path
 Source9: nvidia-cdi-refresh.env
 Source10: 90-nvidia-container-toolkit.preset
+Source11: 99-nvidia-cdi-refresh.rules
 
 %if 0%{?rhel} == 7 || 0%{?amzn} == 2
 BuildRequires: systemd
 %else
 BuildRequires: systemd-rpm-macros
 %endif
+
+# Distributions that don't define the udev rules directory macro fall back to
+# the default location.
+%{!?_udevrulesdir: %global _udevrulesdir %{_prefix}/lib/udev/rules.d}
 
 Obsoletes: nvidia-container-runtime <= 3.5.0-1, nvidia-container-runtime-hook <= 1.4.0-2
 Provides: nvidia-container-runtime
@@ -38,12 +43,13 @@ Requires: nvidia-container-toolkit-base == %{version}-%{release}
 Provides tools and utilities to enable GPU support in containers.
 
 %prep
-cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} %{SOURCE9} %{SOURCE10} .
+cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} %{SOURCE9} %{SOURCE10} %{SOURCE11} .
 
 %install
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_presetdir}
+mkdir -p %{buildroot}%{_udevrulesdir}
 mkdir -p %{buildroot}%{_sysconfdir}/nvidia-container-toolkit
 
 install -m 755 -t %{buildroot}%{_bindir} nvidia-container-runtime-hook
@@ -55,6 +61,7 @@ install -m 755 -t %{buildroot}%{_bindir} nvidia-cdi-hook
 install -m 644 -t %{buildroot}%{_unitdir} nvidia-cdi-refresh.service
 install -m 644 -t %{buildroot}%{_unitdir} nvidia-cdi-refresh.path
 install -m 644 -t %{buildroot}%{_presetdir} 90-nvidia-container-toolkit.preset
+install -m 644 -t %{buildroot}%{_udevrulesdir} 99-nvidia-cdi-refresh.rules
 install -m 644 -t %{buildroot}%{_sysconfdir}/nvidia-container-toolkit nvidia-cdi-refresh.env
 
 %post
@@ -129,6 +136,12 @@ for unit in nvidia-cdi-refresh.path nvidia-cdi-refresh.service; do
   fi
 done
 
+# Reload udev rules so that the nvidia-cdi-refresh rules take effect without a
+# reboot.
+if command -v udevadm >/dev/null 2>&1; then
+  udevadm control --reload-rules >/dev/null 2>&1 || :
+fi
+
 # Trigger CDI refresh on running systemd hosts without making install depend on
 # the current system state.
 if command -v systemctl >/dev/null 2>&1; then
@@ -148,6 +161,7 @@ fi
 %{_unitdir}/nvidia-cdi-refresh.service
 %{_unitdir}/nvidia-cdi-refresh.path
 %{_presetdir}/90-nvidia-container-toolkit.preset
+%{_udevrulesdir}/99-nvidia-cdi-refresh.rules
 %config(noreplace) %{_sysconfdir}/nvidia-container-toolkit/nvidia-cdi-refresh.env
 
 # The OPERATOR EXTENSIONS package consists of components that are required to enable GPU support in Kubernetes.

--- a/tests/e2e/nvidia-cdi-refresh_test.go
+++ b/tests/e2e/nvidia-cdi-refresh_test.go
@@ -93,6 +93,13 @@ EOF
 	fi
 	`
 
+	nvidiaCdiRefreshUdevRulesInstalledTemplate = `
+	if [ ! -f /lib/udev/rules.d/99-nvidia-cdi-refresh.rules ]; then
+		echo "99-nvidia-cdi-refresh.rules is not installed"
+		exit 1
+	fi
+	`
+
 	nvidiaCdiRefreshFileExistsTemplate = `
 	# is /var/run/cdi/nvidia.yaml exists? and exit with 0 if it does not exist
 	if [ ! -f /var/run/cdi/nvidia.yaml ]; then
@@ -209,6 +216,11 @@ var _ = Describe("nvidia-cdi-refresh", Ordered, ContinueOnFailure, Label("system
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should install the nvidia-cdi-refresh udev rules", func(ctx context.Context) {
+			_, _, err := systemdRunner.Run(nvidiaCdiRefreshUdevRulesInstalledTemplate)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should generate the nvidia.yaml file", func(ctx context.Context) {
 			_, _, err := systemdRunner.Run(nvidiaCdiRefreshFileExistsTemplate)
 			Expect(err).ToNot(HaveOccurred())
@@ -255,6 +267,11 @@ var _ = Describe("nvidia-cdi-refresh", Ordered, ContinueOnFailure, Label("system
 
 		It("should load the nvidia-cdi-refresh.service unit", func(ctx context.Context) {
 			_, _, err := systemdRunner.Run(nvidiaCdiRefreshServiceLoadedTemplate)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should install the nvidia-cdi-refresh udev rules", func(ctx context.Context) {
+			_, _, err := systemdRunner.Run(nvidiaCdiRefreshUdevRulesInstalledTemplate)
 			Expect(err).ToNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
Reviewers: @elezar @myeolenv 

Associated with https://github.com/NVIDIA/libnvidia-container/pull/388.

Closes #1982

## Summary

**Re-enables Wayland and associated Vulkan and OpenGL capabilities on the container toolkit without workarounds.**

CDI spec generation only discovered NVIDIA control device nodes that already existed on the host; on systems where no host component triggers their creation, `/dev/nvidia-modeset` (and, after a reboot, the UVM nodes) were silently omitted from the generated specifications. This change creates missing control device nodes ahead of discovery — the programmatic equivalent of running `nvidia-ctk system create-device-nodes --control-devices --load-kernel-modules` at the points where specifications are produced. The legacy-mode counterpart (mounting the node for the `graphics` capability) is NVIDIA/libnvidia-container#388, keeping each half in the component that owns the behavior.

## Why This Exists

The NVIDIA driver does not register its device nodes with devtmpfs; nodes such as `/dev/nvidia-modeset` are created on demand by userspace driver components. On headless Docker hosts (typical Debian, Ubuntu, and Arch installations) nothing ever triggers modeset creation, so:

- `nvidia-ctk cdi generate`, the `nvidia-cdi-refresh` service, and jit-cdi mode (the default resolution of `mode = "auto"`) generated specs without the node, and containers requesting any capability set never received it. Wayland/KMS clients in containers fail as a result.
- In legacy mode, `nvidia-container-cli` creates the node under `--load-kmods` but mounts it only for the `display` capability; NVIDIA/libnvidia-container#388 extends that mount to `graphics`.
- The Kubernetes toolkit installer already pre-creates control device nodes, which explains why GPU Operator nodes behaved differently from plain Docker hosts for identical images.

This closes the device half of the container Wayland/X11 enablement tracked in #1477 and #563.