### PR TITLE
fix: NVIDIA X.Org driver modules mount fixes

### DIFF
--- a/internal/discover/graphics.go
+++ b/internal/discover/graphics.go
@@ -55,29 +55,58 @@ func NewGraphicsMountsDiscoverer(logger logger.Interface, driver *root.Driver, h
 		return nil, fmt.Errorf("failed to construct discoverer for graphics libraries: %w", err)
 	}
 
-	configs := NewMounts(
+	binaries := NewMounts(
 		logger,
-		driver.Configs(),
+		lookup.NewExecutableLocator(logger, driver.Root),
 		driver.Root,
 		[]string{
-			"glvnd/egl_vendor.d/10_nvidia.json",
-			"egl/egl_external_platform.d/15_nvidia_gbm.json",
-			"egl/egl_external_platform.d/10_nvidia_wayland.json",
-			"egl/egl_external_platform.d/09_nvidia_wayland2.json",
-			"nvidia/nvoptix.bin",
-			"X11/xorg.conf.d/10-nvidia.conf",
-			"X11/xorg.conf.d/nvidia-drm-outputclass.conf",
-			"OpenCL/vendors/nvidia.icd",
+			"nvidia-xconfig",
 		},
 	)
 
 	discover := Merge(
 		libraries,
-		configs,
+		binaries,
+		newGraphicsConfigsDiscoverer(logger, driver),
 		newVulkanConfigsDiscover(logger, driver),
 	)
 
 	return discover, nil
+}
+
+// newGraphicsConfigsDiscoverer creates a discoverer for graphics-related config
+// files such as the EGL vendor and external platform ICD files.
+// The config files are mounted at the standard locations in the container so
+// that they are discovered by the loaders in the container even if they are
+// installed at non-standard locations on the host.
+func newGraphicsConfigsDiscoverer(logger logger.Interface, driver *root.Driver) Discover {
+	shareConfigs := WithCache(&mountsToContainerPath{
+		logger:  logger,
+		locator: driver.Configs(),
+		required: []string{
+			"glvnd/egl_vendor.d/10_nvidia.json",
+			"egl/egl_external_platform.d/15_nvidia_gbm.json",
+			"egl/egl_external_platform.d/10_nvidia_wayland.json",
+			"egl/egl_external_platform.d/09_nvidia_wayland2.json",
+			"egl/egl_external_platform.d/20_nvidia_xcb.json",
+			"egl/egl_external_platform.d/20_nvidia_xlib.json",
+			"nvidia/nvoptix.bin",
+			"X11/xorg.conf.d/10-nvidia.conf",
+			"X11/xorg.conf.d/nvidia-drm-outputclass.conf",
+		},
+		containerRoot: "/usr/share",
+	})
+
+	etcConfigs := WithCache(&mountsToContainerPath{
+		logger:  logger,
+		locator: driver.Configs(),
+		required: []string{
+			"OpenCL/vendors/nvidia.icd",
+		},
+		containerRoot: "/etc",
+	})
+
+	return Merge(shareConfigs, etcConfigs)
 }
 
 // newVulkanConfigsDiscover creates a discoverer for vulkan ICD files.
@@ -101,12 +130,12 @@ func newVulkanConfigsDiscover(logger logger.Interface, driver *root.Driver) Disc
 	case "arm64":
 		required = append(required, "vulkan/icd.d/nvidia_icd.aarch64.json")
 	}
-	return &mountsToContainerPath{
+	return WithCache(&mountsToContainerPath{
 		logger:        logger,
 		locator:       locator,
 		required:      required,
 		containerRoot: "/etc",
-	}
+	})
 }
 
 type graphicsDriverLibraries struct {
@@ -135,11 +164,14 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 		driver.Libraries(),
 		driver.Root,
 		[]string{
-			// The libnvidia-egl-gbm and libnvidia-egl-wayland libraries do not
-			// have the RM version. Use the *.* pattern to match X.Y.Z versions.
+			// The EGL platform libraries such as libnvidia-egl-gbm and
+			// libnvidia-egl-wayland do not have the RM version. Use the *.*
+			// pattern to match X.Y.Z versions.
 			"libnvidia-egl-gbm.so.*.*",
 			"libnvidia-egl-wayland.so.*.*",
 			"libnvidia-egl-wayland2.so.*.*",
+			"libnvidia-egl-xcb.so.*.*",
+			"libnvidia-egl-xlib.so.*.*",
 			// We include the following libraries to have them available for
 			// symlink creation below:
 			// If CDI injection is used, these should already be detected as:
@@ -151,6 +183,10 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 		},
 	)
 
+	// The X.Org driver modules are mounted at their host paths. This keeps any
+	// ModulePath specified in the xorg.conf.d config file that is mounted into
+	// the container valid and means that modules installed to the default X.Org
+	// module path on the host are also found there in the container.
 	xorgLibraries := NewMounts(
 		logger,
 		lookup.NewFileLocator(
@@ -231,7 +267,7 @@ func (d graphicsDriverLibraries) Hooks() ([]Hook, error) {
 		return nil, nil
 	}
 
-	hook := d.hookCreator.Create("create-symlinks", links...)
+	hook := d.hookCreator.Create(CreateSymlinksHook, links...)
 
 	return hook.Hooks()
 }

--- a/internal/discover/graphics_test.go
+++ b/internal/discover/graphics_test.go
@@ -17,6 +17,7 @@
 package discover
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/devices"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/lookup/root"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
 )
 
@@ -185,6 +187,78 @@ func TestGraphicsLibrariesDiscoverer(t *testing.T) {
 			require.EqualValues(t, tc.expectedHooks, hooks)
 			require.Len(t, tc.libraries.calls.Mounts, 2)
 			require.Len(t, tc.libraries.calls.Hooks, 0)
+		})
+	}
+}
+
+func TestGraphicsConfigsDiscoverer(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+
+	testCases := []struct {
+		description string
+		files       []string
+		// expected maps the path of the file in the driver root to the path
+		// that it is expected to be mounted at in the container.
+		expected map[string]string
+	}{
+		{
+			description: "config files in the standard locations",
+			files: []string{
+				"/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
+				"/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json",
+				"/usr/share/X11/xorg.conf.d/10-nvidia.conf",
+				"/etc/OpenCL/vendors/nvidia.icd",
+			},
+			expected: map[string]string{
+				"/usr/share/glvnd/egl_vendor.d/10_nvidia.json":              "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
+				"/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json": "/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json",
+				"/usr/share/X11/xorg.conf.d/10-nvidia.conf":                 "/usr/share/X11/xorg.conf.d/10-nvidia.conf",
+				"/etc/OpenCL/vendors/nvidia.icd":                            "/etc/OpenCL/vendors/nvidia.icd",
+			},
+		},
+		{
+			description: "config files in non-standard locations are mounted at the standard locations",
+			files: []string{
+				"/usr/local/share/glvnd/egl_vendor.d/10_nvidia.json",
+				"/usr/local/share/egl/egl_external_platform.d/20_nvidia_xlib.json",
+				"/etc/X11/xorg.conf.d/nvidia-drm-outputclass.conf",
+			},
+			expected: map[string]string{
+				"/usr/local/share/glvnd/egl_vendor.d/10_nvidia.json":               "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
+				"/usr/local/share/egl/egl_external_platform.d/20_nvidia_xlib.json": "/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json",
+				"/etc/X11/xorg.conf.d/nvidia-drm-outputclass.conf":                 "/usr/share/X11/xorg.conf.d/nvidia-drm-outputclass.conf",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// The config search paths include the XDG data dirs. These are
+			// set explicitly to ensure that the test is not affected by the
+			// environment that it is run in.
+			t.Setenv("XDG_DATA_DIRS", "/usr/local/share:/usr/share")
+
+			driverRoot := t.TempDir()
+			for _, f := range tc.files {
+				path := filepath.Join(driverRoot, f)
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+				require.NoError(t, os.WriteFile(path, []byte{}, 0600))
+			}
+
+			driver := root.New(
+				root.WithLogger(logger),
+				root.WithDriverRoot(driverRoot),
+			)
+
+			mounts, err := newGraphicsConfigsDiscoverer(logger, driver).Mounts()
+			require.NoError(t, err)
+
+			discovered := make(map[string]string)
+			for _, mount := range mounts {
+				hostPath := strings.TrimPrefix(mount.HostPath, driverRoot)
+				discovered[hostPath] = mount.Path
+			}
+			require.EqualValues(t, tc.expected, discovered)
 		})
 	}
 }


### PR DESCRIPTION
Reviewers: @elezar @cdesiniotis @henry118

Fixes #1477
Fixes #563

## Summary

Graphics config files for the NVIDIA driver were mounted into the container at their host paths, so on hosts that do not install them under `/usr/share` (or `/etc` for the OpenCL ICD) they land where the loaders in the container never look. This mounts them at the canonical container locations, mirroring the existing Vulkan ICD handling, and injects the EGL X11 platform libraries and `nvidia-xconfig`.

The `create-xorg-config` CDI hook from the previous revision of this PR is gone. Per @cdesiniotis' review, the host's `xorg.conf.d` snippet is what carries the `ModulePath` when the driver installs the X.Org modules outside the default X.Org module path; mounting that snippet where the container's X server reads it is sufficient, and a host without one is treated as a host-side misconfiguration.

## Why This Exists

EGL vendor, EGL external platform and GLVND config files were mounted at their host paths. On hosts with non-FHS layouts these land where container glvnd never looks, forcing workarounds such as `__EGL_VENDOR_LIBRARY_FILENAMES`. The same applies to the `xorg.conf.d` snippet that makes the injected X.Org modules loadable, and to the OpenCL ICD.

The EGL X11 platform libraries (`libnvidia-egl-xcb`, `libnvidia-egl-xlib`) and their external platform config files were not discovered at all, even though the GBM and Wayland platform libraries next to them are.

## Resolution

- EGL/GLVND/X11 config files are mounted at `/usr/share/...` and the OpenCL ICD at `/etc/OpenCL/vendors`, mirroring the existing Vulkan ICD handling.
- The X.Org driver modules keep being mounted at their host paths, so an absolute `ModulePath` in the mounted snippet stays valid in the container, and modules installed to the default X.Org module path on the host are found at the same path in the container.
- `libnvidia-egl-xcb.so.*.*`, `libnvidia-egl-xlib.so.*.*` and their external platform JSON files are discovered and injected.
- `nvidia-xconfig` is injected when present on the host.
- All the mount discoverers in `graphics.go` are wrapped in `WithCache` (per @henry118's earlier review); the X.Org modules were previously discovered twice because `graphicsDriverLibraries` reads `Mounts()` from both `Mounts()` and `Hooks()`.

## Behavior Changes

- Containers requesting `graphics` or `display` receive the config files at canonical paths, the EGL X11 platform libraries and their config files, and `nvidia-xconfig` where installed.
- No new hooks are generated. The generated spec differs from `main` only by those mounts.
- Hosts without the relevant files see per-file discovery warnings, as with existing optional components.

## Implementation Summary

- Split the graphics config discovery out into `newGraphicsConfigsDiscoverer`, using `mountsToContainerPath` for `/usr/share` and `/etc`.
- Add the EGL X11 platform libraries to the graphics library discoverer and `nvidia-xconfig` to a binaries discoverer.
- Add `TestGraphicsConfigsDiscoverer`, covering both standard and non-standard host locations.

## Verification

`go test ./...` failing set is identical to the unmodified `main` baseline on the validation host (all failures are pre-existing environment failures in `nvidia-ctk-installer`, `internal/modifier` CSV mode and `pkg/nvcdi`); `golangci-lint run ./...` reports 0 issues; `gofmt` is clean.

Real-host validation on 2x Tesla P100, driver 580.178.04, Ubuntu 26.04, Docker 29.7.2, container `ubuntu:24.04` with only `xserver-xorg-core` and `mesa-utils` installed:

1. **Host with modules in the default X.Org module path** (`/usr/lib/xorg/modules/{drivers,extensions}`, Ubuntu packaging, snippet without a `ModulePath`): X.Org loads `nvidia_drv.so` and `libglxserver_nvidia.so` from `/usr/lib/xorg/modules/...`, `glxinfo -B` reports `Tesla P100-SXM2-16GB/PCIe/SSE2`. Unchanged from `main`.

2. **Host with modules outside the default X.Org module path** (`/usr/lib/x86_64-linux-gnu/nvidia/xorg`, with the host `10-nvidia.conf` carrying the matching `ModulePath`): the mounted snippet is what makes it work.

   ```
   (==) ModulePath set to "/usr/lib/xorg/modules"
   (**) OutputClass "nvidia" ModulePath extended to "/usr/lib/x86_64-linux-gnu/nvidia/xorg,/usr/lib/xorg/modules"
   (II) LoadModule: "nvidia"
   (II) Loading /usr/lib/x86_64-linux-gnu/nvidia/xorg/nvidia_drv.so
   (II) LoadModule: "glxserver_nvidia"
   (II) Loading /usr/lib/x86_64-linux-gnu/nvidia/xorg/libglxserver_nvidia.so
   (II) NVIDIA GLX Module  580.178.04
   ```

   `glxinfo -B` and the EGL X11 platform both report `Tesla P100-SXM2-16GB/PCIe/SSE2`.

   Note: `MatchDriver "nvidia-drm"` only matches when the DRM device nodes are present in the container, so this path requires `nvidia-drm` loaded on the host and the `display`/`graphics` capability. With `nvidia_drm` unloaded the OutputClass never matches and no `ModulePath` is applied.

3. `nvidia-xconfig` in the container generates a working BusID `xorg.conf`; `libEGL_nvidia` dlopens the injected `libnvidia-egl-xcb.so.1`/`libnvidia-egl-xlib.so.1` when their config files are present (verified with `LD_DEBUG=libs`). On 580 the built-in X11 platform still services `EGL_PLATFORM_X11`, so injecting them is about keeping the container's EGL platform set matching the host's rather than fixing an observed failure today.

4. Legacy-mode parity (`mode = "legacy"`): `graphics` receives the same set as CDI mode; `compute,utility` receives none of it, unchanged from `main`.