### PR TITLE
add new CDI hook to set CUDA memory limits [DO-NOT-MERGE]

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -27,14 +27,17 @@ busybox binary is added to the image, which is licensed under GPLv2.
 | `github.com/containerd/log` | Apache-2.0 | `github.com/containerd/log` |
 | `github.com/containerd/nri/pkg` | Apache-2.0 | `github.com/containerd/nri` |
 | `github.com/containerd/ttrpc` | Apache-2.0 | `github.com/containerd/ttrpc` |
+| `github.com/coreos/go-systemd/v22/dbus` | Apache-2.0 | `github.com/coreos/go-systemd/v22` |
 | `github.com/cyphar/filepath-securejoin` | BSD-3-Clause / MPL-2.0 | `github.com/cyphar/filepath-securejoin` |
 | `github.com/fsnotify/fsnotify` | BSD-3-Clause | `github.com/fsnotify/fsnotify` |
+| `github.com/godbus/dbus/v5` | BSD-2-Clause | `github.com/godbus/dbus/v5` |
 | `github.com/google/uuid` | BSD-3-Clause | `github.com/google/uuid` |
 | `github.com/knqyf263/go-plugin/wasm` | MIT | `github.com/knqyf263/go-plugin` |
 | `github.com/moby/sys/capability` | BSD-2-Clause | `github.com/moby/sys/capability` |
 | `github.com/moby/sys/mountinfo` | Apache-2.0 | `github.com/moby/sys/mountinfo` |
 | `github.com/moby/sys/reexec` | Apache-2.0 | `github.com/moby/sys/reexec` |
-| `github.com/opencontainers/cgroups/devices/config` | Apache-2.0 | `github.com/opencontainers/cgroups` |
+| `github.com/moby/sys/userns` | Apache-2.0 | `github.com/moby/sys/userns` |
+| `github.com/opencontainers/cgroups` | Apache-2.0 | `github.com/opencontainers/cgroups` |
 | `github.com/opencontainers/runc` | Apache-2.0 | `github.com/opencontainers/runc` |
 | `github.com/opencontainers/runtime-spec/specs-go` | Apache-2.0 | `github.com/opencontainers/runtime-spec` |
 | `github.com/opencontainers/runtime-tools` | Apache-2.0 | `github.com/opencontainers/runtime-tools` |
@@ -1155,6 +1158,220 @@ the PCI ID Project at https://pci-ids.ucw.cz/.
 ```
 
 
+### github.com/coreos/go-systemd/v22/dbus
+
+* License: Apache-2.0
+* Module: github.com/coreos/go-systemd/v22
+
+#### LICENSE
+
+```text
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
+#### NOTICE
+
+```text
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).
+
+```
+
+
 ### github.com/cyphar/filepath-securejoin
 
 * License: BSD-3-Clause / MPL-2.0
@@ -2064,6 +2281,43 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 
+### github.com/godbus/dbus/v5
+
+* License: BSD-2-Clause
+* Module: github.com/godbus/dbus/v5
+
+#### LICENSE
+
+```text
+Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
+
 ### github.com/google/uuid
 
 * License: BSD-3-Clause
@@ -2601,7 +2855,221 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 
-### github.com/opencontainers/cgroups/devices/config
+### github.com/moby/sys/userns
+
+* License: Apache-2.0
+* Module: github.com/moby/sys/userns
+
+#### LICENSE
+
+```text
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
+
+### github.com/opencontainers/cgroups
 
 * License: Apache-2.0
 * Module: github.com/opencontainers/cgroups

--- a/cmd/nvidia-cdi-hook/apply-cuda-memory-limits/apply-cuda-memory-limits.go
+++ b/cmd/nvidia-cdi-hook/apply-cuda-memory-limits/apply-cuda-memory-limits.go
@@ -1,0 +1,185 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package cudamemorylimits
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/urfave/cli/v3"
+
+	cgroupinfo "github.com/NVIDIA/nvidia-container-toolkit/internal/info/cgroup"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/oci"
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/lookup"
+)
+
+type command struct {
+	logger logger.Interface
+}
+
+type config struct {
+	driverRoot    string
+	gpuIds        []string
+	containerSpec string
+}
+
+func NewCommand(logger logger.Interface) *cli.Command {
+	c := command{
+		logger: logger,
+	}
+	return c.build()
+}
+
+func (m command) build() *cli.Command {
+	cfg := config{}
+
+	c := cli.Command{
+		Name:  "apply-cuda-memory-limits",
+		Usage: "Set the soft and hard limits of CUDA memory usage on a GPU device in the container.",
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			return ctx, m.validateFlags(cmd, &cfg)
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return m.run(cmd, &cfg)
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "driver-root",
+				Usage:       "Specify the driver root",
+				Destination: &cfg.driverRoot,
+			},
+			&cli.StringSliceFlag{
+				Name:        "gpu-id",
+				Usage:       "Specify the UUID of the GPU",
+				Destination: &cfg.gpuIds,
+			},
+			&cli.StringFlag{
+				Name:        "container-spec",
+				Usage:       "Specify the path to the OCI container spec. If empty or '-' the spec will be read from STDIN",
+				Destination: &cfg.containerSpec,
+			},
+		},
+	}
+
+	return &c
+}
+
+func (m command) validateFlags(_ *cli.Command, cfg *config) error {
+	for _, id := range cfg.gpuIds {
+		if strings.TrimSpace(id) == "" {
+			return fmt.Errorf("gpu-id must not be empty")
+		}
+	}
+
+	return nil
+}
+
+func (m command) run(_ *cli.Command, cfg *config) error {
+	s, err := oci.LoadContainerState(cfg.containerSpec)
+	if err != nil {
+		return fmt.Errorf("failed to load container state: %w", err)
+	}
+	specFilePath := oci.GetSpecFilePath(s.Bundle)
+	fs := oci.NewFileSpec(specFilePath, false)
+	ctrSpec, err := fs.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load OCI container spec: %w", err)
+	}
+
+	memReqStr, ok1 := fs.LookupEnv("NVIDIA_GPU_MEMORY_REQUESTS")
+	if !ok1 {
+		memReqStr, ok1 = fs.LookupEnv("NVIDIA_GPU_MEMORY_REQUEST")
+	}
+	memLimitStr, ok2 := fs.LookupEnv("NVIDIA_GPU_MEMORY_LIMITS")
+	if !ok2 {
+		memLimitStr, ok2 = fs.LookupEnv("NVIDIA_GPU_MEMORY_LIMIT")
+	}
+	if !ok1 || !ok2 {
+		return nil
+	}
+
+	if !cgroupinfo.IsCgroupV2() {
+		return fmt.Errorf("setting GPU memory limits is only supported in cgroup v2")
+	}
+
+	cgroupPath, err := cgroupinfo.GetAbsolutePath(*ctrSpec)
+	if err != nil {
+		return fmt.Errorf("failed to resolve cgroup path: %w", err)
+	}
+
+	memoryRequests, err := strconv.ParseUint(memReqStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse NVIDIA_GPU_MEMORY_REQUESTS: %w", err)
+	}
+
+	memoryLimits, err := strconv.ParseUint(memLimitStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse NVIDIA_GPU_MEMORY_LIMITS: %w", err)
+	}
+	if memoryRequests > memoryLimits {
+		return fmt.Errorf("memory request (%d MiB) exceeds memory limit (%d MiB)", memoryRequests, memoryLimits)
+	}
+
+	return m.runApplyCudaMemoryLimits(cgroupPath, memoryRequests, memoryLimits, cfg.driverRoot, cfg.gpuIds)
+}
+
+func (m command) runApplyCudaMemoryLimits(cgroupPath string, requests uint64, limits uint64, driverRoot string, gpuIDs []string) error {
+
+	driverLibLocator := lookup.NewLibraryLocator(
+		lookup.WithLogger(m.logger),
+		lookup.WithRoot(driverRoot),
+	)
+
+	candidates, err := driverLibLocator.Locate("libnvidia-ml.so.1")
+	if err != nil {
+		return fmt.Errorf("failed to locate libnvidia-ml.so.1: %w", err)
+	}
+	if len(candidates) == 0 {
+		return fmt.Errorf("no libnvidia-ml.so.1 found")
+	}
+
+	m.logger.Infof("driver library found: %s", candidates[0])
+
+	nvmllib := nvml.New(nvml.WithLibraryPath(candidates[0]))
+	ret := nvmllib.Init()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("failed to initialize nvml: %v", ret)
+	}
+	defer func() {
+		_ = nvmllib.Shutdown()
+	}()
+
+	for _, gpuID := range gpuIDs {
+		device, ret := nvmllib.DeviceGetHandleByUUID(gpuID)
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to get GPU device handle with uuid %s: %v", gpuID, ret)
+		}
+		if device == nil {
+			return fmt.Errorf("empty GPU device handle: %s", gpuID)
+		}
+		ret = device.SetMemoryLimits_v1(cgroupPath, int(requests*1024*1024), int(limits*1024*1024))
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to set memory limits for gpu %q: %v", gpuID, ret)
+		}
+	}
+	return nil
+}

--- a/cmd/nvidia-cdi-hook/commands/commands.go
+++ b/cmd/nvidia-cdi-hook/commands/commands.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	cudamemorylimits "github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-cdi-hook/apply-cuda-memory-limits"
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-cdi-hook/chmod"
 	symlinks "github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-cdi-hook/create-symlinks"
 	"github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-cdi-hook/cudacompat"
@@ -91,6 +92,7 @@ func ConfigureCDIHookCommand(logger logger.Interface, base *cli.Command) *cli.Co
 		chmod.NewCommand(logger),
 		cudacompat.NewCommand(logger),
 		disabledevicenodemodification.NewCommand(logger),
+		cudamemorylimits.NewCommand(logger),
 		updateapplicationprofile.NewCommand(logger),
 		{
 			Name:   "noop",

--- a/cmd/nvidia-ctk/cdi/generate/generate_test.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate_test.go
@@ -98,11 +98,35 @@ devices:
         deviceNodes:
             - path: /dev/nvidia0
               hostPath: {{ .driverRoot }}/dev/nvidia0
+        hooks:
+            - hookName: createRuntime
+              path: /usr/bin/nvidia-cdi-hook
+              args:
+                - nvidia-cdi-hook
+                - apply-cuda-memory-limits
+                - --driver-root
+                - {{ .driverRoot }}
+                - --gpu-id
+                - {{ .gpuID }}
+              env:
+                - NVIDIA_CTK_DEBUG=false
     - name: all
       containerEdits:
         deviceNodes:
             - path: /dev/nvidia0
               hostPath: {{ .driverRoot }}/dev/nvidia0
+        hooks:
+            - hookName: createRuntime
+              path: /usr/bin/nvidia-cdi-hook
+              args:
+                - nvidia-cdi-hook
+                - apply-cuda-memory-limits
+                - --driver-root
+                - {{ .driverRoot }}
+                - --gpu-id
+                - {{ .gpuID }}
+              env:
+                - NVIDIA_CTK_DEBUG=false
 containerEdits:
     env:
         - NVIDIA_CTK_LIBCUDA_DIR=/lib/x86_64-linux-gnu
@@ -180,7 +204,7 @@ containerEdits:
 				vendor:        "example.com",
 				class:         "device",
 				driverRoot:    driverRoot,
-				disabledHooks: []string{"enable-cuda-compat"},
+				disabledHooks: []string{"enable-cuda-compat", "apply-cuda-memory-limits"},
 			},
 			expectedOptions: options{
 				format:            "yaml",
@@ -189,7 +213,7 @@ containerEdits:
 				class:             "device",
 				nvidiaCDIHookPath: "/usr/bin/nvidia-cdi-hook",
 				driverRoot:        driverRoot,
-				disabledHooks:     []string{"enable-cuda-compat"},
+				disabledHooks:     []string{"enable-cuda-compat", "apply-cuda-memory-limits"},
 			},
 			expectedSpec: `---
 cdiVersion: 0.5.0
@@ -274,7 +298,7 @@ containerEdits:
 				vendor:        "example.com",
 				class:         "device",
 				driverRoot:    driverRoot,
-				disabledHooks: []string{"enable-cuda-compat", "update-ldcache"},
+				disabledHooks: []string{"enable-cuda-compat", "apply-cuda-memory-limits", "update-ldcache"},
 			},
 			expectedOptions: options{
 				format:            "yaml",
@@ -283,7 +307,7 @@ containerEdits:
 				class:             "device",
 				nvidiaCDIHookPath: "/usr/bin/nvidia-cdi-hook",
 				driverRoot:        driverRoot,
-				disabledHooks:     []string{"enable-cuda-compat", "update-ldcache"},
+				disabledHooks:     []string{"enable-cuda-compat", "apply-cuda-memory-limits", "update-ldcache"},
 			},
 			expectedSpec: `---
 cdiVersion: 0.5.0
@@ -539,7 +563,13 @@ containerEdits:
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, strings.ReplaceAll(tc.expectedSpec, "{{ .driverRoot }}", driverRoot), buf.String())
+			gpuID, ret := server.Devices[0].GetUUID()
+			require.True(t, ret == nvml.SUCCESS, gpuID)
+
+			expected := strings.ReplaceAll(tc.expectedSpec, "{{ .driverRoot }}", driverRoot)
+			expected = strings.ReplaceAll(expected, "{{ .gpuID }}", gpuID)
+
+			require.Equal(t, expected, buf.String())
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/NVIDIA/go-nvlib v0.12.0
-	github.com/NVIDIA/go-nvml v0.13.3-1
+	github.com/NVIDIA/go-nvml v0.13.3-1.0.20260814002628-7f946c0908a3
 	github.com/containerd/nri v0.12.1
 	github.com/cyphar/filepath-securejoin v0.7.0
 	github.com/google/uuid v1.6.0
@@ -31,12 +31,15 @@ require (
 	cyphar.com/go-pathrs v0.2.5 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
+	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/knqyf263/go-plugin v0.9.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
+	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NVIDIA/go-nvlib v0.12.0 h1:LICVlUGlDnpbwQv64rOZQn11xQae1J+c+dvH9CCi7jc=
 github.com/NVIDIA/go-nvlib v0.12.0/go.mod h1:J5M/QPIJJtaipjdONqevSnfgBlkW49uVWX5cFOoQpoA=
-github.com/NVIDIA/go-nvml v0.13.3-1 h1:P76U2h88OZSiMtdhRsJjSF5DXyXUqHIXKeDicVAaae0=
-github.com/NVIDIA/go-nvml v0.13.3-1/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
+github.com/NVIDIA/go-nvml v0.13.3-1.0.20260814002628-7f946c0908a3 h1:r6oO3PV4w/DCEqY7EXbZsQCu5TGs2oM0owr1vWvQxHg=
+github.com/NVIDIA/go-nvml v0.13.3-1.0.20260814002628-7f946c0908a3/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/brianvoe/gofakeit/v7 v7.12.1 h1:df1tiI4SL1dR5Ix4D/r6a3a+nXBJ/OBGU5jEKRBmmqg=
@@ -16,6 +16,8 @@ github.com/containerd/nri v0.12.1 h1:Nkp14W/mdhP0ze83ja/O437du6NQA33W5Y0O+ar3aKM
 github.com/containerd/nri v0.12.1/go.mod h1:TGAfPLH4a+qwbv0PxsefPiR+PobYecDj2aXMtz7GQcg=
 github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRqQ=
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.7.0 h1:s0Y3ITPy6sQn5xt54DuYvTF8hu134ooYLUb58DX/HjE=
 github.com/cyphar/filepath-securejoin v0.7.0/go.mod h1:ymLGms/u3BYaviIiuKFnUx8EkQEZeK6cInNoAPJA3o4=
@@ -27,6 +29,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -54,6 +58,8 @@ github.com/moby/sys/reexec v0.1.0 h1:RrBi8e0EBTLEgfruBOFcxtElzRGTEUkeIFaVXgU7wok
 github.com/moby/sys/reexec v0.1.0/go.mod h1:EqjBg8F3X7iZe5pU6nRZnYCMUTXoxsjiIfHup5wYIN8=
 github.com/moby/sys/symlink v0.3.0 h1:GZX89mEZ9u53f97npBy4Rc3vJKj7JBDj/PN2I22GrNU=
 github.com/moby/sys/symlink v0.3.0/go.mod h1:3eNdhduHmYPcgsJtZXW1W4XUJdZGBIkttZ8xKqPUJq0=
+github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
+github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/onsi/ginkgo/v2 v2.19.1 h1:QXgq3Z8Crl5EL1WBAC98A5sEBHARrAJNzAmMxzLcRF0=
 github.com/onsi/ginkgo/v2 v2.19.1/go.mod h1:O3DtEWQkPa/F7fBMgmZQKKsluAy8pd3rEQdrjkPb9zA=
 github.com/onsi/gomega v1.34.0 h1:eSSPsPNp6ZpsG8X1OVmOTxig+CblTc4AxpPBykhe2Os=

--- a/internal/discover/hooks.go
+++ b/internal/discover/hooks.go
@@ -63,6 +63,8 @@ const (
 	// An UpdateLDCacheHook is the hook used to update the ldcache in the
 	// container. This allows injected libraries to be discoverable.
 	UpdateLDCacheHook = HookName("update-ldcache")
+	// ApplyCudaMemoryLimitsHook is used to assign soft and hard limits of CUDA memory usage to a container
+	ApplyCudaMemoryLimitsHook = HookName("apply-cuda-memory-limits")
 
 	defaultNvidiaCDIHookPath = "/usr/bin/nvidia-cdi-hook"
 )
@@ -222,6 +224,8 @@ func (c cdiHookCreator) getOCIHookType(name HookName) OCIHookType {
 	switch name {
 	case CreateSymlinksHook, ChmodHook, DisableDeviceNodeModificationHook, EnableCudaCompatHook, UpdateLDCacheHook, ApplicationProfileHook:
 		return OCIHookTypeCreateContainer
+	case ApplyCudaMemoryLimitsHook:
+		return OCIHookTypeCreateRuntime
 	default:
 		return OCIHookTypeCreateContainer
 	}
@@ -238,7 +242,7 @@ func (c cdiHookCreator) isDisabled(name HookName, args ...string) bool {
 
 	// still reject hooks that require args if none were provided
 	switch name {
-	case CreateSymlinksHook, ChmodHook:
+	case CreateSymlinksHook, ChmodHook, ApplyCudaMemoryLimitsHook:
 		return len(args) == 0
 	}
 	return false
@@ -266,6 +270,11 @@ func (c cdiHookCreator) transformArgs(name HookName, args ...string) []string {
 		}
 		for _, arg := range args {
 			transformedArgs = append(transformedArgs, "--folder", arg)
+		}
+	case ApplyCudaMemoryLimitsHook:
+		transformedArgs = append(transformedArgs, "--driver-root", args[0])
+		for _, arg := range args[1:] {
+			transformedArgs = append(transformedArgs, "--gpu-id", arg)
 		}
 	default:
 		return args

--- a/internal/info/cgroup/cgroup_path.go
+++ b/internal/info/cgroup/cgroup_path.go
@@ -1,0 +1,137 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from github.com/opencontainers/cgroups,
+# licensed under the Apache License, Version 2.0.
+
+**/
+
+package cgroup
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fs2"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+)
+
+func IsCgroupV2() bool {
+	const v2FsMagicNumber = 0x63677270
+	var s unix.Statfs_t
+	err := unix.Statfs("/sys/fs/cgroup", &s)
+	if err != nil {
+		panic(err)
+	}
+	return s.Type == v2FsMagicNumber
+}
+
+func GetAbsolutePath(spec specs.Spec) (string, error) {
+	c := &cgroups.Cgroup{}
+	myCgroupPath := spec.Linux.CgroupsPath
+	parts := strings.Split(myCgroupPath, ":")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups, got %q instead", myCgroupPath)
+	}
+	c.Parent = parts[0]
+	c.ScopePrefix = parts[1]
+	c.Name = parts[2]
+
+	return getPath(c)
+}
+
+func getUnitName(c *cgroups.Cgroup) string {
+	// by default, we create a scope unless the user explicitly asks for a slice.
+	if !strings.HasSuffix(c.Name, ".slice") {
+		return c.ScopePrefix + "-" + c.Name + ".scope"
+	}
+	return c.Name
+}
+
+func getPath(c *cgroups.Cgroup) (string, error) {
+
+	sliceFull, err := getSliceFull(c)
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(sliceFull, getUnitName(c))
+	path, err = securejoin.SecureJoin(fs2.UnifiedMountpoint, path)
+	if err != nil {
+		return "", err
+	}
+
+	// an example of the final path in rootless:
+	// "/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/user.slice/libpod-132ff0d72245e6f13a3bbc6cdc5376886897b60ac59eaa8dea1df7ab959cbf1c.scope"
+
+	return path, nil
+}
+
+func getSliceFull(c *cgroups.Cgroup) (string, error) {
+	slice := "system.slice"
+	if c.Rootless {
+		slice = "user.slice"
+	}
+	if c.Parent != "" {
+		var err error
+		slice, err = expandSlice(c.Parent)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// an example of the final slice in rootless: "/user.slice/user-1001.slice/user@1001.service/user.slice"
+	// NOTE: systemdDbus.PropSlice requires the "/user.slice/user-1001.slice/user@1001.service/" prefix NOT to be specified.
+	return slice, nil
+}
+
+// systemd represents slice hierarchy using `-`, so we need to follow suit when
+// generating the path of slice. Essentially, test-a-b.slice becomes
+// /test.slice/test-a.slice/test-a-b.slice.
+func expandSlice(slice string) (string, error) {
+	suffix := ".slice"
+	// Name has to end with ".slice", but can't be just ".slice".
+	if len(slice) < len(suffix) || !strings.HasSuffix(slice, suffix) {
+		return "", fmt.Errorf("invalid slice name: %s", slice)
+	}
+
+	// Path-separators are not allowed.
+	if strings.Contains(slice, "/") {
+		return "", fmt.Errorf("invalid slice name: %s", slice)
+	}
+
+	var path, prefix string
+	sliceName := strings.TrimSuffix(slice, suffix)
+	// if input was -.slice, we should just return root now
+	if sliceName == "-" {
+		return "/", nil
+	}
+	for component := range strings.SplitSeq(sliceName, "-") {
+		// test--a.slice isn't permitted, nor is -test.slice.
+		if component == "" {
+			return "", fmt.Errorf("invalid slice name: %s", slice)
+		}
+
+		// Append the component to the path and to the prefix.
+		path += "/" + prefix + component + suffix
+		prefix += component + "-"
+	}
+	return path, nil
+}

--- a/pkg/nvcdi/cuda-memory-limits.go
+++ b/pkg/nvcdi/cuda-memory-limits.go
@@ -1,0 +1,54 @@
+package nvcdi
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/discover"
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
+)
+
+type cudaMemoryLimits struct {
+	logger      logger.Interface
+	driverRoot  string
+	uuid        string
+	hookCreator discover.HookCreator
+}
+
+func (l *nvcdilib) newCudaMemoryLimits(d device.Device) (discover.Discover, error) {
+	uuid, nvmlRet := d.GetUUID()
+	if nvmlRet != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get device UUID: %w", nvmlRet)
+	}
+
+	cMemLimits := &cudaMemoryLimits{
+		logger:      l.logger,
+		driverRoot:  l.driver.Root,
+		uuid:        uuid,
+		hookCreator: l.hookCreator,
+	}
+
+	return cMemLimits, nil
+}
+
+// Devices are empty for this discoverer
+func (c *cudaMemoryLimits) Devices() ([]discover.Device, error) {
+	return nil, nil
+}
+
+// EnvVars are empty for this discoverer
+func (c *cudaMemoryLimits) EnvVars() ([]discover.EnvVar, error) {
+	return nil, nil
+}
+
+// Hooks returns a set of hooks that assigns a CUDA memory limit to the cgroup of the GPU workload container
+func (c *cudaMemoryLimits) Hooks() ([]discover.Hook, error) {
+	return c.hookCreator.Create("apply-cuda-memory-limits", c.driverRoot, c.uuid).Hooks()
+}
+
+// Mounts are empty for this discoverer
+func (c *cudaMemoryLimits) Mounts() ([]discover.Mount, error) {
+	return nil, nil
+}

--- a/pkg/nvcdi/full-gpu-nvml.go
+++ b/pkg/nvcdi/full-gpu-nvml.go
@@ -173,11 +173,17 @@ func (l *fullGPUDeviceSpecGenerator) newFullGPUDiscoverer(d device.Device) (disc
 		deviceNodes,
 	)
 
+	cudaMemoryLimitsHook, err := (*nvcdilib)(l.nvmllib).newCudaMemoryLimits(d)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cuda memory limits discoverer: %w", err)
+	}
+
 	var discoverers []discover.Discover
 
 	discoverers = append(discoverers,
 		deviceNodes,
 		deviceFolderPermissionHooks,
+		cudaMemoryLimitsHook,
 	)
 
 	discoverers = append(discoverers, l.additionalDiscoverers...)

--- a/pkg/nvcdi/lib-csv_test.go
+++ b/pkg/nvcdi/lib-csv_test.go
@@ -200,6 +200,14 @@ func TestDeviceSpecGenerators(t *testing.T) {
 							{Path: "/dev/nvidiactl", HostPath: "/dev/nvidiactl"},
 							{Path: "/dev/nvmap", HostPath: "/dev/nvmap", FileMode: to.Ptr(os.FileMode(0400)), Permissions: "rwm", GID: to.Ptr[uint32](44)},
 						},
+						Hooks: []*specs.Hook{
+							{
+								HookName: "createRuntime",
+								Path:     "/usr/bin/nvidia-cdi-hook",
+								Args:     []string{"nvidia-cdi-hook", "apply-cuda-memory-limits", "--driver-root", "", "--gpu-id", "GPU-1"},
+								Env:      []string{"NVIDIA_CTK_DEBUG=false"},
+							},
+						},
 					},
 				},
 			},

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/cgo_helpers_static.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/cgo_helpers_static.go
@@ -121,3 +121,17 @@ func stringToInt8Slice(s string, out []int8) {
 		out[i] = 0
 	}
 }
+
+func int8PtrToString(p *int8) string {
+	goString := C.GoString((*C.char)(unsafe.Pointer(p)))
+	return goString
+}
+
+func stringToCPtr(s string) unsafe.Pointer {
+	// s is a Go string
+	cstr := C.CString(s)
+
+	// Cast *C.char to *int8 if your struct requires it
+	p := unsafe.Pointer(cstr)
+	return p
+}

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/const.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/const.go
@@ -44,6 +44,8 @@ const (
 	DEVICE_PCI_BUS_ID_LEGACY_FMT = "%04X:%02X:%02X.0"
 	// DEVICE_PCI_BUS_ID_FMT as defined in nvml/nvml.h
 	DEVICE_PCI_BUS_ID_FMT = "%08X:%02X:%02X.0"
+	// DEVICE_MEMORY_LIMIT_MAX as defined in nvml/nvml.h
+	DEVICE_MEMORY_LIMIT_MAX = 18446744073709551615
 	// NVLINK_MAX_LINKS as defined in nvml/nvml.h
 	NVLINK_MAX_LINKS = 36
 	// TOPOLOGY_CPU as defined in nvml/nvml.h
@@ -56,6 +58,32 @@ const (
 	DEVICE_UUID_ASCII_LEN = 41
 	// DEVICE_UUID_BINARY_LEN as defined in nvml/nvml.h
 	DEVICE_UUID_BINARY_LEN = 16
+	// PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS = 2
+	// PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX as defined in nvml/nvml.h
+	PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX = 8
+	// PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX = 3
+	// PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX = 4
+	// PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM = 3
+	// PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM = 4
+	// PERF_METRICS_SAMPLE_COUNT as defined in nvml/nvml.h
+	PERF_METRICS_SAMPLE_COUNT = 13
+	// PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X = 32
+	// PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX = 16
+	// PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X = 0
+	// PERF_METRICS_CONTROLLER_TYPE_PFPP_1X as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_TYPE_PFPP_1X = 1
+	// PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX = 0
+	// PERF_CF_PM_SENSOR_MAX_SIGNALS as defined in nvml/nvml.h
+	PERF_CF_PM_SENSOR_MAX_SIGNALS = 1024
 	// FlagDefault as defined in nvml/nvml.h
 	FlagDefault = 0
 	// FlagForce as defined in nvml/nvml.h
@@ -118,8 +146,14 @@ const (
 	DEVICE_ARCH_HOPPER = 9
 	// DEVICE_ARCH_BLACKWELL as defined in nvml/nvml.h
 	DEVICE_ARCH_BLACKWELL = 10
+	// DEVICE_ARCH_DLA as defined in nvml/nvml.h
+	DEVICE_ARCH_DLA = 11
+	// DEVICE_ARCH_DLA2 as defined in nvml/nvml.h
+	DEVICE_ARCH_DLA2 = 12
 	// DEVICE_ARCH_RUBIN as defined in nvml/nvml.h
 	DEVICE_ARCH_RUBIN = 13
+	// DEVICE_ARCH_NPU3 as defined in nvml/nvml.h
+	DEVICE_ARCH_NPU3 = 15
 	// DEVICE_ARCH_UNKNOWN as defined in nvml/nvml.h
 	DEVICE_ARCH_UNKNOWN = 4294967295
 	// BUS_TYPE_UNKNOWN as defined in nvml/nvml.h
@@ -854,8 +888,18 @@ const (
 	FI_DEV_REMAPPED_ROWS_COR_INACTIVE = 301
 	// FI_DEV_REMAPPED_ROWS_UNC_INACTIVE as defined in nvml/nvml.h
 	FI_DEV_REMAPPED_ROWS_UNC_INACTIVE = 302
+	// FI_DEV_ACTIVE_BANK_REMAPPINGS as defined in nvml/nvml.h
+	FI_DEV_ACTIVE_BANK_REMAPPINGS = 303
+	// FI_DEV_INACTIVE_BANK_REMAPPINGS as defined in nvml/nvml.h
+	FI_DEV_INACTIVE_BANK_REMAPPINGS = 304
+	// FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX as defined in nvml/nvml.h
+	FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX = 305
+	// FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE as defined in nvml/nvml.h
+	FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE = 306
+	// FI_DEV_PENDING_BANK_REMAPPING as defined in nvml/nvml.h
+	FI_DEV_PENDING_BANK_REMAPPING = 307
 	// FI_MAX as defined in nvml/nvml.h
-	FI_MAX = 303
+	FI_MAX = 308
 	// MCLK_SWITCH_TYPE_NOT_SUPPORTED as defined in nvml/nvml.h
 	MCLK_SWITCH_TYPE_NOT_SUPPORTED = 0
 	// MCLK_SWITCH_TYPE_DEFERRED as defined in nvml/nvml.h
@@ -914,6 +958,30 @@ const (
 	EventTypeGpuRecoveryAction = 32768
 	// EventTypeAll as defined in nvml/nvml.h
 	EventTypeAll = 65439
+	// GPU_INSTANCE_ID_ANY as defined in nvml/nvml.h
+	GPU_INSTANCE_ID_ANY = 4294967295
+	// COMPUTE_INSTANCE_ID_ANY as defined in nvml/nvml.h
+	COMPUTE_INSTANCE_ID_ANY = 4294967295
+	// OPERATIONAL_EVENT_ATTR_UNCONTAINED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_UNCONTAINED = 1
+	// OPERATIONAL_EVENT_ATTR_LATENT as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_LATENT = 2
+	// OPERATIONAL_EVENT_ATTR_PROPAGATED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_PROPAGATED = 4
+	// OPERATIONAL_EVENT_ATTR_COMPONENT_RESET as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_COMPONENT_RESET = 8
+	// OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED = 16
+	// OPERATIONAL_EVENT_ATTR_PRIMARY as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_PRIMARY = 32
+	// OPERATIONAL_EVENT_ATTR_OVERFLOW as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_OVERFLOW = 64
+	// OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED = 1
+	// OPERATIONAL_EVENT_GROUP_ATTR_PREVERR as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_GROUP_ATTR_PREVERR = 2
+	// OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED = 4
 	// SystemEventTypeGpuDriverUnbind as defined in nvml/nvml.h
 	SystemEventTypeGpuDriverUnbind = 1
 	// SystemEventTypeGpuDriverBind as defined in nvml/nvml.h
@@ -940,10 +1008,14 @@ const (
 	ClocksThrottleReasonHwPowerBrakeSlowdown = 128
 	// ClocksEventReasonDisplayClockSetting as defined in nvml/nvml.h
 	ClocksEventReasonDisplayClockSetting = 256
+	// ClocksEventReasonBoardLimit as defined in nvml/nvml.h
+	ClocksEventReasonBoardLimit = 512
+	// ClocksEventReasonReliability as defined in nvml/nvml.h
+	ClocksEventReasonReliability = 1024
 	// ClocksEventReasonNone as defined in nvml/nvml.h
 	ClocksEventReasonNone = 0
 	// ClocksEventReasonAll as defined in nvml/nvml.h
-	ClocksEventReasonAll = 511
+	ClocksEventReasonAll = 2047
 	// ClocksThrottleReasonGpuIdle as defined in nvml/nvml.h
 	ClocksThrottleReasonGpuIdle = 1
 	// ClocksThrottleReasonApplicationsClocksSetting as defined in nvml/nvml.h
@@ -959,7 +1031,7 @@ const (
 	// ClocksThrottleReasonNone as defined in nvml/nvml.h
 	ClocksThrottleReasonNone = 0
 	// ClocksThrottleReasonAll as defined in nvml/nvml.h
-	ClocksThrottleReasonAll = 511
+	ClocksThrottleReasonAll = 2047
 	// NVFBC_SESSION_FLAG_DIFFMAP_ENABLED as defined in nvml/nvml.h
 	NVFBC_SESSION_FLAG_DIFFMAP_ENABLED = 1
 	// NVFBC_SESSION_FLAG_CLASSIFICATIONMAP_ENABLED as defined in nvml/nvml.h
@@ -1108,6 +1180,16 @@ const (
 	GPU_FABRIC_HEALTH_MASK_SHIFT_PARTITION_ASSIGNED = 12
 	// GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED as defined in nvml/nvml.h
 	GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED = 3
+	// GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED = 0
+	// GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED = 1
+	// GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED = 2
+	// GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE = 14
+	// GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE = 3
 	// GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED as defined in nvml/nvml.h
 	GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED = 0
 	// GPU_FABRIC_HEALTH_SUMMARY_HEALTHY as defined in nvml/nvml.h
@@ -1116,6 +1198,16 @@ const (
 	GPU_FABRIC_HEALTH_SUMMARY_UNHEALTHY = 2
 	// GPU_FABRIC_HEALTH_SUMMARY_LIMITED_CAPACITY as defined in nvml/nvml.h
 	GPU_FABRIC_HEALTH_SUMMARY_LIMITED_CAPACITY = 3
+	// GPU_FABRIC_CLIQUE_MAX as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_MAX = 64
+	// GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER = 0
+	// GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER = 1
+	// GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT = 2
+	// GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT = 3
 	// INIT_FLAG_NO_GPUS as defined in nvml/nvml.h
 	INIT_FLAG_NO_GPUS = 1
 	// INIT_FLAG_NO_ATTACH as defined in nvml/nvml.h
@@ -1162,6 +1254,8 @@ const (
 	NVLINK_STATE_ACTIVE = 1
 	// NVLINK_STATE_SLEEP as defined in nvml/nvml.h
 	NVLINK_STATE_SLEEP = 2
+	// NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED as defined in nvml/nvml.h
+	NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED = 3
 	// NVLINK_TOTAL_SUPPORTED_BW_MODES as defined in nvml/nvml.h
 	NVLINK_TOTAL_SUPPORTED_BW_MODES = 23
 	// NVLINK_FIRMWARE_UCODE_TYPE_MSE as defined in nvml/nvml.h
@@ -1527,7 +1621,10 @@ const (
 	BRAND_NVIDIA              BrandType = 14
 	BRAND_GEFORCE_RTX         BrandType = 15
 	BRAND_TITAN_RTX           BrandType = 16
-	BRAND_COUNT               BrandType = 18
+	BRAND_NVIDIA_DLA          BrandType = 17
+	BRAND_NVIDIA_VGAMEDEV     BrandType = 18
+	BRAND_NVIDIA_NPU          BrandType = 19
+	BRAND_COUNT               BrandType = 20
 )
 
 // TemperatureThresholds as declared in nvml/nvml.h
@@ -1551,8 +1648,9 @@ type TemperatureSensors int32
 
 // TemperatureSensors enumeration from nvml/nvml.h
 const (
-	TEMPERATURE_GPU   TemperatureSensors = iota
-	TEMPERATURE_COUNT TemperatureSensors = 1
+	TEMPERATURE_GPU     TemperatureSensors = iota
+	TEMPERATURE_GPU_MAX TemperatureSensors = 1
+	TEMPERATURE_COUNT   TemperatureSensors = 2
 )
 
 // ComputeMode as declared in nvml/nvml.h
@@ -1847,6 +1945,8 @@ const (
 	GPU_RECOVERY_ACTION_DRAIN_P2P           DeviceGpuRecoveryAction = 3
 	GPU_RECOVERY_ACTION_DRAIN_AND_RESET     DeviceGpuRecoveryAction = 4
 	GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN DeviceGpuRecoveryAction = 5
+	GPU_RECOVERY_ACTION_BUS_RESET           DeviceGpuRecoveryAction = 6
+	GPU_RECOVERY_ACTION_SYSTEM_REBOOT       DeviceGpuRecoveryAction = 7
 )
 
 // FanState as declared in nvml/nvml.h
@@ -2032,6 +2132,50 @@ const (
 	GRID_LICENSE_FEATURE_CODE_VWORKSTATION GridLicenseFeatureCode = 2
 	GRID_LICENSE_FEATURE_CODE_GAMING       GridLicenseFeatureCode = 3
 	GRID_LICENSE_FEATURE_CODE_COMPUTE      GridLicenseFeatureCode = 4
+	GRID_LICENSE_FEATURE_CODE_VGAMEDEV     GridLicenseFeatureCode = 5
+)
+
+// GpuOperationalEventLogLevel as declared in nvml/nvml.h
+type GpuOperationalEventLogLevel int32
+
+// GpuOperationalEventLogLevel enumeration from nvml/nvml.h
+const (
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL       GpuOperationalEventLogLevel = iota
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_TELEMETRY GpuOperationalEventLogLevel = 10
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_DIAG      GpuOperationalEventLogLevel = 20
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_NOTICE    GpuOperationalEventLogLevel = 30
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_WARNING   GpuOperationalEventLogLevel = 40
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_ERROR     GpuOperationalEventLogLevel = 50
+)
+
+// OperationalEventSeverity as declared in nvml/nvml.h
+type OperationalEventSeverity int32
+
+// OperationalEventSeverity enumeration from nvml/nvml.h
+const (
+	OPERATIONAL_EVENT_SEVERITY_ALL           OperationalEventSeverity = iota
+	OPERATIONAL_EVENT_SEVERITY_INFORMATIONAL OperationalEventSeverity = 10
+	OPERATIONAL_EVENT_SEVERITY_CORRECTED     OperationalEventSeverity = 20
+	OPERATIONAL_EVENT_SEVERITY_RECOVERABLE   OperationalEventSeverity = 30
+	OPERATIONAL_EVENT_SEVERITY_FATAL         OperationalEventSeverity = 40
+)
+
+// EventDataType as declared in nvml/nvml.h
+type EventDataType int32
+
+// EventDataType enumeration from nvml/nvml.h
+const (
+	EVENT_DATA_TYPE_NVML_EVENT            EventDataType = iota
+	EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT EventDataType = 1
+)
+
+// GpuOperationalEventContextType as declared in nvml/nvml.h
+type GpuOperationalEventContextType int32
+
+// GpuOperationalEventContextType enumeration from nvml/nvml.h
+const (
+	GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_UNKNOWN    GpuOperationalEventContextType = iota
+	GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID GpuOperationalEventContextType = 1
 )
 
 // CPERType as declared in nvml/nvml.h
@@ -2042,26 +2186,44 @@ const (
 	CPER_ACCESS_TYPE_GPU CPERType = 1
 )
 
+// NvlinkTelemetrySampleType as declared in nvml/nvml.h
+type NvlinkTelemetrySampleType int32
+
+// NvlinkTelemetrySampleType enumeration from nvml/nvml.h
+const (
+	NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_TX NvlinkTelemetrySampleType = iota
+	NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_RX NvlinkTelemetrySampleType = 1
+	NVLINK_TELEMETRY_SAMPLE_TYPE_COUNT             NvlinkTelemetrySampleType = 2
+)
+
 // PRMCounterId as declared in nvml/nvml.h
 type PRMCounterId int32
 
 // PRMCounterId enumeration from nvml/nvml.h
 const (
-	PRM_COUNTER_ID_NONE                                                 PRMCounterId = iota
-	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS           PRMCounterId = 1
-	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS PRMCounterId = 2
-	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS PRMCounterId = 101
-	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY         PRMCounterId = 102
-	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES PRMCounterId = 103
-	PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT                    PRMCounterId = 201
-	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES                                  PRMCounterId = 301
-	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR                               PRMCounterId = 302
-	PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE                     PRMCounterId = 303
-	PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES                                 PRMCounterId = 304
-	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES                           PRMCounterId = 305
-	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS                          PRMCounterId = 306
-	PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS                                PRMCounterId = 307
-	PRM_COUNTER_ID_PPRM_OPER_RECOVERY                                   PRMCounterId = 1001
+	PRM_COUNTER_ID_NONE                                                                PRMCounterId = iota
+	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS                          PRMCounterId = 1
+	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS                PRMCounterId = 2
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS                PRMCounterId = 101
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY                        PRMCounterId = 102
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES                PRMCounterId = 103
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_IN_LAST_HOST_SERDES_FEQ_RECOVERY           PRMCounterId = 104
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_TIME_IN_HOST_SERDES_FEQ_RECOVERY          PRMCounterId = 105
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_RECOVERY_COUNT            PRMCounterId = 106
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_SUCCESSFUL_RECOVERY_COUNT PRMCounterId = 107
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_HOST_SERDES_FEQ_ATTEMPTS_COUNT             PRMCounterId = 108
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_STEP_ATTEMPTS          PRMCounterId = 109
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_TIME                   PRMCounterId = 110
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_TIME                  PRMCounterId = 111
+	PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT                                   PRMCounterId = 201
+	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES                                                 PRMCounterId = 301
+	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR                                              PRMCounterId = 302
+	PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE                                    PRMCounterId = 303
+	PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES                                                PRMCounterId = 304
+	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES                                          PRMCounterId = 305
+	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS                                         PRMCounterId = 306
+	PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS                                               PRMCounterId = 307
+	PRM_COUNTER_ID_PPRM_OPER_RECOVERY                                                  PRMCounterId = 1001
 )
 
 // GpmMetricId as declared in nvml/nvml.h
@@ -2371,7 +2533,151 @@ const (
 	GPM_METRIC_NVLINK_L34_TX               GpmMetricId = 330
 	GPM_METRIC_NVLINK_L35_RX               GpmMetricId = 331
 	GPM_METRIC_NVLINK_L35_TX               GpmMetricId = 332
-	GPM_METRIC_MAX                         GpmMetricId = 333
+	GPM_METRIC_NVLINK_L36_RX               GpmMetricId = 333
+	GPM_METRIC_NVLINK_L36_TX               GpmMetricId = 334
+	GPM_METRIC_NVLINK_L37_RX               GpmMetricId = 335
+	GPM_METRIC_NVLINK_L37_TX               GpmMetricId = 336
+	GPM_METRIC_NVLINK_L38_RX               GpmMetricId = 337
+	GPM_METRIC_NVLINK_L38_TX               GpmMetricId = 338
+	GPM_METRIC_NVLINK_L39_RX               GpmMetricId = 339
+	GPM_METRIC_NVLINK_L39_TX               GpmMetricId = 340
+	GPM_METRIC_NVLINK_L40_RX               GpmMetricId = 341
+	GPM_METRIC_NVLINK_L40_TX               GpmMetricId = 342
+	GPM_METRIC_NVLINK_L41_RX               GpmMetricId = 343
+	GPM_METRIC_NVLINK_L41_TX               GpmMetricId = 344
+	GPM_METRIC_NVLINK_L42_RX               GpmMetricId = 345
+	GPM_METRIC_NVLINK_L42_TX               GpmMetricId = 346
+	GPM_METRIC_NVLINK_L43_RX               GpmMetricId = 347
+	GPM_METRIC_NVLINK_L43_TX               GpmMetricId = 348
+	GPM_METRIC_NVLINK_L44_RX               GpmMetricId = 349
+	GPM_METRIC_NVLINK_L44_TX               GpmMetricId = 350
+	GPM_METRIC_NVLINK_L45_RX               GpmMetricId = 351
+	GPM_METRIC_NVLINK_L45_TX               GpmMetricId = 352
+	GPM_METRIC_NVLINK_L46_RX               GpmMetricId = 353
+	GPM_METRIC_NVLINK_L46_TX               GpmMetricId = 354
+	GPM_METRIC_NVLINK_L47_RX               GpmMetricId = 355
+	GPM_METRIC_NVLINK_L47_TX               GpmMetricId = 356
+	GPM_METRIC_NVLINK_L48_RX               GpmMetricId = 357
+	GPM_METRIC_NVLINK_L48_TX               GpmMetricId = 358
+	GPM_METRIC_NVLINK_L49_RX               GpmMetricId = 359
+	GPM_METRIC_NVLINK_L49_TX               GpmMetricId = 360
+	GPM_METRIC_NVLINK_L50_RX               GpmMetricId = 361
+	GPM_METRIC_NVLINK_L50_TX               GpmMetricId = 362
+	GPM_METRIC_NVLINK_L51_RX               GpmMetricId = 363
+	GPM_METRIC_NVLINK_L51_TX               GpmMetricId = 364
+	GPM_METRIC_NVLINK_L52_RX               GpmMetricId = 365
+	GPM_METRIC_NVLINK_L52_TX               GpmMetricId = 366
+	GPM_METRIC_NVLINK_L53_RX               GpmMetricId = 367
+	GPM_METRIC_NVLINK_L53_TX               GpmMetricId = 368
+	GPM_METRIC_NVLINK_L54_RX               GpmMetricId = 369
+	GPM_METRIC_NVLINK_L54_TX               GpmMetricId = 370
+	GPM_METRIC_NVLINK_L55_RX               GpmMetricId = 371
+	GPM_METRIC_NVLINK_L55_TX               GpmMetricId = 372
+	GPM_METRIC_NVLINK_L56_RX               GpmMetricId = 373
+	GPM_METRIC_NVLINK_L56_TX               GpmMetricId = 374
+	GPM_METRIC_NVLINK_L57_RX               GpmMetricId = 375
+	GPM_METRIC_NVLINK_L57_TX               GpmMetricId = 376
+	GPM_METRIC_NVLINK_L58_RX               GpmMetricId = 377
+	GPM_METRIC_NVLINK_L58_TX               GpmMetricId = 378
+	GPM_METRIC_NVLINK_L59_RX               GpmMetricId = 379
+	GPM_METRIC_NVLINK_L59_TX               GpmMetricId = 380
+	GPM_METRIC_NVLINK_L60_RX               GpmMetricId = 381
+	GPM_METRIC_NVLINK_L60_TX               GpmMetricId = 382
+	GPM_METRIC_NVLINK_L61_RX               GpmMetricId = 383
+	GPM_METRIC_NVLINK_L61_TX               GpmMetricId = 384
+	GPM_METRIC_NVLINK_L62_RX               GpmMetricId = 385
+	GPM_METRIC_NVLINK_L62_TX               GpmMetricId = 386
+	GPM_METRIC_NVLINK_L63_RX               GpmMetricId = 387
+	GPM_METRIC_NVLINK_L63_TX               GpmMetricId = 388
+	GPM_METRIC_NVLINK_L64_RX               GpmMetricId = 389
+	GPM_METRIC_NVLINK_L64_TX               GpmMetricId = 390
+	GPM_METRIC_NVLINK_L65_RX               GpmMetricId = 391
+	GPM_METRIC_NVLINK_L65_TX               GpmMetricId = 392
+	GPM_METRIC_NVLINK_L66_RX               GpmMetricId = 393
+	GPM_METRIC_NVLINK_L66_TX               GpmMetricId = 394
+	GPM_METRIC_NVLINK_L67_RX               GpmMetricId = 395
+	GPM_METRIC_NVLINK_L67_TX               GpmMetricId = 396
+	GPM_METRIC_NVLINK_L68_RX               GpmMetricId = 397
+	GPM_METRIC_NVLINK_L68_TX               GpmMetricId = 398
+	GPM_METRIC_NVLINK_L69_RX               GpmMetricId = 399
+	GPM_METRIC_NVLINK_L69_TX               GpmMetricId = 400
+	GPM_METRIC_NVLINK_L70_RX               GpmMetricId = 401
+	GPM_METRIC_NVLINK_L70_TX               GpmMetricId = 402
+	GPM_METRIC_NVLINK_L71_RX               GpmMetricId = 403
+	GPM_METRIC_NVLINK_L71_TX               GpmMetricId = 404
+	GPM_METRIC_NVLINK_L36_RX_PER_SEC       GpmMetricId = 405
+	GPM_METRIC_NVLINK_L36_TX_PER_SEC       GpmMetricId = 406
+	GPM_METRIC_NVLINK_L37_RX_PER_SEC       GpmMetricId = 407
+	GPM_METRIC_NVLINK_L37_TX_PER_SEC       GpmMetricId = 408
+	GPM_METRIC_NVLINK_L38_RX_PER_SEC       GpmMetricId = 409
+	GPM_METRIC_NVLINK_L38_TX_PER_SEC       GpmMetricId = 410
+	GPM_METRIC_NVLINK_L39_RX_PER_SEC       GpmMetricId = 411
+	GPM_METRIC_NVLINK_L39_TX_PER_SEC       GpmMetricId = 412
+	GPM_METRIC_NVLINK_L40_RX_PER_SEC       GpmMetricId = 413
+	GPM_METRIC_NVLINK_L40_TX_PER_SEC       GpmMetricId = 414
+	GPM_METRIC_NVLINK_L41_RX_PER_SEC       GpmMetricId = 415
+	GPM_METRIC_NVLINK_L41_TX_PER_SEC       GpmMetricId = 416
+	GPM_METRIC_NVLINK_L42_RX_PER_SEC       GpmMetricId = 417
+	GPM_METRIC_NVLINK_L42_TX_PER_SEC       GpmMetricId = 418
+	GPM_METRIC_NVLINK_L43_RX_PER_SEC       GpmMetricId = 419
+	GPM_METRIC_NVLINK_L43_TX_PER_SEC       GpmMetricId = 420
+	GPM_METRIC_NVLINK_L44_RX_PER_SEC       GpmMetricId = 421
+	GPM_METRIC_NVLINK_L44_TX_PER_SEC       GpmMetricId = 422
+	GPM_METRIC_NVLINK_L45_RX_PER_SEC       GpmMetricId = 423
+	GPM_METRIC_NVLINK_L45_TX_PER_SEC       GpmMetricId = 424
+	GPM_METRIC_NVLINK_L46_RX_PER_SEC       GpmMetricId = 425
+	GPM_METRIC_NVLINK_L46_TX_PER_SEC       GpmMetricId = 426
+	GPM_METRIC_NVLINK_L47_RX_PER_SEC       GpmMetricId = 427
+	GPM_METRIC_NVLINK_L47_TX_PER_SEC       GpmMetricId = 428
+	GPM_METRIC_NVLINK_L48_RX_PER_SEC       GpmMetricId = 429
+	GPM_METRIC_NVLINK_L48_TX_PER_SEC       GpmMetricId = 430
+	GPM_METRIC_NVLINK_L49_RX_PER_SEC       GpmMetricId = 431
+	GPM_METRIC_NVLINK_L49_TX_PER_SEC       GpmMetricId = 432
+	GPM_METRIC_NVLINK_L50_RX_PER_SEC       GpmMetricId = 433
+	GPM_METRIC_NVLINK_L50_TX_PER_SEC       GpmMetricId = 434
+	GPM_METRIC_NVLINK_L51_RX_PER_SEC       GpmMetricId = 435
+	GPM_METRIC_NVLINK_L51_TX_PER_SEC       GpmMetricId = 436
+	GPM_METRIC_NVLINK_L52_RX_PER_SEC       GpmMetricId = 437
+	GPM_METRIC_NVLINK_L52_TX_PER_SEC       GpmMetricId = 438
+	GPM_METRIC_NVLINK_L53_RX_PER_SEC       GpmMetricId = 439
+	GPM_METRIC_NVLINK_L53_TX_PER_SEC       GpmMetricId = 440
+	GPM_METRIC_NVLINK_L54_RX_PER_SEC       GpmMetricId = 441
+	GPM_METRIC_NVLINK_L54_TX_PER_SEC       GpmMetricId = 442
+	GPM_METRIC_NVLINK_L55_RX_PER_SEC       GpmMetricId = 443
+	GPM_METRIC_NVLINK_L55_TX_PER_SEC       GpmMetricId = 444
+	GPM_METRIC_NVLINK_L56_RX_PER_SEC       GpmMetricId = 445
+	GPM_METRIC_NVLINK_L56_TX_PER_SEC       GpmMetricId = 446
+	GPM_METRIC_NVLINK_L57_RX_PER_SEC       GpmMetricId = 447
+	GPM_METRIC_NVLINK_L57_TX_PER_SEC       GpmMetricId = 448
+	GPM_METRIC_NVLINK_L58_RX_PER_SEC       GpmMetricId = 449
+	GPM_METRIC_NVLINK_L58_TX_PER_SEC       GpmMetricId = 450
+	GPM_METRIC_NVLINK_L59_RX_PER_SEC       GpmMetricId = 451
+	GPM_METRIC_NVLINK_L59_TX_PER_SEC       GpmMetricId = 452
+	GPM_METRIC_NVLINK_L60_RX_PER_SEC       GpmMetricId = 453
+	GPM_METRIC_NVLINK_L60_TX_PER_SEC       GpmMetricId = 454
+	GPM_METRIC_NVLINK_L61_RX_PER_SEC       GpmMetricId = 455
+	GPM_METRIC_NVLINK_L61_TX_PER_SEC       GpmMetricId = 456
+	GPM_METRIC_NVLINK_L62_RX_PER_SEC       GpmMetricId = 457
+	GPM_METRIC_NVLINK_L62_TX_PER_SEC       GpmMetricId = 458
+	GPM_METRIC_NVLINK_L63_RX_PER_SEC       GpmMetricId = 459
+	GPM_METRIC_NVLINK_L63_TX_PER_SEC       GpmMetricId = 460
+	GPM_METRIC_NVLINK_L64_RX_PER_SEC       GpmMetricId = 461
+	GPM_METRIC_NVLINK_L64_TX_PER_SEC       GpmMetricId = 462
+	GPM_METRIC_NVLINK_L65_RX_PER_SEC       GpmMetricId = 463
+	GPM_METRIC_NVLINK_L65_TX_PER_SEC       GpmMetricId = 464
+	GPM_METRIC_NVLINK_L66_RX_PER_SEC       GpmMetricId = 465
+	GPM_METRIC_NVLINK_L66_TX_PER_SEC       GpmMetricId = 466
+	GPM_METRIC_NVLINK_L67_RX_PER_SEC       GpmMetricId = 467
+	GPM_METRIC_NVLINK_L67_TX_PER_SEC       GpmMetricId = 468
+	GPM_METRIC_NVLINK_L68_RX_PER_SEC       GpmMetricId = 469
+	GPM_METRIC_NVLINK_L68_TX_PER_SEC       GpmMetricId = 470
+	GPM_METRIC_NVLINK_L69_RX_PER_SEC       GpmMetricId = 471
+	GPM_METRIC_NVLINK_L69_TX_PER_SEC       GpmMetricId = 472
+	GPM_METRIC_NVLINK_L70_RX_PER_SEC       GpmMetricId = 473
+	GPM_METRIC_NVLINK_L70_TX_PER_SEC       GpmMetricId = 474
+	GPM_METRIC_NVLINK_L71_RX_PER_SEC       GpmMetricId = 475
+	GPM_METRIC_NVLINK_L71_TX_PER_SEC       GpmMetricId = 476
+	GPM_METRIC_MAX                         GpmMetricId = 477
 )
 
 // PowerProfileType as declared in nvml/nvml.h
@@ -2379,22 +2685,32 @@ type PowerProfileType int32
 
 // PowerProfileType enumeration from nvml/nvml.h
 const (
-	POWER_PROFILE_MAX_P         PowerProfileType = iota
-	POWER_PROFILE_MAX_Q         PowerProfileType = 1
-	POWER_PROFILE_COMPUTE       PowerProfileType = 2
-	POWER_PROFILE_MEMORY_BOUND  PowerProfileType = 3
-	POWER_PROFILE_NETWORK       PowerProfileType = 4
-	POWER_PROFILE_BALANCED      PowerProfileType = 5
-	POWER_PROFILE_LLM_INFERENCE PowerProfileType = 6
-	POWER_PROFILE_LLM_TRAINING  PowerProfileType = 7
-	POWER_PROFILE_RBM           PowerProfileType = 8
-	POWER_PROFILE_DCPCIE        PowerProfileType = 9
-	POWER_PROFILE_HMMA_SPARSE   PowerProfileType = 10
-	POWER_PROFILE_HMMA_DENSE    PowerProfileType = 11
-	POWER_PROFILE_SYNC_BALANCED PowerProfileType = 12
-	POWER_PROFILE_HPC           PowerProfileType = 13
-	POWER_PROFILE_MIG           PowerProfileType = 14
-	POWER_PROFILE_MAX           PowerProfileType = 15
+	POWER_PROFILE_MAX_P                       PowerProfileType = iota
+	POWER_PROFILE_MAX_Q                       PowerProfileType = 1
+	POWER_PROFILE_COMPUTE                     PowerProfileType = 2
+	POWER_PROFILE_MEMORY_BOUND                PowerProfileType = 3
+	POWER_PROFILE_NETWORK                     PowerProfileType = 4
+	POWER_PROFILE_BALANCED                    PowerProfileType = 5
+	POWER_PROFILE_LLM_INFERENCE               PowerProfileType = 6
+	POWER_PROFILE_LLM_TRAINING                PowerProfileType = 7
+	POWER_PROFILE_RBM                         PowerProfileType = 8
+	POWER_PROFILE_DCPCIE                      PowerProfileType = 9
+	POWER_PROFILE_HMMA_SPARSE                 PowerProfileType = 10
+	POWER_PROFILE_HMMA_DENSE                  PowerProfileType = 11
+	POWER_PROFILE_SYNC_BALANCED               PowerProfileType = 12
+	POWER_PROFILE_HPC                         PowerProfileType = 13
+	POWER_PROFILE_MIG                         PowerProfileType = 14
+	POWER_PROFILE_MAX_Q_1                     PowerProfileType = 15
+	POWER_PROFILE_NETWORK_BOUND               PowerProfileType = 16
+	POWER_PROFILE_HIGH_THROUGHPUT_INFERENCE   PowerProfileType = 17
+	POWER_PROFILE_MEDIUM_THROUGHPUT_INFERENCE PowerProfileType = 18
+	POWER_PROFILE_LOW_LATENCY_INFERENCE       PowerProfileType = 19
+	POWER_PROFILE_TRAINING                    PowerProfileType = 20
+	POWER_PROFILE_INFERENCE                   PowerProfileType = 21
+	POWER_PROFILE_MAX_Q_2                     PowerProfileType = 22
+	POWER_PROFILE_MAX_Q_3                     PowerProfileType = 23
+	POWER_PROFILE_LOW_PRIORITY_BACKGROUND     PowerProfileType = 24
+	POWER_PROFILE_MAX                         PowerProfileType = 25
 )
 
 // PowerProfileOperation as declared in nvml/nvml.h

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/device.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/device.go
@@ -3261,6 +3261,16 @@ func (device nvmlDevice) GetGpuFabricInfoV() GpuFabricInfoHandler {
 	return GpuFabricInfoHandler{device}
 }
 
+func (l *library) DeviceGetGpuFabricInfo_v4(device Device) (GpuFabricInfo_v4, Return) {
+	return device.GetGpuFabricInfo_v4()
+}
+
+func (device nvmlDevice) GetGpuFabricInfo_v4() (GpuFabricInfo_v4, Return) {
+	var info GpuFabricInfo_v4
+	ret := nvmlDeviceGetGpuFabricInfo_v4(device, &info)
+	return info, ret
+}
+
 // nvml.DeviceGetProcessesUtilizationInfo()
 func (l *library) DeviceGetProcessesUtilizationInfo(device Device) (ProcessesUtilizationInfo, Return) {
 	return device.GetProcessesUtilizationInfo()
@@ -3830,4 +3840,89 @@ func (l *library) GpuInstanceSetVgpuSchedulerState_v2(gpuInstance GpuInstance, s
 
 func (gpuInstance nvmlGpuInstance) SetVgpuSchedulerState_v2(schedulerState *VgpuSchedulerState_v2) Return {
 	return nvmlGpuInstanceSetVgpuSchedulerState_v2(gpuInstance, schedulerState)
+}
+
+func (l *library) DeviceSetMemoryLimits_v1(device Device, namespace string, requests int, limits int) Return {
+	return device.SetMemoryLimits_v1(namespace, requests, limits)
+}
+
+func (device nvmlDevice) SetMemoryLimits_v1(namespace string, requests int, limits int) Return {
+	d := &SetMemoryLimits_v1{}
+	cptr := stringToCPtr(namespace)
+	defer free(cptr)
+	d.NameSpace = (*int8)(cptr)
+	d.SoftLimit = uint64(requests)
+	d.HardLimit = uint64(limits)
+	return nvmlDeviceSetMemoryLimits_v1(device, d)
+}
+
+func (l *library) DeviceGetMemoryLimits_v1(device Device, namespace string) (GetMemoryLimits_v1, Return) {
+	return device.GetMemoryLimits_v1(namespace)
+}
+
+func (device nvmlDevice) GetMemoryLimits_v1(namespace string) (GetMemoryLimits_v1, Return) {
+	d := &GetMemoryLimits_v1{}
+	cptr := stringToCPtr(namespace)
+	defer free(cptr)
+	d.NameSpace = (*int8)(cptr)
+	ret := nvmlDeviceGetMemoryLimits_v1(device, d)
+	return *d, ret
+}
+
+// nvml.DeviceSetAdaptiveTgpMode_v1()
+func (l *library) DeviceSetAdaptiveTgpMode_v1(device Device, mode EnableState) Return {
+	return device.SetAdaptiveTgpMode_v1(mode)
+}
+
+func (device nvmlDevice) SetAdaptiveTgpMode_v1(mode EnableState) Return {
+	return nvmlDeviceSetAdaptiveTgpMode_v1(device, mode)
+}
+
+// nvml.DeviceGetAdaptiveTgpModeInfo_v1()
+func (l *library) DeviceGetAdaptiveTgpModeInfo_v1(device Device) (AdaptiveTgpModeInfo_v1, Return) {
+	return device.GetAdaptiveTgpModeInfo_v1()
+}
+
+func (device nvmlDevice) GetAdaptiveTgpModeInfo_v1() (AdaptiveTgpModeInfo_v1, Return) {
+	var info AdaptiveTgpModeInfo_v1
+	ret := nvmlDeviceGetAdaptiveTgpModeInfo_v1(device, &info)
+	return info, ret
+}
+
+// nvml.DevicePerfMetricsGetSamples_v1()
+func (l *library) DevicePerfMetricsGetSamples_v1(device Device, samples *PerfMetricsSamples_v1) Return {
+	return device.PerfMetricsGetSamples_v1(samples)
+}
+
+func (device nvmlDevice) PerfMetricsGetSamples_v1(samples *PerfMetricsSamples_v1) Return {
+	return nvmlDevicePerfMetricsGetSamples_v1(device, samples)
+}
+
+// nvml.DeviceSetNvlinkBwModeAsync_v1()
+func (l *library) DeviceSetNvlinkBwModeAsync_v1(device Device, setBwModeAsync *NvlinkSetBwModeAsync_v1) Return {
+	return device.SetNvlinkBwModeAsync_v1(setBwModeAsync)
+}
+
+func (device nvmlDevice) SetNvlinkBwModeAsync_v1(setBwModeAsync *NvlinkSetBwModeAsync_v1) Return {
+	return nvmlDeviceSetNvlinkBwModeAsync_v1(device, setBwModeAsync)
+}
+
+// nvml.DeviceGetNvLinkTelemetrySamples_v1()
+func (l *library) DeviceGetNvLinkTelemetrySamples_v1(device Device, samples *NvlinkTelemetrySamples_v1) Return {
+	return device.GetNvLinkTelemetrySamples_v1(samples)
+}
+
+func (device nvmlDevice) GetNvLinkTelemetrySamples_v1(samples *NvlinkTelemetrySamples_v1) Return {
+	return nvmlDeviceGetNvLinkTelemetrySamples_v1(device, samples)
+}
+
+// nvml.DeviceGetBankRemapperStatus_v1()
+func (l *library) DeviceGetBankRemapperStatus_v1(device Device) (EccBankRemapperStatus_v1, Return) {
+	return device.GetBankRemapperStatus_v1()
+}
+
+func (device nvmlDevice) GetBankRemapperStatus_v1() (EccBankRemapperStatus_v1, Return) {
+	var status EccBankRemapperStatus_v1
+	ret := nvmlDeviceGetBankRemapperStatus_v1(device, &status)
+	return status, ret
 }

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/event_set.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/event_set.go
@@ -14,6 +14,8 @@
 
 package nvml
 
+import "unsafe"
+
 // EventData includes an interface type for Device instead of nvmlDevice
 type EventData struct {
 	Device            Device
@@ -79,4 +81,72 @@ func (l *library) SystemRegisterEvents(request *SystemRegisterEventRequest) Retu
 // nvml.SystemEventSetWait()
 func (l *library) SystemEventSetWait(request *SystemEventSetWaitRequest) Return {
 	return nvmlSystemEventSetWait(request)
+}
+
+// nvml.EventSetRegisterGpuOperationalEvents_v1()
+func (l *library) EventSetRegisterGpuOperationalEvents_v1(set EventSet, config *GpuOperationalEventConfig_v1) Return {
+	return set.RegisterGpuOperationalEvents_v1(config)
+}
+
+func (set nvmlEventSet) RegisterGpuOperationalEvents_v1(config *GpuOperationalEventConfig_v1) Return {
+	return nvmlEventSetRegisterGpuOperationalEvents_v1(set, config)
+}
+
+// nvml.EventSetWait_v3()
+func (l *library) EventSetWait_v3(set EventSet, timeoutms uint32) (EventData_v2, Return) {
+	return set.Wait_v3(timeoutms)
+}
+
+func (set nvmlEventSet) Wait_v3(timeoutms uint32) (EventData_v2, Return) {
+	var data EventData_v2
+	ret := nvmlEventSetWait_v3(set, &data, timeoutms)
+	return data, ret
+}
+
+// nvml.EventSetGetContextCount_v1()
+func (l *library) EventSetGetContextCount_v1(set EventSet) (uint32, Return) {
+	return set.GetContextCount_v1()
+}
+
+func (set nvmlEventSet) GetContextCount_v1() (uint32, Return) {
+	var count uint32
+	ret := nvmlEventSetGetContextCount_v1(set, &count)
+	return count, ret
+}
+
+// nvml.EventSetGetContextInfo_v1()
+func (l *library) EventSetGetContextInfo_v1(set EventSet, index uint32) (OperationalEventContextInfo_v1, Return) {
+	return set.GetContextInfo_v1(index)
+}
+
+func (set nvmlEventSet) GetContextInfo_v1(index uint32) (OperationalEventContextInfo_v1, Return) {
+	var info OperationalEventContextInfo_v1
+	ret := nvmlEventSetGetContextInfo_v1(set, index, &info)
+	return info, ret
+}
+
+// nvml.EventSetGetContextData_v1()
+func (l *library) EventSetGetContextData_v1(set EventSet, index uint32, data []byte) (uint32, Return) {
+	return set.GetContextData_v1(index, data)
+}
+
+func (set nvmlEventSet) GetContextData_v1(index uint32, data []byte) (uint32, Return) {
+	dataSize := uint32(len(data))
+	var ptr unsafe.Pointer
+	if len(data) > 0 {
+		ptr = unsafe.Pointer(&data[0])
+	}
+	ret := nvmlEventSetGetContextData_v1(set, index, ptr, &dataSize)
+	return dataSize, ret
+}
+
+// nvml.EventSetGetGpuOperationalEventContextLegacyXid_v1()
+func (l *library) EventSetGetGpuOperationalEventContextLegacyXid_v1(set EventSet, index uint32) (GpuOperationalEventContextLegacyXid_v1, Return) {
+	return set.GetGpuOperationalEventContextLegacyXid_v1(index)
+}
+
+func (set nvmlEventSet) GetGpuOperationalEventContextLegacyXid_v1(index uint32) (GpuOperationalEventContextLegacyXid_v1, Return) {
+	var xid GpuOperationalEventContextLegacyXid_v1
+	ret := nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(set, index, &xid)
+	return xid, ret
 }

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/gpm.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/gpm.go
@@ -20,7 +20,7 @@ type GpmMetricsGetType struct {
 	NumMetrics uint32
 	Sample1    GpmSample
 	Sample2    GpmSample
-	Metrics    [333]GpmMetric
+	Metrics    [477]GpmMetric
 }
 
 func (g *GpmMetricsGetType) convert() *nvmlGpmMetricsGetType {

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/device.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/device.go
@@ -63,6 +63,9 @@ var _ nvml.Device = &Device{}
 //			GetAdaptiveClockInfoStatusFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetAdaptiveClockInfoStatus method")
 //			},
+//			GetAdaptiveTgpModeInfo_v1Func: func() (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+//				panic("mock out the GetAdaptiveTgpModeInfo_v1 method")
+//			},
 //			GetAddressingModeFunc: func() (nvml.DeviceAddressingMode, nvml.Return) {
 //				panic("mock out the GetAddressingMode method")
 //			},
@@ -83,6 +86,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			GetBBXTimeData_v1Func: func() (nvml.BBXTimeData_v1, nvml.Return) {
 //				panic("mock out the GetBBXTimeData_v1 method")
+//			},
+//			GetBankRemapperStatus_v1Func: func() (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+//				panic("mock out the GetBankRemapperStatus_v1 method")
 //			},
 //			GetBoardIdFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetBoardId method")
@@ -252,6 +258,9 @@ var _ nvml.Device = &Device{}
 //			GetGpuFabricInfoVFunc: func() nvml.GpuFabricInfoHandler {
 //				panic("mock out the GetGpuFabricInfoV method")
 //			},
+//			GetGpuFabricInfo_v4Func: func() (nvml.GpuFabricInfo_v4, nvml.Return) {
+//				panic("mock out the GetGpuFabricInfo_v4 method")
+//			},
 //			GetGpuInstanceByIdFunc: func(n int) (nvml.GpuInstance, nvml.Return) {
 //				panic("mock out the GetGpuInstanceById method")
 //			},
@@ -363,6 +372,9 @@ var _ nvml.Device = &Device{}
 //			GetMemoryInfo_v2Func: func() (nvml.Memory_v2, nvml.Return) {
 //				panic("mock out the GetMemoryInfo_v2 method")
 //			},
+//			GetMemoryLimits_v1Func: func(s string) (nvml.GetMemoryLimits_v1, nvml.Return) {
+//				panic("mock out the GetMemoryLimits_v1 method")
+//			},
 //			GetMigDeviceHandleByIndexFunc: func(n int) (nvml.Device, nvml.Return) {
 //				panic("mock out the GetMigDeviceHandleByIndex method")
 //			},
@@ -413,6 +425,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			GetNvLinkStateFunc: func(n int) (nvml.EnableState, nvml.Return) {
 //				panic("mock out the GetNvLinkState method")
+//			},
+//			GetNvLinkTelemetrySamples_v1Func: func(nvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1) nvml.Return {
+//				panic("mock out the GetNvLinkTelemetrySamples_v1 method")
 //			},
 //			GetNvLinkUtilizationControlFunc: func(n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return) {
 //				panic("mock out the GetNvLinkUtilizationControl method")
@@ -669,6 +684,9 @@ var _ nvml.Device = &Device{}
 //			OnSameBoardFunc: func(device nvml.Device) (int, nvml.Return) {
 //				panic("mock out the OnSameBoard method")
 //			},
+//			PerfMetricsGetSamples_v1Func: func(perfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1) nvml.Return {
+//				panic("mock out the PerfMetricsGetSamples_v1 method")
+//			},
 //			PowerSmoothingActivatePresetProfileFunc: func(powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 //				panic("mock out the PowerSmoothingActivatePresetProfile method")
 //			},
@@ -707,6 +725,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			SetAccountingModeFunc: func(enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the SetAccountingMode method")
+//			},
+//			SetAdaptiveTgpMode_v1Func: func(enableState nvml.EnableState) nvml.Return {
+//				panic("mock out the SetAdaptiveTgpMode_v1 method")
 //			},
 //			SetApplicationsClocksFunc: func(v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the SetApplicationsClocks method")
@@ -762,6 +783,9 @@ var _ nvml.Device = &Device{}
 //			SetMemClkVfOffsetFunc: func(n int) nvml.Return {
 //				panic("mock out the SetMemClkVfOffset method")
 //			},
+//			SetMemoryLimits_v1Func: func(s string, n1 int, n2 int) nvml.Return {
+//				panic("mock out the SetMemoryLimits_v1 method")
+//			},
 //			SetMemoryLockedClocksFunc: func(v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the SetMemoryLockedClocks method")
 //			},
@@ -776,6 +800,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			SetNvlinkBwModeFunc: func(nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return {
 //				panic("mock out the SetNvlinkBwMode method")
+//			},
+//			SetNvlinkBwModeAsync_v1Func: func(nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+//				panic("mock out the SetNvlinkBwModeAsync_v1 method")
 //			},
 //			SetPersistenceModeFunc: func(enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the SetPersistenceMode method")
@@ -883,6 +910,9 @@ type Device struct {
 	// GetAdaptiveClockInfoStatusFunc mocks the GetAdaptiveClockInfoStatus method.
 	GetAdaptiveClockInfoStatusFunc func() (uint32, nvml.Return)
 
+	// GetAdaptiveTgpModeInfo_v1Func mocks the GetAdaptiveTgpModeInfo_v1 method.
+	GetAdaptiveTgpModeInfo_v1Func func() (nvml.AdaptiveTgpModeInfo_v1, nvml.Return)
+
 	// GetAddressingModeFunc mocks the GetAddressingMode method.
 	GetAddressingModeFunc func() (nvml.DeviceAddressingMode, nvml.Return)
 
@@ -903,6 +933,9 @@ type Device struct {
 
 	// GetBBXTimeData_v1Func mocks the GetBBXTimeData_v1 method.
 	GetBBXTimeData_v1Func func() (nvml.BBXTimeData_v1, nvml.Return)
+
+	// GetBankRemapperStatus_v1Func mocks the GetBankRemapperStatus_v1 method.
+	GetBankRemapperStatus_v1Func func() (nvml.EccBankRemapperStatus_v1, nvml.Return)
 
 	// GetBoardIdFunc mocks the GetBoardId method.
 	GetBoardIdFunc func() (uint32, nvml.Return)
@@ -1072,6 +1105,9 @@ type Device struct {
 	// GetGpuFabricInfoVFunc mocks the GetGpuFabricInfoV method.
 	GetGpuFabricInfoVFunc func() nvml.GpuFabricInfoHandler
 
+	// GetGpuFabricInfo_v4Func mocks the GetGpuFabricInfo_v4 method.
+	GetGpuFabricInfo_v4Func func() (nvml.GpuFabricInfo_v4, nvml.Return)
+
 	// GetGpuInstanceByIdFunc mocks the GetGpuInstanceById method.
 	GetGpuInstanceByIdFunc func(n int) (nvml.GpuInstance, nvml.Return)
 
@@ -1183,6 +1219,9 @@ type Device struct {
 	// GetMemoryInfo_v2Func mocks the GetMemoryInfo_v2 method.
 	GetMemoryInfo_v2Func func() (nvml.Memory_v2, nvml.Return)
 
+	// GetMemoryLimits_v1Func mocks the GetMemoryLimits_v1 method.
+	GetMemoryLimits_v1Func func(s string) (nvml.GetMemoryLimits_v1, nvml.Return)
+
 	// GetMigDeviceHandleByIndexFunc mocks the GetMigDeviceHandleByIndex method.
 	GetMigDeviceHandleByIndexFunc func(n int) (nvml.Device, nvml.Return)
 
@@ -1233,6 +1272,9 @@ type Device struct {
 
 	// GetNvLinkStateFunc mocks the GetNvLinkState method.
 	GetNvLinkStateFunc func(n int) (nvml.EnableState, nvml.Return)
+
+	// GetNvLinkTelemetrySamples_v1Func mocks the GetNvLinkTelemetrySamples_v1 method.
+	GetNvLinkTelemetrySamples_v1Func func(nvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1) nvml.Return
 
 	// GetNvLinkUtilizationControlFunc mocks the GetNvLinkUtilizationControl method.
 	GetNvLinkUtilizationControlFunc func(n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return)
@@ -1489,6 +1531,9 @@ type Device struct {
 	// OnSameBoardFunc mocks the OnSameBoard method.
 	OnSameBoardFunc func(device nvml.Device) (int, nvml.Return)
 
+	// PerfMetricsGetSamples_v1Func mocks the PerfMetricsGetSamples_v1 method.
+	PerfMetricsGetSamples_v1Func func(perfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1) nvml.Return
+
 	// PowerSmoothingActivatePresetProfileFunc mocks the PowerSmoothingActivatePresetProfile method.
 	PowerSmoothingActivatePresetProfileFunc func(powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return
 
@@ -1527,6 +1572,9 @@ type Device struct {
 
 	// SetAccountingModeFunc mocks the SetAccountingMode method.
 	SetAccountingModeFunc func(enableState nvml.EnableState) nvml.Return
+
+	// SetAdaptiveTgpMode_v1Func mocks the SetAdaptiveTgpMode_v1 method.
+	SetAdaptiveTgpMode_v1Func func(enableState nvml.EnableState) nvml.Return
 
 	// SetApplicationsClocksFunc mocks the SetApplicationsClocks method.
 	SetApplicationsClocksFunc func(v1 uint32, v2 uint32) nvml.Return
@@ -1582,6 +1630,9 @@ type Device struct {
 	// SetMemClkVfOffsetFunc mocks the SetMemClkVfOffset method.
 	SetMemClkVfOffsetFunc func(n int) nvml.Return
 
+	// SetMemoryLimits_v1Func mocks the SetMemoryLimits_v1 method.
+	SetMemoryLimits_v1Func func(s string, n1 int, n2 int) nvml.Return
+
 	// SetMemoryLockedClocksFunc mocks the SetMemoryLockedClocks method.
 	SetMemoryLockedClocksFunc func(v1 uint32, v2 uint32) nvml.Return
 
@@ -1596,6 +1647,9 @@ type Device struct {
 
 	// SetNvlinkBwModeFunc mocks the SetNvlinkBwMode method.
 	SetNvlinkBwModeFunc func(nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return
+
+	// SetNvlinkBwModeAsync_v1Func mocks the SetNvlinkBwModeAsync_v1 method.
+	SetNvlinkBwModeAsync_v1Func func(nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return
 
 	// SetPersistenceModeFunc mocks the SetPersistenceMode method.
 	SetPersistenceModeFunc func(enableState nvml.EnableState) nvml.Return
@@ -1720,6 +1774,9 @@ type Device struct {
 		// GetAdaptiveClockInfoStatus holds details about calls to the GetAdaptiveClockInfoStatus method.
 		GetAdaptiveClockInfoStatus []struct {
 		}
+		// GetAdaptiveTgpModeInfo_v1 holds details about calls to the GetAdaptiveTgpModeInfo_v1 method.
+		GetAdaptiveTgpModeInfo_v1 []struct {
+		}
 		// GetAddressingMode holds details about calls to the GetAddressingMode method.
 		GetAddressingMode []struct {
 		}
@@ -1742,6 +1799,9 @@ type Device struct {
 		}
 		// GetBBXTimeData_v1 holds details about calls to the GetBBXTimeData_v1 method.
 		GetBBXTimeData_v1 []struct {
+		}
+		// GetBankRemapperStatus_v1 holds details about calls to the GetBankRemapperStatus_v1 method.
+		GetBankRemapperStatus_v1 []struct {
 		}
 		// GetBoardId holds details about calls to the GetBoardId method.
 		GetBoardId []struct {
@@ -1939,6 +1999,9 @@ type Device struct {
 		// GetGpuFabricInfoV holds details about calls to the GetGpuFabricInfoV method.
 		GetGpuFabricInfoV []struct {
 		}
+		// GetGpuFabricInfo_v4 holds details about calls to the GetGpuFabricInfo_v4 method.
+		GetGpuFabricInfo_v4 []struct {
+		}
 		// GetGpuInstanceById holds details about calls to the GetGpuInstanceById method.
 		GetGpuInstanceById []struct {
 			// N is the n argument value.
@@ -2080,6 +2143,11 @@ type Device struct {
 		// GetMemoryInfo_v2 holds details about calls to the GetMemoryInfo_v2 method.
 		GetMemoryInfo_v2 []struct {
 		}
+		// GetMemoryLimits_v1 holds details about calls to the GetMemoryLimits_v1 method.
+		GetMemoryLimits_v1 []struct {
+			// S is the s argument value.
+			S string
+		}
 		// GetMigDeviceHandleByIndex holds details about calls to the GetMigDeviceHandleByIndex method.
 		GetMigDeviceHandleByIndex []struct {
 			// N is the n argument value.
@@ -2150,6 +2218,11 @@ type Device struct {
 		GetNvLinkState []struct {
 			// N is the n argument value.
 			N int
+		}
+		// GetNvLinkTelemetrySamples_v1 holds details about calls to the GetNvLinkTelemetrySamples_v1 method.
+		GetNvLinkTelemetrySamples_v1 []struct {
+			// NvlinkTelemetrySamples_v1 is the nvlinkTelemetrySamples_v1 argument value.
+			NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
 		}
 		// GetNvLinkUtilizationControl holds details about calls to the GetNvLinkUtilizationControl method.
 		GetNvLinkUtilizationControl []struct {
@@ -2478,6 +2551,11 @@ type Device struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// PerfMetricsGetSamples_v1 holds details about calls to the PerfMetricsGetSamples_v1 method.
+		PerfMetricsGetSamples_v1 []struct {
+			// PerfMetricsSamples_v1 is the perfMetricsSamples_v1 argument value.
+			PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+		}
 		// PowerSmoothingActivatePresetProfile holds details about calls to the PowerSmoothingActivatePresetProfile method.
 		PowerSmoothingActivatePresetProfile []struct {
 			// PowerSmoothingProfile is the powerSmoothingProfile argument value.
@@ -2542,6 +2620,11 @@ type Device struct {
 		}
 		// SetAccountingMode holds details about calls to the SetAccountingMode method.
 		SetAccountingMode []struct {
+			// EnableState is the enableState argument value.
+			EnableState nvml.EnableState
+		}
+		// SetAdaptiveTgpMode_v1 holds details about calls to the SetAdaptiveTgpMode_v1 method.
+		SetAdaptiveTgpMode_v1 []struct {
 			// EnableState is the enableState argument value.
 			EnableState nvml.EnableState
 		}
@@ -2645,6 +2728,15 @@ type Device struct {
 			// N is the n argument value.
 			N int
 		}
+		// SetMemoryLimits_v1 holds details about calls to the SetMemoryLimits_v1 method.
+		SetMemoryLimits_v1 []struct {
+			// S is the s argument value.
+			S string
+			// N1 is the n1 argument value.
+			N1 int
+			// N2 is the n2 argument value.
+			N2 int
+		}
 		// SetMemoryLockedClocks holds details about calls to the SetMemoryLockedClocks method.
 		SetMemoryLockedClocks []struct {
 			// V1 is the v1 argument value.
@@ -2677,6 +2769,11 @@ type Device struct {
 		SetNvlinkBwMode []struct {
 			// NvlinkSetBwMode is the nvlinkSetBwMode argument value.
 			NvlinkSetBwMode *nvml.NvlinkSetBwMode
+		}
+		// SetNvlinkBwModeAsync_v1 holds details about calls to the SetNvlinkBwModeAsync_v1 method.
+		SetNvlinkBwModeAsync_v1 []struct {
+			// NvlinkSetBwModeAsync_v1 is the nvlinkSetBwModeAsync_v1 argument value.
+			NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
 		}
 		// SetPersistenceMode holds details about calls to the SetPersistenceMode method.
 		SetPersistenceMode []struct {
@@ -2782,6 +2879,7 @@ type Device struct {
 	lockGetAccountingStats_v2                      sync.RWMutex
 	lockGetActiveVgpus                             sync.RWMutex
 	lockGetAdaptiveClockInfoStatus                 sync.RWMutex
+	lockGetAdaptiveTgpModeInfo_v1                  sync.RWMutex
 	lockGetAddressingMode                          sync.RWMutex
 	lockGetApplicationsClock                       sync.RWMutex
 	lockGetArchitecture                            sync.RWMutex
@@ -2789,6 +2887,7 @@ type Device struct {
 	lockGetAutoBoostedClocksEnabled                sync.RWMutex
 	lockGetBAR1MemoryInfo                          sync.RWMutex
 	lockGetBBXTimeData_v1                          sync.RWMutex
+	lockGetBankRemapperStatus_v1                   sync.RWMutex
 	lockGetBoardId                                 sync.RWMutex
 	lockGetBoardPartNumber                         sync.RWMutex
 	lockGetBrand                                   sync.RWMutex
@@ -2845,6 +2944,7 @@ type Device struct {
 	lockGetGpcClkVfOffset                          sync.RWMutex
 	lockGetGpuFabricInfo                           sync.RWMutex
 	lockGetGpuFabricInfoV                          sync.RWMutex
+	lockGetGpuFabricInfo_v4                        sync.RWMutex
 	lockGetGpuInstanceById                         sync.RWMutex
 	lockGetGpuInstanceId                           sync.RWMutex
 	lockGetGpuInstancePossiblePlacements           sync.RWMutex
@@ -2882,6 +2982,7 @@ type Device struct {
 	lockGetMemoryErrorCounter                      sync.RWMutex
 	lockGetMemoryInfo                              sync.RWMutex
 	lockGetMemoryInfo_v2                           sync.RWMutex
+	lockGetMemoryLimits_v1                         sync.RWMutex
 	lockGetMigDeviceHandleByIndex                  sync.RWMutex
 	lockGetMigMode                                 sync.RWMutex
 	lockGetMinMaxClockOfPState                     sync.RWMutex
@@ -2899,6 +3000,7 @@ type Device struct {
 	lockGetNvLinkRemoteDeviceType                  sync.RWMutex
 	lockGetNvLinkRemotePciInfo                     sync.RWMutex
 	lockGetNvLinkState                             sync.RWMutex
+	lockGetNvLinkTelemetrySamples_v1               sync.RWMutex
 	lockGetNvLinkUtilizationControl                sync.RWMutex
 	lockGetNvLinkUtilizationCounter                sync.RWMutex
 	lockGetNvLinkVersion                           sync.RWMutex
@@ -2984,6 +3086,7 @@ type Device struct {
 	lockGpmSetStreamingEnabled                     sync.RWMutex
 	lockIsMigDeviceHandle                          sync.RWMutex
 	lockOnSameBoard                                sync.RWMutex
+	lockPerfMetricsGetSamples_v1                   sync.RWMutex
 	lockPowerSmoothingActivatePresetProfile        sync.RWMutex
 	lockPowerSmoothingSetState                     sync.RWMutex
 	lockPowerSmoothingUpdatePresetProfileParam     sync.RWMutex
@@ -2997,6 +3100,7 @@ type Device struct {
 	lockResetNvLinkUtilizationCounter              sync.RWMutex
 	lockSetAPIRestriction                          sync.RWMutex
 	lockSetAccountingMode                          sync.RWMutex
+	lockSetAdaptiveTgpMode_v1                      sync.RWMutex
 	lockSetApplicationsClocks                      sync.RWMutex
 	lockSetAutoBoostedClocksEnabled                sync.RWMutex
 	lockSetClockOffsets                            sync.RWMutex
@@ -3015,11 +3119,13 @@ type Device struct {
 	lockSetGpuOperationMode                        sync.RWMutex
 	lockSetHostname_v1                             sync.RWMutex
 	lockSetMemClkVfOffset                          sync.RWMutex
+	lockSetMemoryLimits_v1                         sync.RWMutex
 	lockSetMemoryLockedClocks                      sync.RWMutex
 	lockSetMigMode                                 sync.RWMutex
 	lockSetNvLinkDeviceLowPowerThreshold           sync.RWMutex
 	lockSetNvLinkUtilizationControl                sync.RWMutex
 	lockSetNvlinkBwMode                            sync.RWMutex
+	lockSetNvlinkBwModeAsync_v1                    sync.RWMutex
 	lockSetPersistenceMode                         sync.RWMutex
 	lockSetPowerManagementLimit                    sync.RWMutex
 	lockSetPowerManagementLimit_v2                 sync.RWMutex
@@ -3497,6 +3603,33 @@ func (mock *Device) GetAdaptiveClockInfoStatusCalls() []struct {
 	return calls
 }
 
+// GetAdaptiveTgpModeInfo_v1 calls GetAdaptiveTgpModeInfo_v1Func.
+func (mock *Device) GetAdaptiveTgpModeInfo_v1() (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+	if mock.GetAdaptiveTgpModeInfo_v1Func == nil {
+		panic("Device.GetAdaptiveTgpModeInfo_v1Func: method is nil but Device.GetAdaptiveTgpModeInfo_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetAdaptiveTgpModeInfo_v1.Lock()
+	mock.calls.GetAdaptiveTgpModeInfo_v1 = append(mock.calls.GetAdaptiveTgpModeInfo_v1, callInfo)
+	mock.lockGetAdaptiveTgpModeInfo_v1.Unlock()
+	return mock.GetAdaptiveTgpModeInfo_v1Func()
+}
+
+// GetAdaptiveTgpModeInfo_v1Calls gets all the calls that were made to GetAdaptiveTgpModeInfo_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetAdaptiveTgpModeInfo_v1Calls())
+func (mock *Device) GetAdaptiveTgpModeInfo_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetAdaptiveTgpModeInfo_v1.RLock()
+	calls = mock.calls.GetAdaptiveTgpModeInfo_v1
+	mock.lockGetAdaptiveTgpModeInfo_v1.RUnlock()
+	return calls
+}
+
 // GetAddressingMode calls GetAddressingModeFunc.
 func (mock *Device) GetAddressingMode() (nvml.DeviceAddressingMode, nvml.Return) {
 	if mock.GetAddressingModeFunc == nil {
@@ -3688,6 +3821,33 @@ func (mock *Device) GetBBXTimeData_v1Calls() []struct {
 	mock.lockGetBBXTimeData_v1.RLock()
 	calls = mock.calls.GetBBXTimeData_v1
 	mock.lockGetBBXTimeData_v1.RUnlock()
+	return calls
+}
+
+// GetBankRemapperStatus_v1 calls GetBankRemapperStatus_v1Func.
+func (mock *Device) GetBankRemapperStatus_v1() (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+	if mock.GetBankRemapperStatus_v1Func == nil {
+		panic("Device.GetBankRemapperStatus_v1Func: method is nil but Device.GetBankRemapperStatus_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetBankRemapperStatus_v1.Lock()
+	mock.calls.GetBankRemapperStatus_v1 = append(mock.calls.GetBankRemapperStatus_v1, callInfo)
+	mock.lockGetBankRemapperStatus_v1.Unlock()
+	return mock.GetBankRemapperStatus_v1Func()
+}
+
+// GetBankRemapperStatus_v1Calls gets all the calls that were made to GetBankRemapperStatus_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetBankRemapperStatus_v1Calls())
+func (mock *Device) GetBankRemapperStatus_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetBankRemapperStatus_v1.RLock()
+	calls = mock.calls.GetBankRemapperStatus_v1
+	mock.lockGetBankRemapperStatus_v1.RUnlock()
 	return calls
 }
 
@@ -5270,6 +5430,33 @@ func (mock *Device) GetGpuFabricInfoVCalls() []struct {
 	return calls
 }
 
+// GetGpuFabricInfo_v4 calls GetGpuFabricInfo_v4Func.
+func (mock *Device) GetGpuFabricInfo_v4() (nvml.GpuFabricInfo_v4, nvml.Return) {
+	if mock.GetGpuFabricInfo_v4Func == nil {
+		panic("Device.GetGpuFabricInfo_v4Func: method is nil but Device.GetGpuFabricInfo_v4 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetGpuFabricInfo_v4.Lock()
+	mock.calls.GetGpuFabricInfo_v4 = append(mock.calls.GetGpuFabricInfo_v4, callInfo)
+	mock.lockGetGpuFabricInfo_v4.Unlock()
+	return mock.GetGpuFabricInfo_v4Func()
+}
+
+// GetGpuFabricInfo_v4Calls gets all the calls that were made to GetGpuFabricInfo_v4.
+// Check the length with:
+//
+//	len(mockedDevice.GetGpuFabricInfo_v4Calls())
+func (mock *Device) GetGpuFabricInfo_v4Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetGpuFabricInfo_v4.RLock()
+	calls = mock.calls.GetGpuFabricInfo_v4
+	mock.lockGetGpuFabricInfo_v4.RUnlock()
+	return calls
+}
+
 // GetGpuInstanceById calls GetGpuInstanceByIdFunc.
 func (mock *Device) GetGpuInstanceById(n int) (nvml.GpuInstance, nvml.Return) {
 	if mock.GetGpuInstanceByIdFunc == nil {
@@ -6341,6 +6528,38 @@ func (mock *Device) GetMemoryInfo_v2Calls() []struct {
 	return calls
 }
 
+// GetMemoryLimits_v1 calls GetMemoryLimits_v1Func.
+func (mock *Device) GetMemoryLimits_v1(s string) (nvml.GetMemoryLimits_v1, nvml.Return) {
+	if mock.GetMemoryLimits_v1Func == nil {
+		panic("Device.GetMemoryLimits_v1Func: method is nil but Device.GetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockGetMemoryLimits_v1.Lock()
+	mock.calls.GetMemoryLimits_v1 = append(mock.calls.GetMemoryLimits_v1, callInfo)
+	mock.lockGetMemoryLimits_v1.Unlock()
+	return mock.GetMemoryLimits_v1Func(s)
+}
+
+// GetMemoryLimits_v1Calls gets all the calls that were made to GetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetMemoryLimits_v1Calls())
+func (mock *Device) GetMemoryLimits_v1Calls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockGetMemoryLimits_v1.RLock()
+	calls = mock.calls.GetMemoryLimits_v1
+	mock.lockGetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // GetMigDeviceHandleByIndex calls GetMigDeviceHandleByIndexFunc.
 func (mock *Device) GetMigDeviceHandleByIndex(n int) (nvml.Device, nvml.Return) {
 	if mock.GetMigDeviceHandleByIndexFunc == nil {
@@ -6844,6 +7063,38 @@ func (mock *Device) GetNvLinkStateCalls() []struct {
 	mock.lockGetNvLinkState.RLock()
 	calls = mock.calls.GetNvLinkState
 	mock.lockGetNvLinkState.RUnlock()
+	return calls
+}
+
+// GetNvLinkTelemetrySamples_v1 calls GetNvLinkTelemetrySamples_v1Func.
+func (mock *Device) GetNvLinkTelemetrySamples_v1(nvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1) nvml.Return {
+	if mock.GetNvLinkTelemetrySamples_v1Func == nil {
+		panic("Device.GetNvLinkTelemetrySamples_v1Func: method is nil but Device.GetNvLinkTelemetrySamples_v1 was just called")
+	}
+	callInfo := struct {
+		NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
+	}{
+		NvlinkTelemetrySamples_v1: nvlinkTelemetrySamples_v1,
+	}
+	mock.lockGetNvLinkTelemetrySamples_v1.Lock()
+	mock.calls.GetNvLinkTelemetrySamples_v1 = append(mock.calls.GetNvLinkTelemetrySamples_v1, callInfo)
+	mock.lockGetNvLinkTelemetrySamples_v1.Unlock()
+	return mock.GetNvLinkTelemetrySamples_v1Func(nvlinkTelemetrySamples_v1)
+}
+
+// GetNvLinkTelemetrySamples_v1Calls gets all the calls that were made to GetNvLinkTelemetrySamples_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetNvLinkTelemetrySamples_v1Calls())
+func (mock *Device) GetNvLinkTelemetrySamples_v1Calls() []struct {
+	NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
+} {
+	var calls []struct {
+		NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
+	}
+	mock.lockGetNvLinkTelemetrySamples_v1.RLock()
+	calls = mock.calls.GetNvLinkTelemetrySamples_v1
+	mock.lockGetNvLinkTelemetrySamples_v1.RUnlock()
 	return calls
 }
 
@@ -9316,6 +9567,38 @@ func (mock *Device) OnSameBoardCalls() []struct {
 	return calls
 }
 
+// PerfMetricsGetSamples_v1 calls PerfMetricsGetSamples_v1Func.
+func (mock *Device) PerfMetricsGetSamples_v1(perfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1) nvml.Return {
+	if mock.PerfMetricsGetSamples_v1Func == nil {
+		panic("Device.PerfMetricsGetSamples_v1Func: method is nil but Device.PerfMetricsGetSamples_v1 was just called")
+	}
+	callInfo := struct {
+		PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+	}{
+		PerfMetricsSamples_v1: perfMetricsSamples_v1,
+	}
+	mock.lockPerfMetricsGetSamples_v1.Lock()
+	mock.calls.PerfMetricsGetSamples_v1 = append(mock.calls.PerfMetricsGetSamples_v1, callInfo)
+	mock.lockPerfMetricsGetSamples_v1.Unlock()
+	return mock.PerfMetricsGetSamples_v1Func(perfMetricsSamples_v1)
+}
+
+// PerfMetricsGetSamples_v1Calls gets all the calls that were made to PerfMetricsGetSamples_v1.
+// Check the length with:
+//
+//	len(mockedDevice.PerfMetricsGetSamples_v1Calls())
+func (mock *Device) PerfMetricsGetSamples_v1Calls() []struct {
+	PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+} {
+	var calls []struct {
+		PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+	}
+	mock.lockPerfMetricsGetSamples_v1.RLock()
+	calls = mock.calls.PerfMetricsGetSamples_v1
+	mock.lockPerfMetricsGetSamples_v1.RUnlock()
+	return calls
+}
+
 // PowerSmoothingActivatePresetProfile calls PowerSmoothingActivatePresetProfileFunc.
 func (mock *Device) PowerSmoothingActivatePresetProfile(powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 	if mock.PowerSmoothingActivatePresetProfileFunc == nil {
@@ -9730,6 +10013,38 @@ func (mock *Device) SetAccountingModeCalls() []struct {
 	mock.lockSetAccountingMode.RLock()
 	calls = mock.calls.SetAccountingMode
 	mock.lockSetAccountingMode.RUnlock()
+	return calls
+}
+
+// SetAdaptiveTgpMode_v1 calls SetAdaptiveTgpMode_v1Func.
+func (mock *Device) SetAdaptiveTgpMode_v1(enableState nvml.EnableState) nvml.Return {
+	if mock.SetAdaptiveTgpMode_v1Func == nil {
+		panic("Device.SetAdaptiveTgpMode_v1Func: method is nil but Device.SetAdaptiveTgpMode_v1 was just called")
+	}
+	callInfo := struct {
+		EnableState nvml.EnableState
+	}{
+		EnableState: enableState,
+	}
+	mock.lockSetAdaptiveTgpMode_v1.Lock()
+	mock.calls.SetAdaptiveTgpMode_v1 = append(mock.calls.SetAdaptiveTgpMode_v1, callInfo)
+	mock.lockSetAdaptiveTgpMode_v1.Unlock()
+	return mock.SetAdaptiveTgpMode_v1Func(enableState)
+}
+
+// SetAdaptiveTgpMode_v1Calls gets all the calls that were made to SetAdaptiveTgpMode_v1.
+// Check the length with:
+//
+//	len(mockedDevice.SetAdaptiveTgpMode_v1Calls())
+func (mock *Device) SetAdaptiveTgpMode_v1Calls() []struct {
+	EnableState nvml.EnableState
+} {
+	var calls []struct {
+		EnableState nvml.EnableState
+	}
+	mock.lockSetAdaptiveTgpMode_v1.RLock()
+	calls = mock.calls.SetAdaptiveTgpMode_v1
+	mock.lockSetAdaptiveTgpMode_v1.RUnlock()
 	return calls
 }
 
@@ -10328,6 +10643,46 @@ func (mock *Device) SetMemClkVfOffsetCalls() []struct {
 	return calls
 }
 
+// SetMemoryLimits_v1 calls SetMemoryLimits_v1Func.
+func (mock *Device) SetMemoryLimits_v1(s string, n1 int, n2 int) nvml.Return {
+	if mock.SetMemoryLimits_v1Func == nil {
+		panic("Device.SetMemoryLimits_v1Func: method is nil but Device.SetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		S  string
+		N1 int
+		N2 int
+	}{
+		S:  s,
+		N1: n1,
+		N2: n2,
+	}
+	mock.lockSetMemoryLimits_v1.Lock()
+	mock.calls.SetMemoryLimits_v1 = append(mock.calls.SetMemoryLimits_v1, callInfo)
+	mock.lockSetMemoryLimits_v1.Unlock()
+	return mock.SetMemoryLimits_v1Func(s, n1, n2)
+}
+
+// SetMemoryLimits_v1Calls gets all the calls that were made to SetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedDevice.SetMemoryLimits_v1Calls())
+func (mock *Device) SetMemoryLimits_v1Calls() []struct {
+	S  string
+	N1 int
+	N2 int
+} {
+	var calls []struct {
+		S  string
+		N1 int
+		N2 int
+	}
+	mock.lockSetMemoryLimits_v1.RLock()
+	calls = mock.calls.SetMemoryLimits_v1
+	mock.lockSetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // SetMemoryLockedClocks calls SetMemoryLockedClocksFunc.
 func (mock *Device) SetMemoryLockedClocks(v1 uint32, v2 uint32) nvml.Return {
 	if mock.SetMemoryLockedClocksFunc == nil {
@@ -10501,6 +10856,38 @@ func (mock *Device) SetNvlinkBwModeCalls() []struct {
 	mock.lockSetNvlinkBwMode.RLock()
 	calls = mock.calls.SetNvlinkBwMode
 	mock.lockSetNvlinkBwMode.RUnlock()
+	return calls
+}
+
+// SetNvlinkBwModeAsync_v1 calls SetNvlinkBwModeAsync_v1Func.
+func (mock *Device) SetNvlinkBwModeAsync_v1(nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+	if mock.SetNvlinkBwModeAsync_v1Func == nil {
+		panic("Device.SetNvlinkBwModeAsync_v1Func: method is nil but Device.SetNvlinkBwModeAsync_v1 was just called")
+	}
+	callInfo := struct {
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}{
+		NvlinkSetBwModeAsync_v1: nvlinkSetBwModeAsync_v1,
+	}
+	mock.lockSetNvlinkBwModeAsync_v1.Lock()
+	mock.calls.SetNvlinkBwModeAsync_v1 = append(mock.calls.SetNvlinkBwModeAsync_v1, callInfo)
+	mock.lockSetNvlinkBwModeAsync_v1.Unlock()
+	return mock.SetNvlinkBwModeAsync_v1Func(nvlinkSetBwModeAsync_v1)
+}
+
+// SetNvlinkBwModeAsync_v1Calls gets all the calls that were made to SetNvlinkBwModeAsync_v1.
+// Check the length with:
+//
+//	len(mockedDevice.SetNvlinkBwModeAsync_v1Calls())
+func (mock *Device) SetNvlinkBwModeAsync_v1Calls() []struct {
+	NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+} {
+	var calls []struct {
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}
+	mock.lockSetNvlinkBwModeAsync_v1.RLock()
+	calls = mock.calls.SetNvlinkBwModeAsync_v1
+	mock.lockSetNvlinkBwModeAsync_v1.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/eventset.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/eventset.go
@@ -21,8 +21,26 @@ var _ nvml.EventSet = &EventSet{}
 //			FreeFunc: func() nvml.Return {
 //				panic("mock out the Free method")
 //			},
+//			GetContextCount_v1Func: func() (uint32, nvml.Return) {
+//				panic("mock out the GetContextCount_v1 method")
+//			},
+//			GetContextData_v1Func: func(v uint32, bytes []byte) (uint32, nvml.Return) {
+//				panic("mock out the GetContextData_v1 method")
+//			},
+//			GetContextInfo_v1Func: func(v uint32) (nvml.OperationalEventContextInfo_v1, nvml.Return) {
+//				panic("mock out the GetContextInfo_v1 method")
+//			},
+//			GetGpuOperationalEventContextLegacyXid_v1Func: func(v uint32) (nvml.GpuOperationalEventContextLegacyXid_v1, nvml.Return) {
+//				panic("mock out the GetGpuOperationalEventContextLegacyXid_v1 method")
+//			},
+//			RegisterGpuOperationalEvents_v1Func: func(gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+//				panic("mock out the RegisterGpuOperationalEvents_v1 method")
+//			},
 //			WaitFunc: func(v uint32) (nvml.EventData, nvml.Return) {
 //				panic("mock out the Wait method")
+//			},
+//			Wait_v3Func: func(v uint32) (nvml.EventData_v2, nvml.Return) {
+//				panic("mock out the Wait_v3 method")
 //			},
 //		}
 //
@@ -34,22 +52,76 @@ type EventSet struct {
 	// FreeFunc mocks the Free method.
 	FreeFunc func() nvml.Return
 
+	// GetContextCount_v1Func mocks the GetContextCount_v1 method.
+	GetContextCount_v1Func func() (uint32, nvml.Return)
+
+	// GetContextData_v1Func mocks the GetContextData_v1 method.
+	GetContextData_v1Func func(v uint32, bytes []byte) (uint32, nvml.Return)
+
+	// GetContextInfo_v1Func mocks the GetContextInfo_v1 method.
+	GetContextInfo_v1Func func(v uint32) (nvml.OperationalEventContextInfo_v1, nvml.Return)
+
+	// GetGpuOperationalEventContextLegacyXid_v1Func mocks the GetGpuOperationalEventContextLegacyXid_v1 method.
+	GetGpuOperationalEventContextLegacyXid_v1Func func(v uint32) (nvml.GpuOperationalEventContextLegacyXid_v1, nvml.Return)
+
+	// RegisterGpuOperationalEvents_v1Func mocks the RegisterGpuOperationalEvents_v1 method.
+	RegisterGpuOperationalEvents_v1Func func(gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return
+
 	// WaitFunc mocks the Wait method.
 	WaitFunc func(v uint32) (nvml.EventData, nvml.Return)
+
+	// Wait_v3Func mocks the Wait_v3 method.
+	Wait_v3Func func(v uint32) (nvml.EventData_v2, nvml.Return)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// Free holds details about calls to the Free method.
 		Free []struct {
 		}
+		// GetContextCount_v1 holds details about calls to the GetContextCount_v1 method.
+		GetContextCount_v1 []struct {
+		}
+		// GetContextData_v1 holds details about calls to the GetContextData_v1 method.
+		GetContextData_v1 []struct {
+			// V is the v argument value.
+			V uint32
+			// Bytes is the bytes argument value.
+			Bytes []byte
+		}
+		// GetContextInfo_v1 holds details about calls to the GetContextInfo_v1 method.
+		GetContextInfo_v1 []struct {
+			// V is the v argument value.
+			V uint32
+		}
+		// GetGpuOperationalEventContextLegacyXid_v1 holds details about calls to the GetGpuOperationalEventContextLegacyXid_v1 method.
+		GetGpuOperationalEventContextLegacyXid_v1 []struct {
+			// V is the v argument value.
+			V uint32
+		}
+		// RegisterGpuOperationalEvents_v1 holds details about calls to the RegisterGpuOperationalEvents_v1 method.
+		RegisterGpuOperationalEvents_v1 []struct {
+			// GpuOperationalEventConfig_v1 is the gpuOperationalEventConfig_v1 argument value.
+			GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+		}
 		// Wait holds details about calls to the Wait method.
 		Wait []struct {
 			// V is the v argument value.
 			V uint32
 		}
+		// Wait_v3 holds details about calls to the Wait_v3 method.
+		Wait_v3 []struct {
+			// V is the v argument value.
+			V uint32
+		}
 	}
-	lockFree sync.RWMutex
-	lockWait sync.RWMutex
+	lockFree                                      sync.RWMutex
+	lockGetContextCount_v1                        sync.RWMutex
+	lockGetContextData_v1                         sync.RWMutex
+	lockGetContextInfo_v1                         sync.RWMutex
+	lockGetGpuOperationalEventContextLegacyXid_v1 sync.RWMutex
+	lockRegisterGpuOperationalEvents_v1           sync.RWMutex
+	lockWait                                      sync.RWMutex
+	lockWait_v3                                   sync.RWMutex
 }
 
 // Free calls FreeFunc.
@@ -76,6 +148,165 @@ func (mock *EventSet) FreeCalls() []struct {
 	mock.lockFree.RLock()
 	calls = mock.calls.Free
 	mock.lockFree.RUnlock()
+	return calls
+}
+
+// GetContextCount_v1 calls GetContextCount_v1Func.
+func (mock *EventSet) GetContextCount_v1() (uint32, nvml.Return) {
+	if mock.GetContextCount_v1Func == nil {
+		panic("EventSet.GetContextCount_v1Func: method is nil but EventSet.GetContextCount_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetContextCount_v1.Lock()
+	mock.calls.GetContextCount_v1 = append(mock.calls.GetContextCount_v1, callInfo)
+	mock.lockGetContextCount_v1.Unlock()
+	return mock.GetContextCount_v1Func()
+}
+
+// GetContextCount_v1Calls gets all the calls that were made to GetContextCount_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetContextCount_v1Calls())
+func (mock *EventSet) GetContextCount_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetContextCount_v1.RLock()
+	calls = mock.calls.GetContextCount_v1
+	mock.lockGetContextCount_v1.RUnlock()
+	return calls
+}
+
+// GetContextData_v1 calls GetContextData_v1Func.
+func (mock *EventSet) GetContextData_v1(v uint32, bytes []byte) (uint32, nvml.Return) {
+	if mock.GetContextData_v1Func == nil {
+		panic("EventSet.GetContextData_v1Func: method is nil but EventSet.GetContextData_v1 was just called")
+	}
+	callInfo := struct {
+		V     uint32
+		Bytes []byte
+	}{
+		V:     v,
+		Bytes: bytes,
+	}
+	mock.lockGetContextData_v1.Lock()
+	mock.calls.GetContextData_v1 = append(mock.calls.GetContextData_v1, callInfo)
+	mock.lockGetContextData_v1.Unlock()
+	return mock.GetContextData_v1Func(v, bytes)
+}
+
+// GetContextData_v1Calls gets all the calls that were made to GetContextData_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetContextData_v1Calls())
+func (mock *EventSet) GetContextData_v1Calls() []struct {
+	V     uint32
+	Bytes []byte
+} {
+	var calls []struct {
+		V     uint32
+		Bytes []byte
+	}
+	mock.lockGetContextData_v1.RLock()
+	calls = mock.calls.GetContextData_v1
+	mock.lockGetContextData_v1.RUnlock()
+	return calls
+}
+
+// GetContextInfo_v1 calls GetContextInfo_v1Func.
+func (mock *EventSet) GetContextInfo_v1(v uint32) (nvml.OperationalEventContextInfo_v1, nvml.Return) {
+	if mock.GetContextInfo_v1Func == nil {
+		panic("EventSet.GetContextInfo_v1Func: method is nil but EventSet.GetContextInfo_v1 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockGetContextInfo_v1.Lock()
+	mock.calls.GetContextInfo_v1 = append(mock.calls.GetContextInfo_v1, callInfo)
+	mock.lockGetContextInfo_v1.Unlock()
+	return mock.GetContextInfo_v1Func(v)
+}
+
+// GetContextInfo_v1Calls gets all the calls that were made to GetContextInfo_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetContextInfo_v1Calls())
+func (mock *EventSet) GetContextInfo_v1Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockGetContextInfo_v1.RLock()
+	calls = mock.calls.GetContextInfo_v1
+	mock.lockGetContextInfo_v1.RUnlock()
+	return calls
+}
+
+// GetGpuOperationalEventContextLegacyXid_v1 calls GetGpuOperationalEventContextLegacyXid_v1Func.
+func (mock *EventSet) GetGpuOperationalEventContextLegacyXid_v1(v uint32) (nvml.GpuOperationalEventContextLegacyXid_v1, nvml.Return) {
+	if mock.GetGpuOperationalEventContextLegacyXid_v1Func == nil {
+		panic("EventSet.GetGpuOperationalEventContextLegacyXid_v1Func: method is nil but EventSet.GetGpuOperationalEventContextLegacyXid_v1 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.Lock()
+	mock.calls.GetGpuOperationalEventContextLegacyXid_v1 = append(mock.calls.GetGpuOperationalEventContextLegacyXid_v1, callInfo)
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.Unlock()
+	return mock.GetGpuOperationalEventContextLegacyXid_v1Func(v)
+}
+
+// GetGpuOperationalEventContextLegacyXid_v1Calls gets all the calls that were made to GetGpuOperationalEventContextLegacyXid_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetGpuOperationalEventContextLegacyXid_v1Calls())
+func (mock *EventSet) GetGpuOperationalEventContextLegacyXid_v1Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.RLock()
+	calls = mock.calls.GetGpuOperationalEventContextLegacyXid_v1
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.RUnlock()
+	return calls
+}
+
+// RegisterGpuOperationalEvents_v1 calls RegisterGpuOperationalEvents_v1Func.
+func (mock *EventSet) RegisterGpuOperationalEvents_v1(gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+	if mock.RegisterGpuOperationalEvents_v1Func == nil {
+		panic("EventSet.RegisterGpuOperationalEvents_v1Func: method is nil but EventSet.RegisterGpuOperationalEvents_v1 was just called")
+	}
+	callInfo := struct {
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}{
+		GpuOperationalEventConfig_v1: gpuOperationalEventConfig_v1,
+	}
+	mock.lockRegisterGpuOperationalEvents_v1.Lock()
+	mock.calls.RegisterGpuOperationalEvents_v1 = append(mock.calls.RegisterGpuOperationalEvents_v1, callInfo)
+	mock.lockRegisterGpuOperationalEvents_v1.Unlock()
+	return mock.RegisterGpuOperationalEvents_v1Func(gpuOperationalEventConfig_v1)
+}
+
+// RegisterGpuOperationalEvents_v1Calls gets all the calls that were made to RegisterGpuOperationalEvents_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.RegisterGpuOperationalEvents_v1Calls())
+func (mock *EventSet) RegisterGpuOperationalEvents_v1Calls() []struct {
+	GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+} {
+	var calls []struct {
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}
+	mock.lockRegisterGpuOperationalEvents_v1.RLock()
+	calls = mock.calls.RegisterGpuOperationalEvents_v1
+	mock.lockRegisterGpuOperationalEvents_v1.RUnlock()
 	return calls
 }
 
@@ -108,5 +339,37 @@ func (mock *EventSet) WaitCalls() []struct {
 	mock.lockWait.RLock()
 	calls = mock.calls.Wait
 	mock.lockWait.RUnlock()
+	return calls
+}
+
+// Wait_v3 calls Wait_v3Func.
+func (mock *EventSet) Wait_v3(v uint32) (nvml.EventData_v2, nvml.Return) {
+	if mock.Wait_v3Func == nil {
+		panic("EventSet.Wait_v3Func: method is nil but EventSet.Wait_v3 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockWait_v3.Lock()
+	mock.calls.Wait_v3 = append(mock.calls.Wait_v3, callInfo)
+	mock.lockWait_v3.Unlock()
+	return mock.Wait_v3Func(v)
+}
+
+// Wait_v3Calls gets all the calls that were made to Wait_v3.
+// Check the length with:
+//
+//	len(mockedEventSet.Wait_v3Calls())
+func (mock *EventSet) Wait_v3Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockWait_v3.RLock()
+	calls = mock.calls.Wait_v3
+	mock.lockWait_v3.RUnlock()
 	return calls
 }

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/interface.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/interface.go
@@ -72,6 +72,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetAdaptiveClockInfoStatusFunc: func(device nvml.Device) (uint32, nvml.Return) {
 //				panic("mock out the DeviceGetAdaptiveClockInfoStatus method")
 //			},
+//			DeviceGetAdaptiveTgpModeInfo_v1Func: func(device nvml.Device) (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+//				panic("mock out the DeviceGetAdaptiveTgpModeInfo_v1 method")
+//			},
 //			DeviceGetAddressingModeFunc: func(device nvml.Device) (nvml.DeviceAddressingMode, nvml.Return) {
 //				panic("mock out the DeviceGetAddressingMode method")
 //			},
@@ -92,6 +95,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceGetBBXTimeData_v1Func: func(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return) {
 //				panic("mock out the DeviceGetBBXTimeData_v1 method")
+//			},
+//			DeviceGetBankRemapperStatus_v1Func: func(device nvml.Device) (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+//				panic("mock out the DeviceGetBankRemapperStatus_v1 method")
 //			},
 //			DeviceGetBoardIdFunc: func(device nvml.Device) (uint32, nvml.Return) {
 //				panic("mock out the DeviceGetBoardId method")
@@ -264,6 +270,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetGpuFabricInfoVFunc: func(device nvml.Device) nvml.GpuFabricInfoHandler {
 //				panic("mock out the DeviceGetGpuFabricInfoV method")
 //			},
+//			DeviceGetGpuFabricInfo_v4Func: func(device nvml.Device) (nvml.GpuFabricInfo_v4, nvml.Return) {
+//				panic("mock out the DeviceGetGpuFabricInfo_v4 method")
+//			},
 //			DeviceGetGpuInstanceByIdFunc: func(device nvml.Device, n int) (nvml.GpuInstance, nvml.Return) {
 //				panic("mock out the DeviceGetGpuInstanceById method")
 //			},
@@ -390,6 +399,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetMemoryInfo_v2Func: func(device nvml.Device) (nvml.Memory_v2, nvml.Return) {
 //				panic("mock out the DeviceGetMemoryInfo_v2 method")
 //			},
+//			DeviceGetMemoryLimits_v1Func: func(device nvml.Device, s string) (nvml.GetMemoryLimits_v1, nvml.Return) {
+//				panic("mock out the DeviceGetMemoryLimits_v1 method")
+//			},
 //			DeviceGetMigDeviceHandleByIndexFunc: func(device nvml.Device, n int) (nvml.Device, nvml.Return) {
 //				panic("mock out the DeviceGetMigDeviceHandleByIndex method")
 //			},
@@ -440,6 +452,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceGetNvLinkStateFunc: func(device nvml.Device, n int) (nvml.EnableState, nvml.Return) {
 //				panic("mock out the DeviceGetNvLinkState method")
+//			},
+//			DeviceGetNvLinkTelemetrySamples_v1Func: func(device nvml.Device, nvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1) nvml.Return {
+//				panic("mock out the DeviceGetNvLinkTelemetrySamples_v1 method")
 //			},
 //			DeviceGetNvLinkUtilizationControlFunc: func(device nvml.Device, n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return) {
 //				panic("mock out the DeviceGetNvLinkUtilizationControl method")
@@ -681,6 +696,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceOnSameBoardFunc: func(device1 nvml.Device, device2 nvml.Device) (int, nvml.Return) {
 //				panic("mock out the DeviceOnSameBoard method")
 //			},
+//			DevicePerfMetricsGetSamples_v1Func: func(device nvml.Device, perfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1) nvml.Return {
+//				panic("mock out the DevicePerfMetricsGetSamples_v1 method")
+//			},
 //			DevicePowerSmoothingActivatePresetProfileFunc: func(device nvml.Device, powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 //				panic("mock out the DevicePowerSmoothingActivatePresetProfile method")
 //			},
@@ -728,6 +746,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceSetAccountingModeFunc: func(device nvml.Device, enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the DeviceSetAccountingMode method")
+//			},
+//			DeviceSetAdaptiveTgpMode_v1Func: func(device nvml.Device, enableState nvml.EnableState) nvml.Return {
+//				panic("mock out the DeviceSetAdaptiveTgpMode_v1 method")
 //			},
 //			DeviceSetApplicationsClocksFunc: func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the DeviceSetApplicationsClocks method")
@@ -783,6 +804,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceSetMemClkVfOffsetFunc: func(device nvml.Device, n int) nvml.Return {
 //				panic("mock out the DeviceSetMemClkVfOffset method")
 //			},
+//			DeviceSetMemoryLimits_v1Func: func(device nvml.Device, s string, n1 int, n2 int) nvml.Return {
+//				panic("mock out the DeviceSetMemoryLimits_v1 method")
+//			},
 //			DeviceSetMemoryLockedClocksFunc: func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the DeviceSetMemoryLockedClocks method")
 //			},
@@ -797,6 +821,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceSetNvlinkBwModeFunc: func(device nvml.Device, nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return {
 //				panic("mock out the DeviceSetNvlinkBwMode method")
+//			},
+//			DeviceSetNvlinkBwModeAsync_v1Func: func(device nvml.Device, nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+//				panic("mock out the DeviceSetNvlinkBwModeAsync_v1 method")
 //			},
 //			DeviceSetPersistenceModeFunc: func(device nvml.Device, enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the DeviceSetPersistenceMode method")
@@ -858,8 +885,26 @@ var _ nvml.Interface = &Interface{}
 //			EventSetFreeFunc: func(eventSet nvml.EventSet) nvml.Return {
 //				panic("mock out the EventSetFree method")
 //			},
+//			EventSetGetContextCount_v1Func: func(eventSet nvml.EventSet) (uint32, nvml.Return) {
+//				panic("mock out the EventSetGetContextCount_v1 method")
+//			},
+//			EventSetGetContextData_v1Func: func(eventSet nvml.EventSet, v uint32, bytes []byte) (uint32, nvml.Return) {
+//				panic("mock out the EventSetGetContextData_v1 method")
+//			},
+//			EventSetGetContextInfo_v1Func: func(eventSet nvml.EventSet, v uint32) (nvml.OperationalEventContextInfo_v1, nvml.Return) {
+//				panic("mock out the EventSetGetContextInfo_v1 method")
+//			},
+//			EventSetGetGpuOperationalEventContextLegacyXid_v1Func: func(eventSet nvml.EventSet, v uint32) (nvml.GpuOperationalEventContextLegacyXid_v1, nvml.Return) {
+//				panic("mock out the EventSetGetGpuOperationalEventContextLegacyXid_v1 method")
+//			},
+//			EventSetRegisterGpuOperationalEvents_v1Func: func(eventSet nvml.EventSet, gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+//				panic("mock out the EventSetRegisterGpuOperationalEvents_v1 method")
+//			},
 //			EventSetWaitFunc: func(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return) {
 //				panic("mock out the EventSetWait method")
+//			},
+//			EventSetWait_v3Func: func(eventSet nvml.EventSet, v uint32) (nvml.EventData_v2, nvml.Return) {
+//				panic("mock out the EventSetWait_v3 method")
 //			},
 //			ExtensionsFunc: func() nvml.ExtendedInterface {
 //				panic("mock out the Extensions method")
@@ -1170,6 +1215,9 @@ var _ nvml.Interface = &Interface{}
 //			VgpuTypeGetGpuInstanceProfileIdFunc: func(vgpuTypeId nvml.VgpuTypeId) (uint32, nvml.Return) {
 //				panic("mock out the VgpuTypeGetGpuInstanceProfileId method")
 //			},
+//			VgpuTypeGetIDFunc: func(vgpuTypeId nvml.VgpuTypeId) uint32 {
+//				panic("mock out the VgpuTypeGetID method")
+//			},
 //			VgpuTypeGetLicenseFunc: func(vgpuTypeId nvml.VgpuTypeId) (string, nvml.Return) {
 //				panic("mock out the VgpuTypeGetLicense method")
 //			},
@@ -1252,6 +1300,9 @@ type Interface struct {
 	// DeviceGetAdaptiveClockInfoStatusFunc mocks the DeviceGetAdaptiveClockInfoStatus method.
 	DeviceGetAdaptiveClockInfoStatusFunc func(device nvml.Device) (uint32, nvml.Return)
 
+	// DeviceGetAdaptiveTgpModeInfo_v1Func mocks the DeviceGetAdaptiveTgpModeInfo_v1 method.
+	DeviceGetAdaptiveTgpModeInfo_v1Func func(device nvml.Device) (nvml.AdaptiveTgpModeInfo_v1, nvml.Return)
+
 	// DeviceGetAddressingModeFunc mocks the DeviceGetAddressingMode method.
 	DeviceGetAddressingModeFunc func(device nvml.Device) (nvml.DeviceAddressingMode, nvml.Return)
 
@@ -1272,6 +1323,9 @@ type Interface struct {
 
 	// DeviceGetBBXTimeData_v1Func mocks the DeviceGetBBXTimeData_v1 method.
 	DeviceGetBBXTimeData_v1Func func(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return)
+
+	// DeviceGetBankRemapperStatus_v1Func mocks the DeviceGetBankRemapperStatus_v1 method.
+	DeviceGetBankRemapperStatus_v1Func func(device nvml.Device) (nvml.EccBankRemapperStatus_v1, nvml.Return)
 
 	// DeviceGetBoardIdFunc mocks the DeviceGetBoardId method.
 	DeviceGetBoardIdFunc func(device nvml.Device) (uint32, nvml.Return)
@@ -1444,6 +1498,9 @@ type Interface struct {
 	// DeviceGetGpuFabricInfoVFunc mocks the DeviceGetGpuFabricInfoV method.
 	DeviceGetGpuFabricInfoVFunc func(device nvml.Device) nvml.GpuFabricInfoHandler
 
+	// DeviceGetGpuFabricInfo_v4Func mocks the DeviceGetGpuFabricInfo_v4 method.
+	DeviceGetGpuFabricInfo_v4Func func(device nvml.Device) (nvml.GpuFabricInfo_v4, nvml.Return)
+
 	// DeviceGetGpuInstanceByIdFunc mocks the DeviceGetGpuInstanceById method.
 	DeviceGetGpuInstanceByIdFunc func(device nvml.Device, n int) (nvml.GpuInstance, nvml.Return)
 
@@ -1570,6 +1627,9 @@ type Interface struct {
 	// DeviceGetMemoryInfo_v2Func mocks the DeviceGetMemoryInfo_v2 method.
 	DeviceGetMemoryInfo_v2Func func(device nvml.Device) (nvml.Memory_v2, nvml.Return)
 
+	// DeviceGetMemoryLimits_v1Func mocks the DeviceGetMemoryLimits_v1 method.
+	DeviceGetMemoryLimits_v1Func func(device nvml.Device, s string) (nvml.GetMemoryLimits_v1, nvml.Return)
+
 	// DeviceGetMigDeviceHandleByIndexFunc mocks the DeviceGetMigDeviceHandleByIndex method.
 	DeviceGetMigDeviceHandleByIndexFunc func(device nvml.Device, n int) (nvml.Device, nvml.Return)
 
@@ -1620,6 +1680,9 @@ type Interface struct {
 
 	// DeviceGetNvLinkStateFunc mocks the DeviceGetNvLinkState method.
 	DeviceGetNvLinkStateFunc func(device nvml.Device, n int) (nvml.EnableState, nvml.Return)
+
+	// DeviceGetNvLinkTelemetrySamples_v1Func mocks the DeviceGetNvLinkTelemetrySamples_v1 method.
+	DeviceGetNvLinkTelemetrySamples_v1Func func(device nvml.Device, nvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1) nvml.Return
 
 	// DeviceGetNvLinkUtilizationControlFunc mocks the DeviceGetNvLinkUtilizationControl method.
 	DeviceGetNvLinkUtilizationControlFunc func(device nvml.Device, n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return)
@@ -1861,6 +1924,9 @@ type Interface struct {
 	// DeviceOnSameBoardFunc mocks the DeviceOnSameBoard method.
 	DeviceOnSameBoardFunc func(device1 nvml.Device, device2 nvml.Device) (int, nvml.Return)
 
+	// DevicePerfMetricsGetSamples_v1Func mocks the DevicePerfMetricsGetSamples_v1 method.
+	DevicePerfMetricsGetSamples_v1Func func(device nvml.Device, perfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1) nvml.Return
+
 	// DevicePowerSmoothingActivatePresetProfileFunc mocks the DevicePowerSmoothingActivatePresetProfile method.
 	DevicePowerSmoothingActivatePresetProfileFunc func(device nvml.Device, powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return
 
@@ -1908,6 +1974,9 @@ type Interface struct {
 
 	// DeviceSetAccountingModeFunc mocks the DeviceSetAccountingMode method.
 	DeviceSetAccountingModeFunc func(device nvml.Device, enableState nvml.EnableState) nvml.Return
+
+	// DeviceSetAdaptiveTgpMode_v1Func mocks the DeviceSetAdaptiveTgpMode_v1 method.
+	DeviceSetAdaptiveTgpMode_v1Func func(device nvml.Device, enableState nvml.EnableState) nvml.Return
 
 	// DeviceSetApplicationsClocksFunc mocks the DeviceSetApplicationsClocks method.
 	DeviceSetApplicationsClocksFunc func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return
@@ -1963,6 +2032,9 @@ type Interface struct {
 	// DeviceSetMemClkVfOffsetFunc mocks the DeviceSetMemClkVfOffset method.
 	DeviceSetMemClkVfOffsetFunc func(device nvml.Device, n int) nvml.Return
 
+	// DeviceSetMemoryLimits_v1Func mocks the DeviceSetMemoryLimits_v1 method.
+	DeviceSetMemoryLimits_v1Func func(device nvml.Device, s string, n1 int, n2 int) nvml.Return
+
 	// DeviceSetMemoryLockedClocksFunc mocks the DeviceSetMemoryLockedClocks method.
 	DeviceSetMemoryLockedClocksFunc func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return
 
@@ -1977,6 +2049,9 @@ type Interface struct {
 
 	// DeviceSetNvlinkBwModeFunc mocks the DeviceSetNvlinkBwMode method.
 	DeviceSetNvlinkBwModeFunc func(device nvml.Device, nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return
+
+	// DeviceSetNvlinkBwModeAsync_v1Func mocks the DeviceSetNvlinkBwModeAsync_v1 method.
+	DeviceSetNvlinkBwModeAsync_v1Func func(device nvml.Device, nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return
 
 	// DeviceSetPersistenceModeFunc mocks the DeviceSetPersistenceMode method.
 	DeviceSetPersistenceModeFunc func(device nvml.Device, enableState nvml.EnableState) nvml.Return
@@ -2038,8 +2113,26 @@ type Interface struct {
 	// EventSetFreeFunc mocks the EventSetFree method.
 	EventSetFreeFunc func(eventSet nvml.EventSet) nvml.Return
 
+	// EventSetGetContextCount_v1Func mocks the EventSetGetContextCount_v1 method.
+	EventSetGetContextCount_v1Func func(eventSet nvml.EventSet) (uint32, nvml.Return)
+
+	// EventSetGetContextData_v1Func mocks the EventSetGetContextData_v1 method.
+	EventSetGetContextData_v1Func func(eventSet nvml.EventSet, v uint32, bytes []byte) (uint32, nvml.Return)
+
+	// EventSetGetContextInfo_v1Func mocks the EventSetGetContextInfo_v1 method.
+	EventSetGetContextInfo_v1Func func(eventSet nvml.EventSet, v uint32) (nvml.OperationalEventContextInfo_v1, nvml.Return)
+
+	// EventSetGetGpuOperationalEventContextLegacyXid_v1Func mocks the EventSetGetGpuOperationalEventContextLegacyXid_v1 method.
+	EventSetGetGpuOperationalEventContextLegacyXid_v1Func func(eventSet nvml.EventSet, v uint32) (nvml.GpuOperationalEventContextLegacyXid_v1, nvml.Return)
+
+	// EventSetRegisterGpuOperationalEvents_v1Func mocks the EventSetRegisterGpuOperationalEvents_v1 method.
+	EventSetRegisterGpuOperationalEvents_v1Func func(eventSet nvml.EventSet, gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return
+
 	// EventSetWaitFunc mocks the EventSetWait method.
 	EventSetWaitFunc func(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return)
+
+	// EventSetWait_v3Func mocks the EventSetWait_v3 method.
+	EventSetWait_v3Func func(eventSet nvml.EventSet, v uint32) (nvml.EventData_v2, nvml.Return)
 
 	// ExtensionsFunc mocks the Extensions method.
 	ExtensionsFunc func() nvml.ExtendedInterface
@@ -2350,6 +2443,9 @@ type Interface struct {
 	// VgpuTypeGetGpuInstanceProfileIdFunc mocks the VgpuTypeGetGpuInstanceProfileId method.
 	VgpuTypeGetGpuInstanceProfileIdFunc func(vgpuTypeId nvml.VgpuTypeId) (uint32, nvml.Return)
 
+	// VgpuTypeGetIDFunc mocks the VgpuTypeGetID method.
+	VgpuTypeGetIDFunc func(vgpuTypeId nvml.VgpuTypeId) uint32
+
 	// VgpuTypeGetLicenseFunc mocks the VgpuTypeGetLicense method.
 	VgpuTypeGetLicenseFunc func(vgpuTypeId nvml.VgpuTypeId) (string, nvml.Return)
 
@@ -2483,6 +2579,11 @@ type Interface struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// DeviceGetAdaptiveTgpModeInfo_v1 holds details about calls to the DeviceGetAdaptiveTgpModeInfo_v1 method.
+		DeviceGetAdaptiveTgpModeInfo_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
 		// DeviceGetAddressingMode holds details about calls to the DeviceGetAddressingMode method.
 		DeviceGetAddressingMode []struct {
 			// Device is the device argument value.
@@ -2517,6 +2618,11 @@ type Interface struct {
 		}
 		// DeviceGetBBXTimeData_v1 holds details about calls to the DeviceGetBBXTimeData_v1 method.
 		DeviceGetBBXTimeData_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
+		// DeviceGetBankRemapperStatus_v1 holds details about calls to the DeviceGetBankRemapperStatus_v1 method.
+		DeviceGetBankRemapperStatus_v1 []struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
@@ -2831,6 +2937,11 @@ type Interface struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// DeviceGetGpuFabricInfo_v4 holds details about calls to the DeviceGetGpuFabricInfo_v4 method.
+		DeviceGetGpuFabricInfo_v4 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
 		// DeviceGetGpuInstanceById holds details about calls to the DeviceGetGpuInstanceById method.
 		DeviceGetGpuInstanceById []struct {
 			// Device is the device argument value.
@@ -3071,6 +3182,13 @@ type Interface struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// DeviceGetMemoryLimits_v1 holds details about calls to the DeviceGetMemoryLimits_v1 method.
+		DeviceGetMemoryLimits_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// S is the s argument value.
+			S string
+		}
 		// DeviceGetMigDeviceHandleByIndex holds details about calls to the DeviceGetMigDeviceHandleByIndex method.
 		DeviceGetMigDeviceHandleByIndex []struct {
 			// Device is the device argument value.
@@ -3175,6 +3293,13 @@ type Interface struct {
 			Device nvml.Device
 			// N is the n argument value.
 			N int
+		}
+		// DeviceGetNvLinkTelemetrySamples_v1 holds details about calls to the DeviceGetNvLinkTelemetrySamples_v1 method.
+		DeviceGetNvLinkTelemetrySamples_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// NvlinkTelemetrySamples_v1 is the nvlinkTelemetrySamples_v1 argument value.
+			NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
 		}
 		// DeviceGetNvLinkUtilizationControl holds details about calls to the DeviceGetNvLinkUtilizationControl method.
 		DeviceGetNvLinkUtilizationControl []struct {
@@ -3642,6 +3767,13 @@ type Interface struct {
 			// Device2 is the device2 argument value.
 			Device2 nvml.Device
 		}
+		// DevicePerfMetricsGetSamples_v1 holds details about calls to the DevicePerfMetricsGetSamples_v1 method.
+		DevicePerfMetricsGetSamples_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// PerfMetricsSamples_v1 is the perfMetricsSamples_v1 argument value.
+			PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+		}
 		// DevicePowerSmoothingActivatePresetProfile holds details about calls to the DevicePowerSmoothingActivatePresetProfile method.
 		DevicePowerSmoothingActivatePresetProfile []struct {
 			// Device is the device argument value.
@@ -3749,6 +3881,13 @@ type Interface struct {
 		}
 		// DeviceSetAccountingMode holds details about calls to the DeviceSetAccountingMode method.
 		DeviceSetAccountingMode []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// EnableState is the enableState argument value.
+			EnableState nvml.EnableState
+		}
+		// DeviceSetAdaptiveTgpMode_v1 holds details about calls to the DeviceSetAdaptiveTgpMode_v1 method.
+		DeviceSetAdaptiveTgpMode_v1 []struct {
 			// Device is the device argument value.
 			Device nvml.Device
 			// EnableState is the enableState argument value.
@@ -3890,6 +4029,17 @@ type Interface struct {
 			// N is the n argument value.
 			N int
 		}
+		// DeviceSetMemoryLimits_v1 holds details about calls to the DeviceSetMemoryLimits_v1 method.
+		DeviceSetMemoryLimits_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// S is the s argument value.
+			S string
+			// N1 is the n1 argument value.
+			N1 int
+			// N2 is the n2 argument value.
+			N2 int
+		}
 		// DeviceSetMemoryLockedClocks holds details about calls to the DeviceSetMemoryLockedClocks method.
 		DeviceSetMemoryLockedClocks []struct {
 			// Device is the device argument value.
@@ -3932,6 +4082,13 @@ type Interface struct {
 			Device nvml.Device
 			// NvlinkSetBwMode is the nvlinkSetBwMode argument value.
 			NvlinkSetBwMode *nvml.NvlinkSetBwMode
+		}
+		// DeviceSetNvlinkBwModeAsync_v1 holds details about calls to the DeviceSetNvlinkBwModeAsync_v1 method.
+		DeviceSetNvlinkBwModeAsync_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// NvlinkSetBwModeAsync_v1 is the nvlinkSetBwModeAsync_v1 argument value.
+			NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
 		}
 		// DeviceSetPersistenceMode holds details about calls to the DeviceSetPersistenceMode method.
 		DeviceSetPersistenceMode []struct {
@@ -4063,8 +4220,50 @@ type Interface struct {
 			// EventSet is the eventSet argument value.
 			EventSet nvml.EventSet
 		}
+		// EventSetGetContextCount_v1 holds details about calls to the EventSetGetContextCount_v1 method.
+		EventSetGetContextCount_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+		}
+		// EventSetGetContextData_v1 holds details about calls to the EventSetGetContextData_v1 method.
+		EventSetGetContextData_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+			// Bytes is the bytes argument value.
+			Bytes []byte
+		}
+		// EventSetGetContextInfo_v1 holds details about calls to the EventSetGetContextInfo_v1 method.
+		EventSetGetContextInfo_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+		}
+		// EventSetGetGpuOperationalEventContextLegacyXid_v1 holds details about calls to the EventSetGetGpuOperationalEventContextLegacyXid_v1 method.
+		EventSetGetGpuOperationalEventContextLegacyXid_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+		}
+		// EventSetRegisterGpuOperationalEvents_v1 holds details about calls to the EventSetRegisterGpuOperationalEvents_v1 method.
+		EventSetRegisterGpuOperationalEvents_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// GpuOperationalEventConfig_v1 is the gpuOperationalEventConfig_v1 argument value.
+			GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+		}
 		// EventSetWait holds details about calls to the EventSetWait method.
 		EventSetWait []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+		}
+		// EventSetWait_v3 holds details about calls to the EventSetWait_v3 method.
+		EventSetWait_v3 []struct {
 			// EventSet is the eventSet argument value.
 			EventSet nvml.EventSet
 			// V is the v argument value.
@@ -4599,6 +4798,11 @@ type Interface struct {
 			// VgpuTypeId is the vgpuTypeId argument value.
 			VgpuTypeId nvml.VgpuTypeId
 		}
+		// VgpuTypeGetID holds details about calls to the VgpuTypeGetID method.
+		VgpuTypeGetID []struct {
+			// VgpuTypeId is the vgpuTypeId argument value.
+			VgpuTypeId nvml.VgpuTypeId
+		}
 		// VgpuTypeGetLicense holds details about calls to the VgpuTypeGetLicense method.
 		VgpuTypeGetLicense []struct {
 			// VgpuTypeId is the vgpuTypeId argument value.
@@ -4639,397 +4843,413 @@ type Interface struct {
 			N int
 		}
 	}
-	lockComputeInstanceDestroy                           sync.RWMutex
-	lockComputeInstanceGetInfo                           sync.RWMutex
-	lockDeviceClearAccountingPids                        sync.RWMutex
-	lockDeviceClearCpuAffinity                           sync.RWMutex
-	lockDeviceClearEccErrorCounts                        sync.RWMutex
-	lockDeviceClearFieldValues                           sync.RWMutex
-	lockDeviceCreateGpuInstance                          sync.RWMutex
-	lockDeviceCreateGpuInstanceWithPlacement             sync.RWMutex
-	lockDeviceDiscoverGpus                               sync.RWMutex
-	lockDeviceFreezeNvLinkUtilizationCounter             sync.RWMutex
-	lockDeviceGetAPIRestriction                          sync.RWMutex
-	lockDeviceGetAccountingBufferSize                    sync.RWMutex
-	lockDeviceGetAccountingMode                          sync.RWMutex
-	lockDeviceGetAccountingPids                          sync.RWMutex
-	lockDeviceGetAccountingStats                         sync.RWMutex
-	lockDeviceGetAccountingStats_v2                      sync.RWMutex
-	lockDeviceGetActiveVgpus                             sync.RWMutex
-	lockDeviceGetAdaptiveClockInfoStatus                 sync.RWMutex
-	lockDeviceGetAddressingMode                          sync.RWMutex
-	lockDeviceGetApplicationsClock                       sync.RWMutex
-	lockDeviceGetArchitecture                            sync.RWMutex
-	lockDeviceGetAttributes                              sync.RWMutex
-	lockDeviceGetAutoBoostedClocksEnabled                sync.RWMutex
-	lockDeviceGetBAR1MemoryInfo                          sync.RWMutex
-	lockDeviceGetBBXTimeData_v1                          sync.RWMutex
-	lockDeviceGetBoardId                                 sync.RWMutex
-	lockDeviceGetBoardPartNumber                         sync.RWMutex
-	lockDeviceGetBrand                                   sync.RWMutex
-	lockDeviceGetBridgeChipInfo                          sync.RWMutex
-	lockDeviceGetBusType                                 sync.RWMutex
-	lockDeviceGetC2cModeInfoV                            sync.RWMutex
-	lockDeviceGetCapabilities                            sync.RWMutex
-	lockDeviceGetClkMonStatus                            sync.RWMutex
-	lockDeviceGetClock                                   sync.RWMutex
-	lockDeviceGetClockInfo                               sync.RWMutex
-	lockDeviceGetClockOffsets                            sync.RWMutex
-	lockDeviceGetComputeInstanceId                       sync.RWMutex
-	lockDeviceGetComputeMode                             sync.RWMutex
-	lockDeviceGetComputeRunningProcesses                 sync.RWMutex
-	lockDeviceGetConfComputeGpuAttestationReport         sync.RWMutex
-	lockDeviceGetConfComputeGpuCertificate               sync.RWMutex
-	lockDeviceGetConfComputeMemSizeInfo                  sync.RWMutex
-	lockDeviceGetConfComputeProtectedMemoryUsage         sync.RWMutex
-	lockDeviceGetCoolerInfo                              sync.RWMutex
-	lockDeviceGetCount                                   sync.RWMutex
-	lockDeviceGetCpuAffinity                             sync.RWMutex
-	lockDeviceGetCpuAffinityWithinScope                  sync.RWMutex
-	lockDeviceGetCreatableVgpus                          sync.RWMutex
-	lockDeviceGetCudaComputeCapability                   sync.RWMutex
-	lockDeviceGetCurrPcieLinkGeneration                  sync.RWMutex
-	lockDeviceGetCurrPcieLinkWidth                       sync.RWMutex
-	lockDeviceGetCurrentClockFreqs                       sync.RWMutex
-	lockDeviceGetCurrentClocksEventReasons               sync.RWMutex
-	lockDeviceGetCurrentClocksThrottleReasons            sync.RWMutex
-	lockDeviceGetDecoderUtilization                      sync.RWMutex
-	lockDeviceGetDefaultApplicationsClock                sync.RWMutex
-	lockDeviceGetDefaultEccMode                          sync.RWMutex
-	lockDeviceGetDetailedEccErrors                       sync.RWMutex
-	lockDeviceGetDeviceHandleFromMigDeviceHandle         sync.RWMutex
-	lockDeviceGetDisplayActive                           sync.RWMutex
-	lockDeviceGetDisplayMode                             sync.RWMutex
-	lockDeviceGetDramEncryptionMode                      sync.RWMutex
-	lockDeviceGetDriverModel                             sync.RWMutex
-	lockDeviceGetDriverModel_v2                          sync.RWMutex
-	lockDeviceGetDynamicPstatesInfo                      sync.RWMutex
-	lockDeviceGetEccMode                                 sync.RWMutex
-	lockDeviceGetEncoderCapacity                         sync.RWMutex
-	lockDeviceGetEncoderSessions                         sync.RWMutex
-	lockDeviceGetEncoderStats                            sync.RWMutex
-	lockDeviceGetEncoderUtilization                      sync.RWMutex
-	lockDeviceGetEnforcedPowerLimit                      sync.RWMutex
-	lockDeviceGetFBCSessions                             sync.RWMutex
-	lockDeviceGetFBCStats                                sync.RWMutex
-	lockDeviceGetFanControlPolicy_v2                     sync.RWMutex
-	lockDeviceGetFanSpeed                                sync.RWMutex
-	lockDeviceGetFanSpeedRPM                             sync.RWMutex
-	lockDeviceGetFanSpeed_v2                             sync.RWMutex
-	lockDeviceGetFieldValues                             sync.RWMutex
-	lockDeviceGetGpcClkMinMaxVfOffset                    sync.RWMutex
-	lockDeviceGetGpcClkVfOffset                          sync.RWMutex
-	lockDeviceGetGpuFabricInfo                           sync.RWMutex
-	lockDeviceGetGpuFabricInfoV                          sync.RWMutex
-	lockDeviceGetGpuInstanceById                         sync.RWMutex
-	lockDeviceGetGpuInstanceId                           sync.RWMutex
-	lockDeviceGetGpuInstancePossiblePlacements           sync.RWMutex
-	lockDeviceGetGpuInstanceProfileInfo                  sync.RWMutex
-	lockDeviceGetGpuInstanceProfileInfoByIdV             sync.RWMutex
-	lockDeviceGetGpuInstanceProfileInfoV                 sync.RWMutex
-	lockDeviceGetGpuInstanceRemainingCapacity            sync.RWMutex
-	lockDeviceGetGpuInstances                            sync.RWMutex
-	lockDeviceGetGpuMaxPcieLinkGeneration                sync.RWMutex
-	lockDeviceGetGpuOperationMode                        sync.RWMutex
-	lockDeviceGetGraphicsRunningProcesses                sync.RWMutex
-	lockDeviceGetGridLicensableFeatures                  sync.RWMutex
-	lockDeviceGetGspFirmwareMode                         sync.RWMutex
-	lockDeviceGetGspFirmwareVersion                      sync.RWMutex
-	lockDeviceGetHandleByIndex                           sync.RWMutex
-	lockDeviceGetHandleByPciBusId                        sync.RWMutex
-	lockDeviceGetHandleBySerial                          sync.RWMutex
-	lockDeviceGetHandleByUUID                            sync.RWMutex
-	lockDeviceGetHandleByUUIDV                           sync.RWMutex
-	lockDeviceGetHostVgpuMode                            sync.RWMutex
-	lockDeviceGetHostname_v1                             sync.RWMutex
-	lockDeviceGetIndex                                   sync.RWMutex
-	lockDeviceGetInforomConfigurationChecksum            sync.RWMutex
-	lockDeviceGetInforomImageVersion                     sync.RWMutex
-	lockDeviceGetInforomVersion                          sync.RWMutex
-	lockDeviceGetIrqNum                                  sync.RWMutex
-	lockDeviceGetJpgUtilization                          sync.RWMutex
-	lockDeviceGetLastBBXFlushTime                        sync.RWMutex
-	lockDeviceGetMPSComputeRunningProcesses              sync.RWMutex
-	lockDeviceGetMarginTemperature                       sync.RWMutex
-	lockDeviceGetMaxClockInfo                            sync.RWMutex
-	lockDeviceGetMaxCustomerBoostClock                   sync.RWMutex
-	lockDeviceGetMaxMigDeviceCount                       sync.RWMutex
-	lockDeviceGetMaxPcieLinkGeneration                   sync.RWMutex
-	lockDeviceGetMaxPcieLinkWidth                        sync.RWMutex
-	lockDeviceGetMemClkMinMaxVfOffset                    sync.RWMutex
-	lockDeviceGetMemClkVfOffset                          sync.RWMutex
-	lockDeviceGetMemoryAffinity                          sync.RWMutex
-	lockDeviceGetMemoryBusWidth                          sync.RWMutex
-	lockDeviceGetMemoryErrorCounter                      sync.RWMutex
-	lockDeviceGetMemoryInfo                              sync.RWMutex
-	lockDeviceGetMemoryInfo_v2                           sync.RWMutex
-	lockDeviceGetMigDeviceHandleByIndex                  sync.RWMutex
-	lockDeviceGetMigMode                                 sync.RWMutex
-	lockDeviceGetMinMaxClockOfPState                     sync.RWMutex
-	lockDeviceGetMinMaxFanSpeed                          sync.RWMutex
-	lockDeviceGetMinorNumber                             sync.RWMutex
-	lockDeviceGetModuleId                                sync.RWMutex
-	lockDeviceGetMultiGpuBoard                           sync.RWMutex
-	lockDeviceGetName                                    sync.RWMutex
-	lockDeviceGetNumFans                                 sync.RWMutex
-	lockDeviceGetNumGpuCores                             sync.RWMutex
-	lockDeviceGetNumaNodeId                              sync.RWMutex
-	lockDeviceGetNvLinkCapability                        sync.RWMutex
-	lockDeviceGetNvLinkErrorCounter                      sync.RWMutex
-	lockDeviceGetNvLinkInfo                              sync.RWMutex
-	lockDeviceGetNvLinkRemoteDeviceType                  sync.RWMutex
-	lockDeviceGetNvLinkRemotePciInfo                     sync.RWMutex
-	lockDeviceGetNvLinkState                             sync.RWMutex
-	lockDeviceGetNvLinkUtilizationControl                sync.RWMutex
-	lockDeviceGetNvLinkUtilizationCounter                sync.RWMutex
-	lockDeviceGetNvLinkVersion                           sync.RWMutex
-	lockDeviceGetNvlinkBwMode                            sync.RWMutex
-	lockDeviceGetNvlinkSupportedBwModes                  sync.RWMutex
-	lockDeviceGetOfaUtilization                          sync.RWMutex
-	lockDeviceGetP2PStatus                               sync.RWMutex
-	lockDeviceGetPciInfo                                 sync.RWMutex
-	lockDeviceGetPciInfoExt                              sync.RWMutex
-	lockDeviceGetPcieLinkMaxSpeed                        sync.RWMutex
-	lockDeviceGetPcieReplayCounter                       sync.RWMutex
-	lockDeviceGetPcieSpeed                               sync.RWMutex
-	lockDeviceGetPcieThroughput                          sync.RWMutex
-	lockDeviceGetPdi                                     sync.RWMutex
-	lockDeviceGetPerformanceModes                        sync.RWMutex
-	lockDeviceGetPerformanceState                        sync.RWMutex
-	lockDeviceGetPersistenceMode                         sync.RWMutex
-	lockDeviceGetPgpuMetadataString                      sync.RWMutex
-	lockDeviceGetPlatformInfo                            sync.RWMutex
-	lockDeviceGetPowerManagementDefaultLimit             sync.RWMutex
-	lockDeviceGetPowerManagementLimit                    sync.RWMutex
-	lockDeviceGetPowerManagementLimitConstraints         sync.RWMutex
-	lockDeviceGetPowerManagementMode                     sync.RWMutex
-	lockDeviceGetPowerMizerMode_v1                       sync.RWMutex
-	lockDeviceGetPowerSource                             sync.RWMutex
-	lockDeviceGetPowerState                              sync.RWMutex
-	lockDeviceGetPowerUsage                              sync.RWMutex
-	lockDeviceGetProcessUtilization                      sync.RWMutex
-	lockDeviceGetProcessesUtilizationInfo                sync.RWMutex
-	lockDeviceGetRemappedRows                            sync.RWMutex
-	lockDeviceGetRemappedRows_v2                         sync.RWMutex
-	lockDeviceGetRepairStatus                            sync.RWMutex
-	lockDeviceGetRetiredPages                            sync.RWMutex
-	lockDeviceGetRetiredPagesPendingStatus               sync.RWMutex
-	lockDeviceGetRetiredPages_v2                         sync.RWMutex
-	lockDeviceGetRowRemapperHistogram                    sync.RWMutex
-	lockDeviceGetRunningProcessDetailList                sync.RWMutex
-	lockDeviceGetSamples                                 sync.RWMutex
-	lockDeviceGetSerial                                  sync.RWMutex
-	lockDeviceGetSramEccErrorStatus                      sync.RWMutex
-	lockDeviceGetSramUniqueUncorrectedEccErrorCounts     sync.RWMutex
-	lockDeviceGetSupportedClocksEventReasons             sync.RWMutex
-	lockDeviceGetSupportedClocksThrottleReasons          sync.RWMutex
-	lockDeviceGetSupportedEventTypes                     sync.RWMutex
-	lockDeviceGetSupportedGraphicsClocks                 sync.RWMutex
-	lockDeviceGetSupportedMemoryClocks                   sync.RWMutex
-	lockDeviceGetSupportedPerformanceStates              sync.RWMutex
-	lockDeviceGetSupportedVgpus                          sync.RWMutex
-	lockDeviceGetTargetFanSpeed                          sync.RWMutex
-	lockDeviceGetTemperature                             sync.RWMutex
-	lockDeviceGetTemperatureThreshold                    sync.RWMutex
-	lockDeviceGetTemperatureV                            sync.RWMutex
-	lockDeviceGetThermalSettings                         sync.RWMutex
-	lockDeviceGetTopologyCommonAncestor                  sync.RWMutex
-	lockDeviceGetTopologyNearestGpus                     sync.RWMutex
-	lockDeviceGetTotalEccErrors                          sync.RWMutex
-	lockDeviceGetTotalEnergyConsumption                  sync.RWMutex
-	lockDeviceGetUUID                                    sync.RWMutex
-	lockDeviceGetUnrepairableMemoryFlag_v1               sync.RWMutex
-	lockDeviceGetUtilizationRates                        sync.RWMutex
-	lockDeviceGetVbiosVersion                            sync.RWMutex
-	lockDeviceGetVgpuCapabilities                        sync.RWMutex
-	lockDeviceGetVgpuHeterogeneousMode                   sync.RWMutex
-	lockDeviceGetVgpuInstancesUtilizationInfo            sync.RWMutex
-	lockDeviceGetVgpuMetadata                            sync.RWMutex
-	lockDeviceGetVgpuProcessUtilization                  sync.RWMutex
-	lockDeviceGetVgpuProcessesUtilizationInfo            sync.RWMutex
-	lockDeviceGetVgpuSchedulerCapabilities               sync.RWMutex
-	lockDeviceGetVgpuSchedulerLog                        sync.RWMutex
-	lockDeviceGetVgpuSchedulerLog_v2                     sync.RWMutex
-	lockDeviceGetVgpuSchedulerState                      sync.RWMutex
-	lockDeviceGetVgpuSchedulerState_v2                   sync.RWMutex
-	lockDeviceGetVgpuTypeCreatablePlacements             sync.RWMutex
-	lockDeviceGetVgpuTypeSupportedPlacements             sync.RWMutex
-	lockDeviceGetVgpuUtilization                         sync.RWMutex
-	lockDeviceGetViolationStatus                         sync.RWMutex
-	lockDeviceGetVirtualizationMode                      sync.RWMutex
-	lockDeviceIsMigDeviceHandle                          sync.RWMutex
-	lockDeviceModifyDrainState                           sync.RWMutex
-	lockDeviceOnSameBoard                                sync.RWMutex
-	lockDevicePowerSmoothingActivatePresetProfile        sync.RWMutex
-	lockDevicePowerSmoothingSetState                     sync.RWMutex
-	lockDevicePowerSmoothingUpdatePresetProfileParam     sync.RWMutex
-	lockDeviceQueryDrainState                            sync.RWMutex
-	lockDeviceReadPRMCounters_v1                         sync.RWMutex
-	lockDeviceReadWritePRM_v1                            sync.RWMutex
-	lockDeviceRegisterEvents                             sync.RWMutex
-	lockDeviceRemoveGpu                                  sync.RWMutex
-	lockDeviceRemoveGpu_v2                               sync.RWMutex
-	lockDeviceResetApplicationsClocks                    sync.RWMutex
-	lockDeviceResetGpuLockedClocks                       sync.RWMutex
-	lockDeviceResetMemoryLockedClocks                    sync.RWMutex
-	lockDeviceResetNvLinkErrorCounters                   sync.RWMutex
-	lockDeviceResetNvLinkUtilizationCounter              sync.RWMutex
-	lockDeviceSetAPIRestriction                          sync.RWMutex
-	lockDeviceSetAccountingMode                          sync.RWMutex
-	lockDeviceSetApplicationsClocks                      sync.RWMutex
-	lockDeviceSetAutoBoostedClocksEnabled                sync.RWMutex
-	lockDeviceSetClockOffsets                            sync.RWMutex
-	lockDeviceSetComputeMode                             sync.RWMutex
-	lockDeviceSetConfComputeUnprotectedMemSize           sync.RWMutex
-	lockDeviceSetCpuAffinity                             sync.RWMutex
-	lockDeviceSetDefaultAutoBoostedClocksEnabled         sync.RWMutex
-	lockDeviceSetDefaultFanSpeed_v2                      sync.RWMutex
-	lockDeviceSetDramEncryptionMode                      sync.RWMutex
-	lockDeviceSetDriverModel                             sync.RWMutex
-	lockDeviceSetEccMode                                 sync.RWMutex
-	lockDeviceSetFanControlPolicy                        sync.RWMutex
-	lockDeviceSetFanSpeed_v2                             sync.RWMutex
-	lockDeviceSetGpcClkVfOffset                          sync.RWMutex
-	lockDeviceSetGpuLockedClocks                         sync.RWMutex
-	lockDeviceSetGpuOperationMode                        sync.RWMutex
-	lockDeviceSetHostname_v1                             sync.RWMutex
-	lockDeviceSetMemClkVfOffset                          sync.RWMutex
-	lockDeviceSetMemoryLockedClocks                      sync.RWMutex
-	lockDeviceSetMigMode                                 sync.RWMutex
-	lockDeviceSetNvLinkDeviceLowPowerThreshold           sync.RWMutex
-	lockDeviceSetNvLinkUtilizationControl                sync.RWMutex
-	lockDeviceSetNvlinkBwMode                            sync.RWMutex
-	lockDeviceSetPersistenceMode                         sync.RWMutex
-	lockDeviceSetPowerManagementLimit                    sync.RWMutex
-	lockDeviceSetPowerManagementLimit_v2                 sync.RWMutex
-	lockDeviceSetRusdSettings_v1                         sync.RWMutex
-	lockDeviceSetTemperatureThreshold                    sync.RWMutex
-	lockDeviceSetVgpuCapabilities                        sync.RWMutex
-	lockDeviceSetVgpuHeterogeneousMode                   sync.RWMutex
-	lockDeviceSetVgpuSchedulerState                      sync.RWMutex
-	lockDeviceSetVgpuSchedulerState_v2                   sync.RWMutex
-	lockDeviceSetVirtualizationMode                      sync.RWMutex
-	lockDeviceValidateInforom                            sync.RWMutex
-	lockDeviceVgpuForceGspUnload                         sync.RWMutex
-	lockDeviceWorkloadPowerProfileClearRequestedProfiles sync.RWMutex
-	lockDeviceWorkloadPowerProfileGetCurrentProfiles     sync.RWMutex
-	lockDeviceWorkloadPowerProfileGetProfilesInfo        sync.RWMutex
-	lockDeviceWorkloadPowerProfileSetRequestedProfiles   sync.RWMutex
-	lockDeviceWorkloadPowerProfileUpdateProfiles_v1      sync.RWMutex
-	lockErrorString                                      sync.RWMutex
-	lockEventSetCreate                                   sync.RWMutex
-	lockEventSetFree                                     sync.RWMutex
-	lockEventSetWait                                     sync.RWMutex
-	lockExtensions                                       sync.RWMutex
-	lockGetExcludedDeviceCount                           sync.RWMutex
-	lockGetExcludedDeviceInfoByIndex                     sync.RWMutex
-	lockGetVgpuCompatibility                             sync.RWMutex
-	lockGetVgpuDriverCapabilities                        sync.RWMutex
-	lockGetVgpuVersion                                   sync.RWMutex
-	lockGpmMetricsGet                                    sync.RWMutex
-	lockGpmMetricsGetV                                   sync.RWMutex
-	lockGpmMigSampleGet                                  sync.RWMutex
-	lockGpmQueryDeviceSupport                            sync.RWMutex
-	lockGpmQueryDeviceSupportV                           sync.RWMutex
-	lockGpmQueryIfStreamingEnabled                       sync.RWMutex
-	lockGpmSampleAlloc                                   sync.RWMutex
-	lockGpmSampleFree                                    sync.RWMutex
-	lockGpmSampleGet                                     sync.RWMutex
-	lockGpmSetStreamingEnabled                           sync.RWMutex
-	lockGpuInstanceCreateComputeInstance                 sync.RWMutex
-	lockGpuInstanceCreateComputeInstanceWithPlacement    sync.RWMutex
-	lockGpuInstanceDestroy                               sync.RWMutex
-	lockGpuInstanceGetActiveVgpus                        sync.RWMutex
-	lockGpuInstanceGetComputeInstanceById                sync.RWMutex
-	lockGpuInstanceGetComputeInstancePossiblePlacements  sync.RWMutex
-	lockGpuInstanceGetComputeInstanceProfileInfo         sync.RWMutex
-	lockGpuInstanceGetComputeInstanceProfileInfoV        sync.RWMutex
-	lockGpuInstanceGetComputeInstanceRemainingCapacity   sync.RWMutex
-	lockGpuInstanceGetComputeInstances                   sync.RWMutex
-	lockGpuInstanceGetCreatableVgpus                     sync.RWMutex
-	lockGpuInstanceGetInfo                               sync.RWMutex
-	lockGpuInstanceGetVgpuHeterogeneousMode              sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerLog                   sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerLog_v2                sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerState                 sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerState_v2              sync.RWMutex
-	lockGpuInstanceGetVgpuTypeCreatablePlacements        sync.RWMutex
-	lockGpuInstanceSetVgpuHeterogeneousMode              sync.RWMutex
-	lockGpuInstanceSetVgpuSchedulerState                 sync.RWMutex
-	lockGpuInstanceSetVgpuSchedulerState_v2              sync.RWMutex
-	lockInit                                             sync.RWMutex
-	lockInitWithFlags                                    sync.RWMutex
-	lockSetVgpuVersion                                   sync.RWMutex
-	lockShutdown                                         sync.RWMutex
-	lockSystemEventSetCreate                             sync.RWMutex
-	lockSystemEventSetFree                               sync.RWMutex
-	lockSystemEventSetWait                               sync.RWMutex
-	lockSystemGetCPER_v1                                 sync.RWMutex
-	lockSystemGetConfComputeCapabilities                 sync.RWMutex
-	lockSystemGetConfComputeGpusReadyState               sync.RWMutex
-	lockSystemGetConfComputeKeyRotationThresholdInfo     sync.RWMutex
-	lockSystemGetConfComputeSettings                     sync.RWMutex
-	lockSystemGetConfComputeState                        sync.RWMutex
-	lockSystemGetCudaDriverVersion                       sync.RWMutex
-	lockSystemGetCudaDriverVersion_v2                    sync.RWMutex
-	lockSystemGetDriverBranch                            sync.RWMutex
-	lockSystemGetDriverVersion                           sync.RWMutex
-	lockSystemGetHicVersion                              sync.RWMutex
-	lockSystemGetNVMLVersion                             sync.RWMutex
-	lockSystemGetNvlinkBwMode                            sync.RWMutex
-	lockSystemGetProcessName                             sync.RWMutex
-	lockSystemGetTopologyGpuSet                          sync.RWMutex
-	lockSystemRegisterEvents                             sync.RWMutex
-	lockSystemSetConfComputeGpusReadyState               sync.RWMutex
-	lockSystemSetConfComputeKeyRotationThresholdInfo     sync.RWMutex
-	lockSystemSetNvlinkBwMode                            sync.RWMutex
-	lockUnitGetCount                                     sync.RWMutex
-	lockUnitGetDevices                                   sync.RWMutex
-	lockUnitGetFanSpeedInfo                              sync.RWMutex
-	lockUnitGetHandleByIndex                             sync.RWMutex
-	lockUnitGetLedState                                  sync.RWMutex
-	lockUnitGetPsuInfo                                   sync.RWMutex
-	lockUnitGetTemperature                               sync.RWMutex
-	lockUnitGetUnitInfo                                  sync.RWMutex
-	lockUnitSetLedState                                  sync.RWMutex
-	lockVgpuInstanceClearAccountingPids                  sync.RWMutex
-	lockVgpuInstanceGetAccountingMode                    sync.RWMutex
-	lockVgpuInstanceGetAccountingPids                    sync.RWMutex
-	lockVgpuInstanceGetAccountingStats                   sync.RWMutex
-	lockVgpuInstanceGetEccMode                           sync.RWMutex
-	lockVgpuInstanceGetEncoderCapacity                   sync.RWMutex
-	lockVgpuInstanceGetEncoderSessions                   sync.RWMutex
-	lockVgpuInstanceGetEncoderStats                      sync.RWMutex
-	lockVgpuInstanceGetFBCSessions                       sync.RWMutex
-	lockVgpuInstanceGetFBCStats                          sync.RWMutex
-	lockVgpuInstanceGetFbUsage                           sync.RWMutex
-	lockVgpuInstanceGetFrameRateLimit                    sync.RWMutex
-	lockVgpuInstanceGetGpuInstanceId                     sync.RWMutex
-	lockVgpuInstanceGetGpuPciId                          sync.RWMutex
-	lockVgpuInstanceGetLicenseInfo                       sync.RWMutex
-	lockVgpuInstanceGetLicenseStatus                     sync.RWMutex
-	lockVgpuInstanceGetMdevUUID                          sync.RWMutex
-	lockVgpuInstanceGetMetadata                          sync.RWMutex
-	lockVgpuInstanceGetRuntimeStateSize                  sync.RWMutex
-	lockVgpuInstanceGetType                              sync.RWMutex
-	lockVgpuInstanceGetUUID                              sync.RWMutex
-	lockVgpuInstanceGetVmDriverVersion                   sync.RWMutex
-	lockVgpuInstanceGetVmID                              sync.RWMutex
-	lockVgpuInstanceSetEncoderCapacity                   sync.RWMutex
-	lockVgpuTypeGetBAR1Info                              sync.RWMutex
-	lockVgpuTypeGetCapabilities                          sync.RWMutex
-	lockVgpuTypeGetClass                                 sync.RWMutex
-	lockVgpuTypeGetDeviceID                              sync.RWMutex
-	lockVgpuTypeGetFrameRateLimit                        sync.RWMutex
-	lockVgpuTypeGetFramebufferSize                       sync.RWMutex
-	lockVgpuTypeGetGpuInstanceProfileId                  sync.RWMutex
-	lockVgpuTypeGetLicense                               sync.RWMutex
-	lockVgpuTypeGetMaxInstances                          sync.RWMutex
-	lockVgpuTypeGetMaxInstancesPerGpuInstance            sync.RWMutex
-	lockVgpuTypeGetMaxInstancesPerVm                     sync.RWMutex
-	lockVgpuTypeGetName                                  sync.RWMutex
-	lockVgpuTypeGetNumDisplayHeads                       sync.RWMutex
-	lockVgpuTypeGetResolution                            sync.RWMutex
+	lockComputeInstanceDestroy                            sync.RWMutex
+	lockComputeInstanceGetInfo                            sync.RWMutex
+	lockDeviceClearAccountingPids                         sync.RWMutex
+	lockDeviceClearCpuAffinity                            sync.RWMutex
+	lockDeviceClearEccErrorCounts                         sync.RWMutex
+	lockDeviceClearFieldValues                            sync.RWMutex
+	lockDeviceCreateGpuInstance                           sync.RWMutex
+	lockDeviceCreateGpuInstanceWithPlacement              sync.RWMutex
+	lockDeviceDiscoverGpus                                sync.RWMutex
+	lockDeviceFreezeNvLinkUtilizationCounter              sync.RWMutex
+	lockDeviceGetAPIRestriction                           sync.RWMutex
+	lockDeviceGetAccountingBufferSize                     sync.RWMutex
+	lockDeviceGetAccountingMode                           sync.RWMutex
+	lockDeviceGetAccountingPids                           sync.RWMutex
+	lockDeviceGetAccountingStats                          sync.RWMutex
+	lockDeviceGetAccountingStats_v2                       sync.RWMutex
+	lockDeviceGetActiveVgpus                              sync.RWMutex
+	lockDeviceGetAdaptiveClockInfoStatus                  sync.RWMutex
+	lockDeviceGetAdaptiveTgpModeInfo_v1                   sync.RWMutex
+	lockDeviceGetAddressingMode                           sync.RWMutex
+	lockDeviceGetApplicationsClock                        sync.RWMutex
+	lockDeviceGetArchitecture                             sync.RWMutex
+	lockDeviceGetAttributes                               sync.RWMutex
+	lockDeviceGetAutoBoostedClocksEnabled                 sync.RWMutex
+	lockDeviceGetBAR1MemoryInfo                           sync.RWMutex
+	lockDeviceGetBBXTimeData_v1                           sync.RWMutex
+	lockDeviceGetBankRemapperStatus_v1                    sync.RWMutex
+	lockDeviceGetBoardId                                  sync.RWMutex
+	lockDeviceGetBoardPartNumber                          sync.RWMutex
+	lockDeviceGetBrand                                    sync.RWMutex
+	lockDeviceGetBridgeChipInfo                           sync.RWMutex
+	lockDeviceGetBusType                                  sync.RWMutex
+	lockDeviceGetC2cModeInfoV                             sync.RWMutex
+	lockDeviceGetCapabilities                             sync.RWMutex
+	lockDeviceGetClkMonStatus                             sync.RWMutex
+	lockDeviceGetClock                                    sync.RWMutex
+	lockDeviceGetClockInfo                                sync.RWMutex
+	lockDeviceGetClockOffsets                             sync.RWMutex
+	lockDeviceGetComputeInstanceId                        sync.RWMutex
+	lockDeviceGetComputeMode                              sync.RWMutex
+	lockDeviceGetComputeRunningProcesses                  sync.RWMutex
+	lockDeviceGetConfComputeGpuAttestationReport          sync.RWMutex
+	lockDeviceGetConfComputeGpuCertificate                sync.RWMutex
+	lockDeviceGetConfComputeMemSizeInfo                   sync.RWMutex
+	lockDeviceGetConfComputeProtectedMemoryUsage          sync.RWMutex
+	lockDeviceGetCoolerInfo                               sync.RWMutex
+	lockDeviceGetCount                                    sync.RWMutex
+	lockDeviceGetCpuAffinity                              sync.RWMutex
+	lockDeviceGetCpuAffinityWithinScope                   sync.RWMutex
+	lockDeviceGetCreatableVgpus                           sync.RWMutex
+	lockDeviceGetCudaComputeCapability                    sync.RWMutex
+	lockDeviceGetCurrPcieLinkGeneration                   sync.RWMutex
+	lockDeviceGetCurrPcieLinkWidth                        sync.RWMutex
+	lockDeviceGetCurrentClockFreqs                        sync.RWMutex
+	lockDeviceGetCurrentClocksEventReasons                sync.RWMutex
+	lockDeviceGetCurrentClocksThrottleReasons             sync.RWMutex
+	lockDeviceGetDecoderUtilization                       sync.RWMutex
+	lockDeviceGetDefaultApplicationsClock                 sync.RWMutex
+	lockDeviceGetDefaultEccMode                           sync.RWMutex
+	lockDeviceGetDetailedEccErrors                        sync.RWMutex
+	lockDeviceGetDeviceHandleFromMigDeviceHandle          sync.RWMutex
+	lockDeviceGetDisplayActive                            sync.RWMutex
+	lockDeviceGetDisplayMode                              sync.RWMutex
+	lockDeviceGetDramEncryptionMode                       sync.RWMutex
+	lockDeviceGetDriverModel                              sync.RWMutex
+	lockDeviceGetDriverModel_v2                           sync.RWMutex
+	lockDeviceGetDynamicPstatesInfo                       sync.RWMutex
+	lockDeviceGetEccMode                                  sync.RWMutex
+	lockDeviceGetEncoderCapacity                          sync.RWMutex
+	lockDeviceGetEncoderSessions                          sync.RWMutex
+	lockDeviceGetEncoderStats                             sync.RWMutex
+	lockDeviceGetEncoderUtilization                       sync.RWMutex
+	lockDeviceGetEnforcedPowerLimit                       sync.RWMutex
+	lockDeviceGetFBCSessions                              sync.RWMutex
+	lockDeviceGetFBCStats                                 sync.RWMutex
+	lockDeviceGetFanControlPolicy_v2                      sync.RWMutex
+	lockDeviceGetFanSpeed                                 sync.RWMutex
+	lockDeviceGetFanSpeedRPM                              sync.RWMutex
+	lockDeviceGetFanSpeed_v2                              sync.RWMutex
+	lockDeviceGetFieldValues                              sync.RWMutex
+	lockDeviceGetGpcClkMinMaxVfOffset                     sync.RWMutex
+	lockDeviceGetGpcClkVfOffset                           sync.RWMutex
+	lockDeviceGetGpuFabricInfo                            sync.RWMutex
+	lockDeviceGetGpuFabricInfoV                           sync.RWMutex
+	lockDeviceGetGpuFabricInfo_v4                         sync.RWMutex
+	lockDeviceGetGpuInstanceById                          sync.RWMutex
+	lockDeviceGetGpuInstanceId                            sync.RWMutex
+	lockDeviceGetGpuInstancePossiblePlacements            sync.RWMutex
+	lockDeviceGetGpuInstanceProfileInfo                   sync.RWMutex
+	lockDeviceGetGpuInstanceProfileInfoByIdV              sync.RWMutex
+	lockDeviceGetGpuInstanceProfileInfoV                  sync.RWMutex
+	lockDeviceGetGpuInstanceRemainingCapacity             sync.RWMutex
+	lockDeviceGetGpuInstances                             sync.RWMutex
+	lockDeviceGetGpuMaxPcieLinkGeneration                 sync.RWMutex
+	lockDeviceGetGpuOperationMode                         sync.RWMutex
+	lockDeviceGetGraphicsRunningProcesses                 sync.RWMutex
+	lockDeviceGetGridLicensableFeatures                   sync.RWMutex
+	lockDeviceGetGspFirmwareMode                          sync.RWMutex
+	lockDeviceGetGspFirmwareVersion                       sync.RWMutex
+	lockDeviceGetHandleByIndex                            sync.RWMutex
+	lockDeviceGetHandleByPciBusId                         sync.RWMutex
+	lockDeviceGetHandleBySerial                           sync.RWMutex
+	lockDeviceGetHandleByUUID                             sync.RWMutex
+	lockDeviceGetHandleByUUIDV                            sync.RWMutex
+	lockDeviceGetHostVgpuMode                             sync.RWMutex
+	lockDeviceGetHostname_v1                              sync.RWMutex
+	lockDeviceGetIndex                                    sync.RWMutex
+	lockDeviceGetInforomConfigurationChecksum             sync.RWMutex
+	lockDeviceGetInforomImageVersion                      sync.RWMutex
+	lockDeviceGetInforomVersion                           sync.RWMutex
+	lockDeviceGetIrqNum                                   sync.RWMutex
+	lockDeviceGetJpgUtilization                           sync.RWMutex
+	lockDeviceGetLastBBXFlushTime                         sync.RWMutex
+	lockDeviceGetMPSComputeRunningProcesses               sync.RWMutex
+	lockDeviceGetMarginTemperature                        sync.RWMutex
+	lockDeviceGetMaxClockInfo                             sync.RWMutex
+	lockDeviceGetMaxCustomerBoostClock                    sync.RWMutex
+	lockDeviceGetMaxMigDeviceCount                        sync.RWMutex
+	lockDeviceGetMaxPcieLinkGeneration                    sync.RWMutex
+	lockDeviceGetMaxPcieLinkWidth                         sync.RWMutex
+	lockDeviceGetMemClkMinMaxVfOffset                     sync.RWMutex
+	lockDeviceGetMemClkVfOffset                           sync.RWMutex
+	lockDeviceGetMemoryAffinity                           sync.RWMutex
+	lockDeviceGetMemoryBusWidth                           sync.RWMutex
+	lockDeviceGetMemoryErrorCounter                       sync.RWMutex
+	lockDeviceGetMemoryInfo                               sync.RWMutex
+	lockDeviceGetMemoryInfo_v2                            sync.RWMutex
+	lockDeviceGetMemoryLimits_v1                          sync.RWMutex
+	lockDeviceGetMigDeviceHandleByIndex                   sync.RWMutex
+	lockDeviceGetMigMode                                  sync.RWMutex
+	lockDeviceGetMinMaxClockOfPState                      sync.RWMutex
+	lockDeviceGetMinMaxFanSpeed                           sync.RWMutex
+	lockDeviceGetMinorNumber                              sync.RWMutex
+	lockDeviceGetModuleId                                 sync.RWMutex
+	lockDeviceGetMultiGpuBoard                            sync.RWMutex
+	lockDeviceGetName                                     sync.RWMutex
+	lockDeviceGetNumFans                                  sync.RWMutex
+	lockDeviceGetNumGpuCores                              sync.RWMutex
+	lockDeviceGetNumaNodeId                               sync.RWMutex
+	lockDeviceGetNvLinkCapability                         sync.RWMutex
+	lockDeviceGetNvLinkErrorCounter                       sync.RWMutex
+	lockDeviceGetNvLinkInfo                               sync.RWMutex
+	lockDeviceGetNvLinkRemoteDeviceType                   sync.RWMutex
+	lockDeviceGetNvLinkRemotePciInfo                      sync.RWMutex
+	lockDeviceGetNvLinkState                              sync.RWMutex
+	lockDeviceGetNvLinkTelemetrySamples_v1                sync.RWMutex
+	lockDeviceGetNvLinkUtilizationControl                 sync.RWMutex
+	lockDeviceGetNvLinkUtilizationCounter                 sync.RWMutex
+	lockDeviceGetNvLinkVersion                            sync.RWMutex
+	lockDeviceGetNvlinkBwMode                             sync.RWMutex
+	lockDeviceGetNvlinkSupportedBwModes                   sync.RWMutex
+	lockDeviceGetOfaUtilization                           sync.RWMutex
+	lockDeviceGetP2PStatus                                sync.RWMutex
+	lockDeviceGetPciInfo                                  sync.RWMutex
+	lockDeviceGetPciInfoExt                               sync.RWMutex
+	lockDeviceGetPcieLinkMaxSpeed                         sync.RWMutex
+	lockDeviceGetPcieReplayCounter                        sync.RWMutex
+	lockDeviceGetPcieSpeed                                sync.RWMutex
+	lockDeviceGetPcieThroughput                           sync.RWMutex
+	lockDeviceGetPdi                                      sync.RWMutex
+	lockDeviceGetPerformanceModes                         sync.RWMutex
+	lockDeviceGetPerformanceState                         sync.RWMutex
+	lockDeviceGetPersistenceMode                          sync.RWMutex
+	lockDeviceGetPgpuMetadataString                       sync.RWMutex
+	lockDeviceGetPlatformInfo                             sync.RWMutex
+	lockDeviceGetPowerManagementDefaultLimit              sync.RWMutex
+	lockDeviceGetPowerManagementLimit                     sync.RWMutex
+	lockDeviceGetPowerManagementLimitConstraints          sync.RWMutex
+	lockDeviceGetPowerManagementMode                      sync.RWMutex
+	lockDeviceGetPowerMizerMode_v1                        sync.RWMutex
+	lockDeviceGetPowerSource                              sync.RWMutex
+	lockDeviceGetPowerState                               sync.RWMutex
+	lockDeviceGetPowerUsage                               sync.RWMutex
+	lockDeviceGetProcessUtilization                       sync.RWMutex
+	lockDeviceGetProcessesUtilizationInfo                 sync.RWMutex
+	lockDeviceGetRemappedRows                             sync.RWMutex
+	lockDeviceGetRemappedRows_v2                          sync.RWMutex
+	lockDeviceGetRepairStatus                             sync.RWMutex
+	lockDeviceGetRetiredPages                             sync.RWMutex
+	lockDeviceGetRetiredPagesPendingStatus                sync.RWMutex
+	lockDeviceGetRetiredPages_v2                          sync.RWMutex
+	lockDeviceGetRowRemapperHistogram                     sync.RWMutex
+	lockDeviceGetRunningProcessDetailList                 sync.RWMutex
+	lockDeviceGetSamples                                  sync.RWMutex
+	lockDeviceGetSerial                                   sync.RWMutex
+	lockDeviceGetSramEccErrorStatus                       sync.RWMutex
+	lockDeviceGetSramUniqueUncorrectedEccErrorCounts      sync.RWMutex
+	lockDeviceGetSupportedClocksEventReasons              sync.RWMutex
+	lockDeviceGetSupportedClocksThrottleReasons           sync.RWMutex
+	lockDeviceGetSupportedEventTypes                      sync.RWMutex
+	lockDeviceGetSupportedGraphicsClocks                  sync.RWMutex
+	lockDeviceGetSupportedMemoryClocks                    sync.RWMutex
+	lockDeviceGetSupportedPerformanceStates               sync.RWMutex
+	lockDeviceGetSupportedVgpus                           sync.RWMutex
+	lockDeviceGetTargetFanSpeed                           sync.RWMutex
+	lockDeviceGetTemperature                              sync.RWMutex
+	lockDeviceGetTemperatureThreshold                     sync.RWMutex
+	lockDeviceGetTemperatureV                             sync.RWMutex
+	lockDeviceGetThermalSettings                          sync.RWMutex
+	lockDeviceGetTopologyCommonAncestor                   sync.RWMutex
+	lockDeviceGetTopologyNearestGpus                      sync.RWMutex
+	lockDeviceGetTotalEccErrors                           sync.RWMutex
+	lockDeviceGetTotalEnergyConsumption                   sync.RWMutex
+	lockDeviceGetUUID                                     sync.RWMutex
+	lockDeviceGetUnrepairableMemoryFlag_v1                sync.RWMutex
+	lockDeviceGetUtilizationRates                         sync.RWMutex
+	lockDeviceGetVbiosVersion                             sync.RWMutex
+	lockDeviceGetVgpuCapabilities                         sync.RWMutex
+	lockDeviceGetVgpuHeterogeneousMode                    sync.RWMutex
+	lockDeviceGetVgpuInstancesUtilizationInfo             sync.RWMutex
+	lockDeviceGetVgpuMetadata                             sync.RWMutex
+	lockDeviceGetVgpuProcessUtilization                   sync.RWMutex
+	lockDeviceGetVgpuProcessesUtilizationInfo             sync.RWMutex
+	lockDeviceGetVgpuSchedulerCapabilities                sync.RWMutex
+	lockDeviceGetVgpuSchedulerLog                         sync.RWMutex
+	lockDeviceGetVgpuSchedulerLog_v2                      sync.RWMutex
+	lockDeviceGetVgpuSchedulerState                       sync.RWMutex
+	lockDeviceGetVgpuSchedulerState_v2                    sync.RWMutex
+	lockDeviceGetVgpuTypeCreatablePlacements              sync.RWMutex
+	lockDeviceGetVgpuTypeSupportedPlacements              sync.RWMutex
+	lockDeviceGetVgpuUtilization                          sync.RWMutex
+	lockDeviceGetViolationStatus                          sync.RWMutex
+	lockDeviceGetVirtualizationMode                       sync.RWMutex
+	lockDeviceIsMigDeviceHandle                           sync.RWMutex
+	lockDeviceModifyDrainState                            sync.RWMutex
+	lockDeviceOnSameBoard                                 sync.RWMutex
+	lockDevicePerfMetricsGetSamples_v1                    sync.RWMutex
+	lockDevicePowerSmoothingActivatePresetProfile         sync.RWMutex
+	lockDevicePowerSmoothingSetState                      sync.RWMutex
+	lockDevicePowerSmoothingUpdatePresetProfileParam      sync.RWMutex
+	lockDeviceQueryDrainState                             sync.RWMutex
+	lockDeviceReadPRMCounters_v1                          sync.RWMutex
+	lockDeviceReadWritePRM_v1                             sync.RWMutex
+	lockDeviceRegisterEvents                              sync.RWMutex
+	lockDeviceRemoveGpu                                   sync.RWMutex
+	lockDeviceRemoveGpu_v2                                sync.RWMutex
+	lockDeviceResetApplicationsClocks                     sync.RWMutex
+	lockDeviceResetGpuLockedClocks                        sync.RWMutex
+	lockDeviceResetMemoryLockedClocks                     sync.RWMutex
+	lockDeviceResetNvLinkErrorCounters                    sync.RWMutex
+	lockDeviceResetNvLinkUtilizationCounter               sync.RWMutex
+	lockDeviceSetAPIRestriction                           sync.RWMutex
+	lockDeviceSetAccountingMode                           sync.RWMutex
+	lockDeviceSetAdaptiveTgpMode_v1                       sync.RWMutex
+	lockDeviceSetApplicationsClocks                       sync.RWMutex
+	lockDeviceSetAutoBoostedClocksEnabled                 sync.RWMutex
+	lockDeviceSetClockOffsets                             sync.RWMutex
+	lockDeviceSetComputeMode                              sync.RWMutex
+	lockDeviceSetConfComputeUnprotectedMemSize            sync.RWMutex
+	lockDeviceSetCpuAffinity                              sync.RWMutex
+	lockDeviceSetDefaultAutoBoostedClocksEnabled          sync.RWMutex
+	lockDeviceSetDefaultFanSpeed_v2                       sync.RWMutex
+	lockDeviceSetDramEncryptionMode                       sync.RWMutex
+	lockDeviceSetDriverModel                              sync.RWMutex
+	lockDeviceSetEccMode                                  sync.RWMutex
+	lockDeviceSetFanControlPolicy                         sync.RWMutex
+	lockDeviceSetFanSpeed_v2                              sync.RWMutex
+	lockDeviceSetGpcClkVfOffset                           sync.RWMutex
+	lockDeviceSetGpuLockedClocks                          sync.RWMutex
+	lockDeviceSetGpuOperationMode                         sync.RWMutex
+	lockDeviceSetHostname_v1                              sync.RWMutex
+	lockDeviceSetMemClkVfOffset                           sync.RWMutex
+	lockDeviceSetMemoryLimits_v1                          sync.RWMutex
+	lockDeviceSetMemoryLockedClocks                       sync.RWMutex
+	lockDeviceSetMigMode                                  sync.RWMutex
+	lockDeviceSetNvLinkDeviceLowPowerThreshold            sync.RWMutex
+	lockDeviceSetNvLinkUtilizationControl                 sync.RWMutex
+	lockDeviceSetNvlinkBwMode                             sync.RWMutex
+	lockDeviceSetNvlinkBwModeAsync_v1                     sync.RWMutex
+	lockDeviceSetPersistenceMode                          sync.RWMutex
+	lockDeviceSetPowerManagementLimit                     sync.RWMutex
+	lockDeviceSetPowerManagementLimit_v2                  sync.RWMutex
+	lockDeviceSetRusdSettings_v1                          sync.RWMutex
+	lockDeviceSetTemperatureThreshold                     sync.RWMutex
+	lockDeviceSetVgpuCapabilities                         sync.RWMutex
+	lockDeviceSetVgpuHeterogeneousMode                    sync.RWMutex
+	lockDeviceSetVgpuSchedulerState                       sync.RWMutex
+	lockDeviceSetVgpuSchedulerState_v2                    sync.RWMutex
+	lockDeviceSetVirtualizationMode                       sync.RWMutex
+	lockDeviceValidateInforom                             sync.RWMutex
+	lockDeviceVgpuForceGspUnload                          sync.RWMutex
+	lockDeviceWorkloadPowerProfileClearRequestedProfiles  sync.RWMutex
+	lockDeviceWorkloadPowerProfileGetCurrentProfiles      sync.RWMutex
+	lockDeviceWorkloadPowerProfileGetProfilesInfo         sync.RWMutex
+	lockDeviceWorkloadPowerProfileSetRequestedProfiles    sync.RWMutex
+	lockDeviceWorkloadPowerProfileUpdateProfiles_v1       sync.RWMutex
+	lockErrorString                                       sync.RWMutex
+	lockEventSetCreate                                    sync.RWMutex
+	lockEventSetFree                                      sync.RWMutex
+	lockEventSetGetContextCount_v1                        sync.RWMutex
+	lockEventSetGetContextData_v1                         sync.RWMutex
+	lockEventSetGetContextInfo_v1                         sync.RWMutex
+	lockEventSetGetGpuOperationalEventContextLegacyXid_v1 sync.RWMutex
+	lockEventSetRegisterGpuOperationalEvents_v1           sync.RWMutex
+	lockEventSetWait                                      sync.RWMutex
+	lockEventSetWait_v3                                   sync.RWMutex
+	lockExtensions                                        sync.RWMutex
+	lockGetExcludedDeviceCount                            sync.RWMutex
+	lockGetExcludedDeviceInfoByIndex                      sync.RWMutex
+	lockGetVgpuCompatibility                              sync.RWMutex
+	lockGetVgpuDriverCapabilities                         sync.RWMutex
+	lockGetVgpuVersion                                    sync.RWMutex
+	lockGpmMetricsGet                                     sync.RWMutex
+	lockGpmMetricsGetV                                    sync.RWMutex
+	lockGpmMigSampleGet                                   sync.RWMutex
+	lockGpmQueryDeviceSupport                             sync.RWMutex
+	lockGpmQueryDeviceSupportV                            sync.RWMutex
+	lockGpmQueryIfStreamingEnabled                        sync.RWMutex
+	lockGpmSampleAlloc                                    sync.RWMutex
+	lockGpmSampleFree                                     sync.RWMutex
+	lockGpmSampleGet                                      sync.RWMutex
+	lockGpmSetStreamingEnabled                            sync.RWMutex
+	lockGpuInstanceCreateComputeInstance                  sync.RWMutex
+	lockGpuInstanceCreateComputeInstanceWithPlacement     sync.RWMutex
+	lockGpuInstanceDestroy                                sync.RWMutex
+	lockGpuInstanceGetActiveVgpus                         sync.RWMutex
+	lockGpuInstanceGetComputeInstanceById                 sync.RWMutex
+	lockGpuInstanceGetComputeInstancePossiblePlacements   sync.RWMutex
+	lockGpuInstanceGetComputeInstanceProfileInfo          sync.RWMutex
+	lockGpuInstanceGetComputeInstanceProfileInfoV         sync.RWMutex
+	lockGpuInstanceGetComputeInstanceRemainingCapacity    sync.RWMutex
+	lockGpuInstanceGetComputeInstances                    sync.RWMutex
+	lockGpuInstanceGetCreatableVgpus                      sync.RWMutex
+	lockGpuInstanceGetInfo                                sync.RWMutex
+	lockGpuInstanceGetVgpuHeterogeneousMode               sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerLog                    sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerLog_v2                 sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerState                  sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerState_v2               sync.RWMutex
+	lockGpuInstanceGetVgpuTypeCreatablePlacements         sync.RWMutex
+	lockGpuInstanceSetVgpuHeterogeneousMode               sync.RWMutex
+	lockGpuInstanceSetVgpuSchedulerState                  sync.RWMutex
+	lockGpuInstanceSetVgpuSchedulerState_v2               sync.RWMutex
+	lockInit                                              sync.RWMutex
+	lockInitWithFlags                                     sync.RWMutex
+	lockSetVgpuVersion                                    sync.RWMutex
+	lockShutdown                                          sync.RWMutex
+	lockSystemEventSetCreate                              sync.RWMutex
+	lockSystemEventSetFree                                sync.RWMutex
+	lockSystemEventSetWait                                sync.RWMutex
+	lockSystemGetCPER_v1                                  sync.RWMutex
+	lockSystemGetConfComputeCapabilities                  sync.RWMutex
+	lockSystemGetConfComputeGpusReadyState                sync.RWMutex
+	lockSystemGetConfComputeKeyRotationThresholdInfo      sync.RWMutex
+	lockSystemGetConfComputeSettings                      sync.RWMutex
+	lockSystemGetConfComputeState                         sync.RWMutex
+	lockSystemGetCudaDriverVersion                        sync.RWMutex
+	lockSystemGetCudaDriverVersion_v2                     sync.RWMutex
+	lockSystemGetDriverBranch                             sync.RWMutex
+	lockSystemGetDriverVersion                            sync.RWMutex
+	lockSystemGetHicVersion                               sync.RWMutex
+	lockSystemGetNVMLVersion                              sync.RWMutex
+	lockSystemGetNvlinkBwMode                             sync.RWMutex
+	lockSystemGetProcessName                              sync.RWMutex
+	lockSystemGetTopologyGpuSet                           sync.RWMutex
+	lockSystemRegisterEvents                              sync.RWMutex
+	lockSystemSetConfComputeGpusReadyState                sync.RWMutex
+	lockSystemSetConfComputeKeyRotationThresholdInfo      sync.RWMutex
+	lockSystemSetNvlinkBwMode                             sync.RWMutex
+	lockUnitGetCount                                      sync.RWMutex
+	lockUnitGetDevices                                    sync.RWMutex
+	lockUnitGetFanSpeedInfo                               sync.RWMutex
+	lockUnitGetHandleByIndex                              sync.RWMutex
+	lockUnitGetLedState                                   sync.RWMutex
+	lockUnitGetPsuInfo                                    sync.RWMutex
+	lockUnitGetTemperature                                sync.RWMutex
+	lockUnitGetUnitInfo                                   sync.RWMutex
+	lockUnitSetLedState                                   sync.RWMutex
+	lockVgpuInstanceClearAccountingPids                   sync.RWMutex
+	lockVgpuInstanceGetAccountingMode                     sync.RWMutex
+	lockVgpuInstanceGetAccountingPids                     sync.RWMutex
+	lockVgpuInstanceGetAccountingStats                    sync.RWMutex
+	lockVgpuInstanceGetEccMode                            sync.RWMutex
+	lockVgpuInstanceGetEncoderCapacity                    sync.RWMutex
+	lockVgpuInstanceGetEncoderSessions                    sync.RWMutex
+	lockVgpuInstanceGetEncoderStats                       sync.RWMutex
+	lockVgpuInstanceGetFBCSessions                        sync.RWMutex
+	lockVgpuInstanceGetFBCStats                           sync.RWMutex
+	lockVgpuInstanceGetFbUsage                            sync.RWMutex
+	lockVgpuInstanceGetFrameRateLimit                     sync.RWMutex
+	lockVgpuInstanceGetGpuInstanceId                      sync.RWMutex
+	lockVgpuInstanceGetGpuPciId                           sync.RWMutex
+	lockVgpuInstanceGetLicenseInfo                        sync.RWMutex
+	lockVgpuInstanceGetLicenseStatus                      sync.RWMutex
+	lockVgpuInstanceGetMdevUUID                           sync.RWMutex
+	lockVgpuInstanceGetMetadata                           sync.RWMutex
+	lockVgpuInstanceGetRuntimeStateSize                   sync.RWMutex
+	lockVgpuInstanceGetType                               sync.RWMutex
+	lockVgpuInstanceGetUUID                               sync.RWMutex
+	lockVgpuInstanceGetVmDriverVersion                    sync.RWMutex
+	lockVgpuInstanceGetVmID                               sync.RWMutex
+	lockVgpuInstanceSetEncoderCapacity                    sync.RWMutex
+	lockVgpuTypeGetBAR1Info                               sync.RWMutex
+	lockVgpuTypeGetCapabilities                           sync.RWMutex
+	lockVgpuTypeGetClass                                  sync.RWMutex
+	lockVgpuTypeGetDeviceID                               sync.RWMutex
+	lockVgpuTypeGetFrameRateLimit                         sync.RWMutex
+	lockVgpuTypeGetFramebufferSize                        sync.RWMutex
+	lockVgpuTypeGetGpuInstanceProfileId                   sync.RWMutex
+	lockVgpuTypeGetID                                     sync.RWMutex
+	lockVgpuTypeGetLicense                                sync.RWMutex
+	lockVgpuTypeGetMaxInstances                           sync.RWMutex
+	lockVgpuTypeGetMaxInstancesPerGpuInstance             sync.RWMutex
+	lockVgpuTypeGetMaxInstancesPerVm                      sync.RWMutex
+	lockVgpuTypeGetName                                   sync.RWMutex
+	lockVgpuTypeGetNumDisplayHeads                        sync.RWMutex
+	lockVgpuTypeGetResolution                             sync.RWMutex
 }
 
 // ComputeInstanceDestroy calls ComputeInstanceDestroyFunc.
@@ -5647,6 +5867,38 @@ func (mock *Interface) DeviceGetAdaptiveClockInfoStatusCalls() []struct {
 	return calls
 }
 
+// DeviceGetAdaptiveTgpModeInfo_v1 calls DeviceGetAdaptiveTgpModeInfo_v1Func.
+func (mock *Interface) DeviceGetAdaptiveTgpModeInfo_v1(device nvml.Device) (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+	if mock.DeviceGetAdaptiveTgpModeInfo_v1Func == nil {
+		panic("Interface.DeviceGetAdaptiveTgpModeInfo_v1Func: method is nil but Interface.DeviceGetAdaptiveTgpModeInfo_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.Lock()
+	mock.calls.DeviceGetAdaptiveTgpModeInfo_v1 = append(mock.calls.DeviceGetAdaptiveTgpModeInfo_v1, callInfo)
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.Unlock()
+	return mock.DeviceGetAdaptiveTgpModeInfo_v1Func(device)
+}
+
+// DeviceGetAdaptiveTgpModeInfo_v1Calls gets all the calls that were made to DeviceGetAdaptiveTgpModeInfo_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetAdaptiveTgpModeInfo_v1Calls())
+func (mock *Interface) DeviceGetAdaptiveTgpModeInfo_v1Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.RLock()
+	calls = mock.calls.DeviceGetAdaptiveTgpModeInfo_v1
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.RUnlock()
+	return calls
+}
+
 // DeviceGetAddressingMode calls DeviceGetAddressingModeFunc.
 func (mock *Interface) DeviceGetAddressingMode(device nvml.Device) (nvml.DeviceAddressingMode, nvml.Return) {
 	if mock.DeviceGetAddressingModeFunc == nil {
@@ -5872,6 +6124,38 @@ func (mock *Interface) DeviceGetBBXTimeData_v1Calls() []struct {
 	mock.lockDeviceGetBBXTimeData_v1.RLock()
 	calls = mock.calls.DeviceGetBBXTimeData_v1
 	mock.lockDeviceGetBBXTimeData_v1.RUnlock()
+	return calls
+}
+
+// DeviceGetBankRemapperStatus_v1 calls DeviceGetBankRemapperStatus_v1Func.
+func (mock *Interface) DeviceGetBankRemapperStatus_v1(device nvml.Device) (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+	if mock.DeviceGetBankRemapperStatus_v1Func == nil {
+		panic("Interface.DeviceGetBankRemapperStatus_v1Func: method is nil but Interface.DeviceGetBankRemapperStatus_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetBankRemapperStatus_v1.Lock()
+	mock.calls.DeviceGetBankRemapperStatus_v1 = append(mock.calls.DeviceGetBankRemapperStatus_v1, callInfo)
+	mock.lockDeviceGetBankRemapperStatus_v1.Unlock()
+	return mock.DeviceGetBankRemapperStatus_v1Func(device)
+}
+
+// DeviceGetBankRemapperStatus_v1Calls gets all the calls that were made to DeviceGetBankRemapperStatus_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetBankRemapperStatus_v1Calls())
+func (mock *Interface) DeviceGetBankRemapperStatus_v1Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetBankRemapperStatus_v1.RLock()
+	calls = mock.calls.DeviceGetBankRemapperStatus_v1
+	mock.lockDeviceGetBankRemapperStatus_v1.RUnlock()
 	return calls
 }
 
@@ -7750,6 +8034,38 @@ func (mock *Interface) DeviceGetGpuFabricInfoVCalls() []struct {
 	return calls
 }
 
+// DeviceGetGpuFabricInfo_v4 calls DeviceGetGpuFabricInfo_v4Func.
+func (mock *Interface) DeviceGetGpuFabricInfo_v4(device nvml.Device) (nvml.GpuFabricInfo_v4, nvml.Return) {
+	if mock.DeviceGetGpuFabricInfo_v4Func == nil {
+		panic("Interface.DeviceGetGpuFabricInfo_v4Func: method is nil but Interface.DeviceGetGpuFabricInfo_v4 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetGpuFabricInfo_v4.Lock()
+	mock.calls.DeviceGetGpuFabricInfo_v4 = append(mock.calls.DeviceGetGpuFabricInfo_v4, callInfo)
+	mock.lockDeviceGetGpuFabricInfo_v4.Unlock()
+	return mock.DeviceGetGpuFabricInfo_v4Func(device)
+}
+
+// DeviceGetGpuFabricInfo_v4Calls gets all the calls that were made to DeviceGetGpuFabricInfo_v4.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetGpuFabricInfo_v4Calls())
+func (mock *Interface) DeviceGetGpuFabricInfo_v4Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetGpuFabricInfo_v4.RLock()
+	calls = mock.calls.DeviceGetGpuFabricInfo_v4
+	mock.lockDeviceGetGpuFabricInfo_v4.RUnlock()
+	return calls
+}
+
 // DeviceGetGpuInstanceById calls DeviceGetGpuInstanceByIdFunc.
 func (mock *Interface) DeviceGetGpuInstanceById(device nvml.Device, n int) (nvml.GpuInstance, nvml.Return) {
 	if mock.DeviceGetGpuInstanceByIdFunc == nil {
@@ -9154,6 +9470,42 @@ func (mock *Interface) DeviceGetMemoryInfo_v2Calls() []struct {
 	return calls
 }
 
+// DeviceGetMemoryLimits_v1 calls DeviceGetMemoryLimits_v1Func.
+func (mock *Interface) DeviceGetMemoryLimits_v1(device nvml.Device, s string) (nvml.GetMemoryLimits_v1, nvml.Return) {
+	if mock.DeviceGetMemoryLimits_v1Func == nil {
+		panic("Interface.DeviceGetMemoryLimits_v1Func: method is nil but Interface.DeviceGetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+		S      string
+	}{
+		Device: device,
+		S:      s,
+	}
+	mock.lockDeviceGetMemoryLimits_v1.Lock()
+	mock.calls.DeviceGetMemoryLimits_v1 = append(mock.calls.DeviceGetMemoryLimits_v1, callInfo)
+	mock.lockDeviceGetMemoryLimits_v1.Unlock()
+	return mock.DeviceGetMemoryLimits_v1Func(device, s)
+}
+
+// DeviceGetMemoryLimits_v1Calls gets all the calls that were made to DeviceGetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetMemoryLimits_v1Calls())
+func (mock *Interface) DeviceGetMemoryLimits_v1Calls() []struct {
+	Device nvml.Device
+	S      string
+} {
+	var calls []struct {
+		Device nvml.Device
+		S      string
+	}
+	mock.lockDeviceGetMemoryLimits_v1.RLock()
+	calls = mock.calls.DeviceGetMemoryLimits_v1
+	mock.lockDeviceGetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // DeviceGetMigDeviceHandleByIndex calls DeviceGetMigDeviceHandleByIndexFunc.
 func (mock *Interface) DeviceGetMigDeviceHandleByIndex(device nvml.Device, n int) (nvml.Device, nvml.Return) {
 	if mock.DeviceGetMigDeviceHandleByIndexFunc == nil {
@@ -9735,6 +10087,42 @@ func (mock *Interface) DeviceGetNvLinkStateCalls() []struct {
 	mock.lockDeviceGetNvLinkState.RLock()
 	calls = mock.calls.DeviceGetNvLinkState
 	mock.lockDeviceGetNvLinkState.RUnlock()
+	return calls
+}
+
+// DeviceGetNvLinkTelemetrySamples_v1 calls DeviceGetNvLinkTelemetrySamples_v1Func.
+func (mock *Interface) DeviceGetNvLinkTelemetrySamples_v1(device nvml.Device, nvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1) nvml.Return {
+	if mock.DeviceGetNvLinkTelemetrySamples_v1Func == nil {
+		panic("Interface.DeviceGetNvLinkTelemetrySamples_v1Func: method is nil but Interface.DeviceGetNvLinkTelemetrySamples_v1 was just called")
+	}
+	callInfo := struct {
+		Device                    nvml.Device
+		NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
+	}{
+		Device:                    device,
+		NvlinkTelemetrySamples_v1: nvlinkTelemetrySamples_v1,
+	}
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.Lock()
+	mock.calls.DeviceGetNvLinkTelemetrySamples_v1 = append(mock.calls.DeviceGetNvLinkTelemetrySamples_v1, callInfo)
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.Unlock()
+	return mock.DeviceGetNvLinkTelemetrySamples_v1Func(device, nvlinkTelemetrySamples_v1)
+}
+
+// DeviceGetNvLinkTelemetrySamples_v1Calls gets all the calls that were made to DeviceGetNvLinkTelemetrySamples_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetNvLinkTelemetrySamples_v1Calls())
+func (mock *Interface) DeviceGetNvLinkTelemetrySamples_v1Calls() []struct {
+	Device                    nvml.Device
+	NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
+} {
+	var calls []struct {
+		Device                    nvml.Device
+		NvlinkTelemetrySamples_v1 *nvml.NvlinkTelemetrySamples_v1
+	}
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.RLock()
+	calls = mock.calls.DeviceGetNvLinkTelemetrySamples_v1
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.RUnlock()
 	return calls
 }
 
@@ -12430,6 +12818,42 @@ func (mock *Interface) DeviceOnSameBoardCalls() []struct {
 	return calls
 }
 
+// DevicePerfMetricsGetSamples_v1 calls DevicePerfMetricsGetSamples_v1Func.
+func (mock *Interface) DevicePerfMetricsGetSamples_v1(device nvml.Device, perfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1) nvml.Return {
+	if mock.DevicePerfMetricsGetSamples_v1Func == nil {
+		panic("Interface.DevicePerfMetricsGetSamples_v1Func: method is nil but Interface.DevicePerfMetricsGetSamples_v1 was just called")
+	}
+	callInfo := struct {
+		Device                nvml.Device
+		PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+	}{
+		Device:                device,
+		PerfMetricsSamples_v1: perfMetricsSamples_v1,
+	}
+	mock.lockDevicePerfMetricsGetSamples_v1.Lock()
+	mock.calls.DevicePerfMetricsGetSamples_v1 = append(mock.calls.DevicePerfMetricsGetSamples_v1, callInfo)
+	mock.lockDevicePerfMetricsGetSamples_v1.Unlock()
+	return mock.DevicePerfMetricsGetSamples_v1Func(device, perfMetricsSamples_v1)
+}
+
+// DevicePerfMetricsGetSamples_v1Calls gets all the calls that were made to DevicePerfMetricsGetSamples_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DevicePerfMetricsGetSamples_v1Calls())
+func (mock *Interface) DevicePerfMetricsGetSamples_v1Calls() []struct {
+	Device                nvml.Device
+	PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+} {
+	var calls []struct {
+		Device                nvml.Device
+		PerfMetricsSamples_v1 *nvml.PerfMetricsSamples_v1
+	}
+	mock.lockDevicePerfMetricsGetSamples_v1.RLock()
+	calls = mock.calls.DevicePerfMetricsGetSamples_v1
+	mock.lockDevicePerfMetricsGetSamples_v1.RUnlock()
+	return calls
+}
+
 // DevicePowerSmoothingActivatePresetProfile calls DevicePowerSmoothingActivatePresetProfileFunc.
 func (mock *Interface) DevicePowerSmoothingActivatePresetProfile(device nvml.Device, powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 	if mock.DevicePowerSmoothingActivatePresetProfileFunc == nil {
@@ -13003,6 +13427,42 @@ func (mock *Interface) DeviceSetAccountingModeCalls() []struct {
 	mock.lockDeviceSetAccountingMode.RLock()
 	calls = mock.calls.DeviceSetAccountingMode
 	mock.lockDeviceSetAccountingMode.RUnlock()
+	return calls
+}
+
+// DeviceSetAdaptiveTgpMode_v1 calls DeviceSetAdaptiveTgpMode_v1Func.
+func (mock *Interface) DeviceSetAdaptiveTgpMode_v1(device nvml.Device, enableState nvml.EnableState) nvml.Return {
+	if mock.DeviceSetAdaptiveTgpMode_v1Func == nil {
+		panic("Interface.DeviceSetAdaptiveTgpMode_v1Func: method is nil but Interface.DeviceSetAdaptiveTgpMode_v1 was just called")
+	}
+	callInfo := struct {
+		Device      nvml.Device
+		EnableState nvml.EnableState
+	}{
+		Device:      device,
+		EnableState: enableState,
+	}
+	mock.lockDeviceSetAdaptiveTgpMode_v1.Lock()
+	mock.calls.DeviceSetAdaptiveTgpMode_v1 = append(mock.calls.DeviceSetAdaptiveTgpMode_v1, callInfo)
+	mock.lockDeviceSetAdaptiveTgpMode_v1.Unlock()
+	return mock.DeviceSetAdaptiveTgpMode_v1Func(device, enableState)
+}
+
+// DeviceSetAdaptiveTgpMode_v1Calls gets all the calls that were made to DeviceSetAdaptiveTgpMode_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceSetAdaptiveTgpMode_v1Calls())
+func (mock *Interface) DeviceSetAdaptiveTgpMode_v1Calls() []struct {
+	Device      nvml.Device
+	EnableState nvml.EnableState
+} {
+	var calls []struct {
+		Device      nvml.Device
+		EnableState nvml.EnableState
+	}
+	mock.lockDeviceSetAdaptiveTgpMode_v1.RLock()
+	calls = mock.calls.DeviceSetAdaptiveTgpMode_v1
+	mock.lockDeviceSetAdaptiveTgpMode_v1.RUnlock()
 	return calls
 }
 
@@ -13674,6 +14134,50 @@ func (mock *Interface) DeviceSetMemClkVfOffsetCalls() []struct {
 	return calls
 }
 
+// DeviceSetMemoryLimits_v1 calls DeviceSetMemoryLimits_v1Func.
+func (mock *Interface) DeviceSetMemoryLimits_v1(device nvml.Device, s string, n1 int, n2 int) nvml.Return {
+	if mock.DeviceSetMemoryLimits_v1Func == nil {
+		panic("Interface.DeviceSetMemoryLimits_v1Func: method is nil but Interface.DeviceSetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+		S      string
+		N1     int
+		N2     int
+	}{
+		Device: device,
+		S:      s,
+		N1:     n1,
+		N2:     n2,
+	}
+	mock.lockDeviceSetMemoryLimits_v1.Lock()
+	mock.calls.DeviceSetMemoryLimits_v1 = append(mock.calls.DeviceSetMemoryLimits_v1, callInfo)
+	mock.lockDeviceSetMemoryLimits_v1.Unlock()
+	return mock.DeviceSetMemoryLimits_v1Func(device, s, n1, n2)
+}
+
+// DeviceSetMemoryLimits_v1Calls gets all the calls that were made to DeviceSetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceSetMemoryLimits_v1Calls())
+func (mock *Interface) DeviceSetMemoryLimits_v1Calls() []struct {
+	Device nvml.Device
+	S      string
+	N1     int
+	N2     int
+} {
+	var calls []struct {
+		Device nvml.Device
+		S      string
+		N1     int
+		N2     int
+	}
+	mock.lockDeviceSetMemoryLimits_v1.RLock()
+	calls = mock.calls.DeviceSetMemoryLimits_v1
+	mock.lockDeviceSetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // DeviceSetMemoryLockedClocks calls DeviceSetMemoryLockedClocksFunc.
 func (mock *Interface) DeviceSetMemoryLockedClocks(device nvml.Device, v1 uint32, v2 uint32) nvml.Return {
 	if mock.DeviceSetMemoryLockedClocksFunc == nil {
@@ -13867,6 +14371,42 @@ func (mock *Interface) DeviceSetNvlinkBwModeCalls() []struct {
 	mock.lockDeviceSetNvlinkBwMode.RLock()
 	calls = mock.calls.DeviceSetNvlinkBwMode
 	mock.lockDeviceSetNvlinkBwMode.RUnlock()
+	return calls
+}
+
+// DeviceSetNvlinkBwModeAsync_v1 calls DeviceSetNvlinkBwModeAsync_v1Func.
+func (mock *Interface) DeviceSetNvlinkBwModeAsync_v1(device nvml.Device, nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+	if mock.DeviceSetNvlinkBwModeAsync_v1Func == nil {
+		panic("Interface.DeviceSetNvlinkBwModeAsync_v1Func: method is nil but Interface.DeviceSetNvlinkBwModeAsync_v1 was just called")
+	}
+	callInfo := struct {
+		Device                  nvml.Device
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}{
+		Device:                  device,
+		NvlinkSetBwModeAsync_v1: nvlinkSetBwModeAsync_v1,
+	}
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.Lock()
+	mock.calls.DeviceSetNvlinkBwModeAsync_v1 = append(mock.calls.DeviceSetNvlinkBwModeAsync_v1, callInfo)
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.Unlock()
+	return mock.DeviceSetNvlinkBwModeAsync_v1Func(device, nvlinkSetBwModeAsync_v1)
+}
+
+// DeviceSetNvlinkBwModeAsync_v1Calls gets all the calls that were made to DeviceSetNvlinkBwModeAsync_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceSetNvlinkBwModeAsync_v1Calls())
+func (mock *Interface) DeviceSetNvlinkBwModeAsync_v1Calls() []struct {
+	Device                  nvml.Device
+	NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+} {
+	var calls []struct {
+		Device                  nvml.Device
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.RLock()
+	calls = mock.calls.DeviceSetNvlinkBwModeAsync_v1
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.RUnlock()
 	return calls
 }
 
@@ -14569,6 +15109,186 @@ func (mock *Interface) EventSetFreeCalls() []struct {
 	return calls
 }
 
+// EventSetGetContextCount_v1 calls EventSetGetContextCount_v1Func.
+func (mock *Interface) EventSetGetContextCount_v1(eventSet nvml.EventSet) (uint32, nvml.Return) {
+	if mock.EventSetGetContextCount_v1Func == nil {
+		panic("Interface.EventSetGetContextCount_v1Func: method is nil but Interface.EventSetGetContextCount_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+	}{
+		EventSet: eventSet,
+	}
+	mock.lockEventSetGetContextCount_v1.Lock()
+	mock.calls.EventSetGetContextCount_v1 = append(mock.calls.EventSetGetContextCount_v1, callInfo)
+	mock.lockEventSetGetContextCount_v1.Unlock()
+	return mock.EventSetGetContextCount_v1Func(eventSet)
+}
+
+// EventSetGetContextCount_v1Calls gets all the calls that were made to EventSetGetContextCount_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetContextCount_v1Calls())
+func (mock *Interface) EventSetGetContextCount_v1Calls() []struct {
+	EventSet nvml.EventSet
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+	}
+	mock.lockEventSetGetContextCount_v1.RLock()
+	calls = mock.calls.EventSetGetContextCount_v1
+	mock.lockEventSetGetContextCount_v1.RUnlock()
+	return calls
+}
+
+// EventSetGetContextData_v1 calls EventSetGetContextData_v1Func.
+func (mock *Interface) EventSetGetContextData_v1(eventSet nvml.EventSet, v uint32, bytes []byte) (uint32, nvml.Return) {
+	if mock.EventSetGetContextData_v1Func == nil {
+		panic("Interface.EventSetGetContextData_v1Func: method is nil but Interface.EventSetGetContextData_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+		Bytes    []byte
+	}{
+		EventSet: eventSet,
+		V:        v,
+		Bytes:    bytes,
+	}
+	mock.lockEventSetGetContextData_v1.Lock()
+	mock.calls.EventSetGetContextData_v1 = append(mock.calls.EventSetGetContextData_v1, callInfo)
+	mock.lockEventSetGetContextData_v1.Unlock()
+	return mock.EventSetGetContextData_v1Func(eventSet, v, bytes)
+}
+
+// EventSetGetContextData_v1Calls gets all the calls that were made to EventSetGetContextData_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetContextData_v1Calls())
+func (mock *Interface) EventSetGetContextData_v1Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+	Bytes    []byte
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+		Bytes    []byte
+	}
+	mock.lockEventSetGetContextData_v1.RLock()
+	calls = mock.calls.EventSetGetContextData_v1
+	mock.lockEventSetGetContextData_v1.RUnlock()
+	return calls
+}
+
+// EventSetGetContextInfo_v1 calls EventSetGetContextInfo_v1Func.
+func (mock *Interface) EventSetGetContextInfo_v1(eventSet nvml.EventSet, v uint32) (nvml.OperationalEventContextInfo_v1, nvml.Return) {
+	if mock.EventSetGetContextInfo_v1Func == nil {
+		panic("Interface.EventSetGetContextInfo_v1Func: method is nil but Interface.EventSetGetContextInfo_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}{
+		EventSet: eventSet,
+		V:        v,
+	}
+	mock.lockEventSetGetContextInfo_v1.Lock()
+	mock.calls.EventSetGetContextInfo_v1 = append(mock.calls.EventSetGetContextInfo_v1, callInfo)
+	mock.lockEventSetGetContextInfo_v1.Unlock()
+	return mock.EventSetGetContextInfo_v1Func(eventSet, v)
+}
+
+// EventSetGetContextInfo_v1Calls gets all the calls that were made to EventSetGetContextInfo_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetContextInfo_v1Calls())
+func (mock *Interface) EventSetGetContextInfo_v1Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}
+	mock.lockEventSetGetContextInfo_v1.RLock()
+	calls = mock.calls.EventSetGetContextInfo_v1
+	mock.lockEventSetGetContextInfo_v1.RUnlock()
+	return calls
+}
+
+// EventSetGetGpuOperationalEventContextLegacyXid_v1 calls EventSetGetGpuOperationalEventContextLegacyXid_v1Func.
+func (mock *Interface) EventSetGetGpuOperationalEventContextLegacyXid_v1(eventSet nvml.EventSet, v uint32) (nvml.GpuOperationalEventContextLegacyXid_v1, nvml.Return) {
+	if mock.EventSetGetGpuOperationalEventContextLegacyXid_v1Func == nil {
+		panic("Interface.EventSetGetGpuOperationalEventContextLegacyXid_v1Func: method is nil but Interface.EventSetGetGpuOperationalEventContextLegacyXid_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}{
+		EventSet: eventSet,
+		V:        v,
+	}
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.Lock()
+	mock.calls.EventSetGetGpuOperationalEventContextLegacyXid_v1 = append(mock.calls.EventSetGetGpuOperationalEventContextLegacyXid_v1, callInfo)
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.Unlock()
+	return mock.EventSetGetGpuOperationalEventContextLegacyXid_v1Func(eventSet, v)
+}
+
+// EventSetGetGpuOperationalEventContextLegacyXid_v1Calls gets all the calls that were made to EventSetGetGpuOperationalEventContextLegacyXid_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetGpuOperationalEventContextLegacyXid_v1Calls())
+func (mock *Interface) EventSetGetGpuOperationalEventContextLegacyXid_v1Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.RLock()
+	calls = mock.calls.EventSetGetGpuOperationalEventContextLegacyXid_v1
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.RUnlock()
+	return calls
+}
+
+// EventSetRegisterGpuOperationalEvents_v1 calls EventSetRegisterGpuOperationalEvents_v1Func.
+func (mock *Interface) EventSetRegisterGpuOperationalEvents_v1(eventSet nvml.EventSet, gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+	if mock.EventSetRegisterGpuOperationalEvents_v1Func == nil {
+		panic("Interface.EventSetRegisterGpuOperationalEvents_v1Func: method is nil but Interface.EventSetRegisterGpuOperationalEvents_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet                     nvml.EventSet
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}{
+		EventSet:                     eventSet,
+		GpuOperationalEventConfig_v1: gpuOperationalEventConfig_v1,
+	}
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.Lock()
+	mock.calls.EventSetRegisterGpuOperationalEvents_v1 = append(mock.calls.EventSetRegisterGpuOperationalEvents_v1, callInfo)
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.Unlock()
+	return mock.EventSetRegisterGpuOperationalEvents_v1Func(eventSet, gpuOperationalEventConfig_v1)
+}
+
+// EventSetRegisterGpuOperationalEvents_v1Calls gets all the calls that were made to EventSetRegisterGpuOperationalEvents_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetRegisterGpuOperationalEvents_v1Calls())
+func (mock *Interface) EventSetRegisterGpuOperationalEvents_v1Calls() []struct {
+	EventSet                     nvml.EventSet
+	GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+} {
+	var calls []struct {
+		EventSet                     nvml.EventSet
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.RLock()
+	calls = mock.calls.EventSetRegisterGpuOperationalEvents_v1
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.RUnlock()
+	return calls
+}
+
 // EventSetWait calls EventSetWaitFunc.
 func (mock *Interface) EventSetWait(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return) {
 	if mock.EventSetWaitFunc == nil {
@@ -14602,6 +15322,42 @@ func (mock *Interface) EventSetWaitCalls() []struct {
 	mock.lockEventSetWait.RLock()
 	calls = mock.calls.EventSetWait
 	mock.lockEventSetWait.RUnlock()
+	return calls
+}
+
+// EventSetWait_v3 calls EventSetWait_v3Func.
+func (mock *Interface) EventSetWait_v3(eventSet nvml.EventSet, v uint32) (nvml.EventData_v2, nvml.Return) {
+	if mock.EventSetWait_v3Func == nil {
+		panic("Interface.EventSetWait_v3Func: method is nil but Interface.EventSetWait_v3 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}{
+		EventSet: eventSet,
+		V:        v,
+	}
+	mock.lockEventSetWait_v3.Lock()
+	mock.calls.EventSetWait_v3 = append(mock.calls.EventSetWait_v3, callInfo)
+	mock.lockEventSetWait_v3.Unlock()
+	return mock.EventSetWait_v3Func(eventSet, v)
+}
+
+// EventSetWait_v3Calls gets all the calls that were made to EventSetWait_v3.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetWait_v3Calls())
+func (mock *Interface) EventSetWait_v3Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}
+	mock.lockEventSetWait_v3.RLock()
+	calls = mock.calls.EventSetWait_v3
+	mock.lockEventSetWait_v3.RUnlock()
 	return calls
 }
 
@@ -17907,6 +18663,38 @@ func (mock *Interface) VgpuTypeGetGpuInstanceProfileIdCalls() []struct {
 	mock.lockVgpuTypeGetGpuInstanceProfileId.RLock()
 	calls = mock.calls.VgpuTypeGetGpuInstanceProfileId
 	mock.lockVgpuTypeGetGpuInstanceProfileId.RUnlock()
+	return calls
+}
+
+// VgpuTypeGetID calls VgpuTypeGetIDFunc.
+func (mock *Interface) VgpuTypeGetID(vgpuTypeId nvml.VgpuTypeId) uint32 {
+	if mock.VgpuTypeGetIDFunc == nil {
+		panic("Interface.VgpuTypeGetIDFunc: method is nil but Interface.VgpuTypeGetID was just called")
+	}
+	callInfo := struct {
+		VgpuTypeId nvml.VgpuTypeId
+	}{
+		VgpuTypeId: vgpuTypeId,
+	}
+	mock.lockVgpuTypeGetID.Lock()
+	mock.calls.VgpuTypeGetID = append(mock.calls.VgpuTypeGetID, callInfo)
+	mock.lockVgpuTypeGetID.Unlock()
+	return mock.VgpuTypeGetIDFunc(vgpuTypeId)
+}
+
+// VgpuTypeGetIDCalls gets all the calls that were made to VgpuTypeGetID.
+// Check the length with:
+//
+//	len(mockedInterface.VgpuTypeGetIDCalls())
+func (mock *Interface) VgpuTypeGetIDCalls() []struct {
+	VgpuTypeId nvml.VgpuTypeId
+} {
+	var calls []struct {
+		VgpuTypeId nvml.VgpuTypeId
+	}
+	mock.lockVgpuTypeGetID.RLock()
+	calls = mock.calls.VgpuTypeGetID
+	mock.lockVgpuTypeGetID.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/vgputypeid.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/mock/vgputypeid.go
@@ -42,6 +42,9 @@ var _ nvml.VgpuTypeId = &VgpuTypeId{}
 //			GetGpuInstanceProfileIdFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetGpuInstanceProfileId method")
 //			},
+//			GetIDFunc: func() uint32 {
+//				panic("mock out the GetID method")
+//			},
 //			GetLicenseFunc: func() (string, nvml.Return) {
 //				panic("mock out the GetLicense method")
 //			},
@@ -94,6 +97,9 @@ type VgpuTypeId struct {
 	// GetGpuInstanceProfileIdFunc mocks the GetGpuInstanceProfileId method.
 	GetGpuInstanceProfileIdFunc func() (uint32, nvml.Return)
 
+	// GetIDFunc mocks the GetID method.
+	GetIDFunc func() uint32
+
 	// GetLicenseFunc mocks the GetLicense method.
 	GetLicenseFunc func() (string, nvml.Return)
 
@@ -145,6 +151,9 @@ type VgpuTypeId struct {
 		// GetGpuInstanceProfileId holds details about calls to the GetGpuInstanceProfileId method.
 		GetGpuInstanceProfileId []struct {
 		}
+		// GetID holds details about calls to the GetID method.
+		GetID []struct {
+		}
 		// GetLicense holds details about calls to the GetLicense method.
 		GetLicense []struct {
 		}
@@ -181,6 +190,7 @@ type VgpuTypeId struct {
 	lockGetFrameRateLimit       sync.RWMutex
 	lockGetFramebufferSize      sync.RWMutex
 	lockGetGpuInstanceProfileId sync.RWMutex
+	lockGetID                   sync.RWMutex
 	lockGetLicense              sync.RWMutex
 	lockGetMaxInstances         sync.RWMutex
 	lockGetMaxInstancesPerVm    sync.RWMutex
@@ -413,6 +423,33 @@ func (mock *VgpuTypeId) GetGpuInstanceProfileIdCalls() []struct {
 	mock.lockGetGpuInstanceProfileId.RLock()
 	calls = mock.calls.GetGpuInstanceProfileId
 	mock.lockGetGpuInstanceProfileId.RUnlock()
+	return calls
+}
+
+// GetID calls GetIDFunc.
+func (mock *VgpuTypeId) GetID() uint32 {
+	if mock.GetIDFunc == nil {
+		panic("VgpuTypeId.GetIDFunc: method is nil but VgpuTypeId.GetID was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetID.Lock()
+	mock.calls.GetID = append(mock.calls.GetID, callInfo)
+	mock.lockGetID.Unlock()
+	return mock.GetIDFunc()
+}
+
+// GetIDCalls gets all the calls that were made to GetID.
+// Check the length with:
+//
+//	len(mockedVgpuTypeId.GetIDCalls())
+func (mock *VgpuTypeId) GetIDCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetID.RLock()
+	calls = mock.calls.GetID
+	mock.lockGetID.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.go
@@ -1097,6 +1097,24 @@ func nvmlDeviceGetEnforcedPowerLimit(nvmlDevice nvmlDevice, Limit *uint32) Retur
 	return __v
 }
 
+// nvmlDeviceSetAdaptiveTgpMode_v1 function as declared in nvml/nvml.h
+func nvmlDeviceSetAdaptiveTgpMode_v1(nvmlDevice nvmlDevice, Mode EnableState) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cMode, _ := (C.nvmlEnableState_t)(Mode), cgoAllocsUnknown
+	__ret := C.nvmlDeviceSetAdaptiveTgpMode_v1(cnvmlDevice, cMode)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetAdaptiveTgpModeInfo_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetAdaptiveTgpModeInfo_v1(nvmlDevice nvmlDevice, Info *AdaptiveTgpModeInfo_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cInfo, _ := (*C.nvmlAdaptiveTgpModeInfo_v1_t)(unsafe.Pointer(Info)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetAdaptiveTgpModeInfo_v1(cnvmlDevice, cInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlDeviceGetGpuOperationMode function as declared in nvml/nvml.h
 func nvmlDeviceGetGpuOperationMode(nvmlDevice nvmlDevice, Current *GpuOperationMode, Pending *GpuOperationMode) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
@@ -1121,6 +1139,24 @@ func nvmlDeviceGetMemoryInfo_v2(nvmlDevice nvmlDevice, Memory *Memory_v2) Return
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cMemory, _ := (*C.nvmlMemory_v2_t)(unsafe.Pointer(Memory)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetMemoryInfo_v2(cnvmlDevice, cMemory)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceSetMemoryLimits_v1 function as declared in nvml/nvml.h
+func nvmlDeviceSetMemoryLimits_v1(nvmlDevice nvmlDevice, Limits *SetMemoryLimits_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cLimits, _ := (*C.nvmlSetMemoryLimits_v1_t)(unsafe.Pointer(Limits)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceSetMemoryLimits_v1(cnvmlDevice, cLimits)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetMemoryLimits_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetMemoryLimits_v1(nvmlDevice nvmlDevice, Limits *GetMemoryLimits_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cLimits, _ := (*C.nvmlGetMemoryLimits_v1_t)(unsafe.Pointer(Limits)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetMemoryLimits_v1(cnvmlDevice, cLimits)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -1543,6 +1579,15 @@ func nvmlDeviceGetGpuFabricInfoV(nvmlDevice nvmlDevice, GpuFabricInfo *GpuFabric
 	return __v
 }
 
+// nvmlDeviceGetGpuFabricInfo_v4 function as declared in nvml/nvml.h
+func nvmlDeviceGetGpuFabricInfo_v4(nvmlDevice nvmlDevice, GpuFabricInfo *GpuFabricInfo_v4) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cGpuFabricInfo, _ := (*C.nvmlGpuFabricInfo_v4_t)(unsafe.Pointer(GpuFabricInfo)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetGpuFabricInfo_v4(cnvmlDevice, cGpuFabricInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlSystemGetConfComputeCapabilities function as declared in nvml/nvml.h
 func nvmlSystemGetConfComputeCapabilities(Capabilities *ConfComputeSystemCaps) Return {
 	cCapabilities, _ := (*C.nvmlConfComputeSystemCaps_t)(unsafe.Pointer(Capabilities)), cgoAllocsUnknown
@@ -1851,6 +1896,15 @@ func nvmlDeviceGetHostname_v1(nvmlDevice nvmlDevice, Hostname *Hostname_v1) Retu
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cHostname, _ := (*C.nvmlHostname_v1_t)(unsafe.Pointer(Hostname)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetHostname_v1(cnvmlDevice, cHostname)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDevicePerfMetricsGetSamples_v1 function as declared in nvml/nvml.h
+func nvmlDevicePerfMetricsGetSamples_v1(nvmlDevice nvmlDevice, Samples *PerfMetricsSamples_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cSamples, _ := (*C.nvmlPerfMetricsSamples_v1_t)(unsafe.Pointer(Samples)), cgoAllocsUnknown
+	__ret := C.nvmlDevicePerfMetricsGetSamples_v1(cnvmlDevice, cSamples)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -2264,11 +2318,29 @@ func nvmlDeviceSetNvlinkBwMode(nvmlDevice nvmlDevice, SetBwMode *NvlinkSetBwMode
 	return __v
 }
 
+// nvmlDeviceSetNvlinkBwModeAsync_v1 function as declared in nvml/nvml.h
+func nvmlDeviceSetNvlinkBwModeAsync_v1(nvmlDevice nvmlDevice, SetBwModeAsync *NvlinkSetBwModeAsync_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cSetBwModeAsync, _ := (*C.nvmlNvlinkSetBwModeAsync_v1_t)(unsafe.Pointer(SetBwModeAsync)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceSetNvlinkBwModeAsync_v1(cnvmlDevice, cSetBwModeAsync)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlDeviceGetNvLinkInfo function as declared in nvml/nvml.h
 func nvmlDeviceGetNvLinkInfo(nvmlDevice nvmlDevice, Info *NvLinkInfo) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cInfo, _ := (*C.nvmlNvLinkInfo_t)(unsafe.Pointer(Info)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetNvLinkInfo(cnvmlDevice, cInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetNvLinkTelemetrySamples_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetNvLinkTelemetrySamples_v1(nvmlDevice nvmlDevice, Samples *NvlinkTelemetrySamples_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cSamples, _ := (*C.nvmlNvlinkTelemetrySamples_v1_t)(unsafe.Pointer(Samples)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetNvLinkTelemetrySamples_v1(cnvmlDevice, cSamples)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -2306,6 +2378,65 @@ func nvmlEventSetWait_v2(Set nvmlEventSet, Data *nvmlEventData, Timeoutms uint32
 	cData, _ := (*C.nvmlEventData_t)(unsafe.Pointer(Data)), cgoAllocsUnknown
 	cTimeoutms, _ := (C.uint)(Timeoutms), cgoAllocsUnknown
 	__ret := C.nvmlEventSetWait_v2(cSet, cData, cTimeoutms)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetRegisterGpuOperationalEvents_v1 function as declared in nvml/nvml.h
+func nvmlEventSetRegisterGpuOperationalEvents_v1(nvmlEventSet nvmlEventSet, Config *GpuOperationalEventConfig_v1) Return {
+	cnvmlEventSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&nvmlEventSet)), cgoAllocsUnknown
+	cConfig, _ := (*C.nvmlGpuOperationalEventConfig_v1_t)(unsafe.Pointer(Config)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetRegisterGpuOperationalEvents_v1(cnvmlEventSet, cConfig)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetWait_v3 function as declared in nvml/nvml.h
+func nvmlEventSetWait_v3(Set nvmlEventSet, Data *EventData_v2, Timeoutms uint32) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cData, _ := (*C.nvmlEventData_v2_t)(unsafe.Pointer(Data)), cgoAllocsUnknown
+	cTimeoutms, _ := (C.uint)(Timeoutms), cgoAllocsUnknown
+	__ret := C.nvmlEventSetWait_v3(cSet, cData, cTimeoutms)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetContextCount_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetContextCount_v1(Set nvmlEventSet, Count *uint32) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cCount, _ := (*C.uint)(unsafe.Pointer(Count)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetContextCount_v1(cSet, cCount)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetContextInfo_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetContextInfo_v1(Set nvmlEventSet, Index uint32, Info *OperationalEventContextInfo_v1) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cIndex, _ := (C.uint)(Index), cgoAllocsUnknown
+	cInfo, _ := (*C.nvmlOperationalEventContextInfo_v1_t)(unsafe.Pointer(Info)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetContextInfo_v1(cSet, cIndex, cInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetContextData_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetContextData_v1(Set nvmlEventSet, Index uint32, Data unsafe.Pointer, DataSize *uint32) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cIndex, _ := (C.uint)(Index), cgoAllocsUnknown
+	cData, _ := Data, cgoAllocsUnknown
+	cDataSize, _ := (*C.uint)(unsafe.Pointer(DataSize)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetContextData_v1(cSet, cIndex, cData, cDataSize)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(Set nvmlEventSet, Index uint32, Xid *GpuOperationalEventContextLegacyXid_v1) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cIndex, _ := (C.uint)(Index), cgoAllocsUnknown
+	cXid, _ := (*C.nvmlGpuOperationalEventContextLegacyXid_v1_t)(unsafe.Pointer(Xid)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(cSet, cIndex, cXid)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -3681,6 +3812,15 @@ func nvmlDeviceSetRusdSettings_v1(nvmlDevice nvmlDevice, Settings *RusdSettings_
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cSettings, _ := (*C.nvmlRusdSettings_v1_t)(unsafe.Pointer(Settings)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceSetRusdSettings_v1(cnvmlDevice, cSettings)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetBankRemapperStatus_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetBankRemapperStatus_v1(nvmlDevice nvmlDevice, PBankRemapperStatus *EccBankRemapperStatus_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cPBankRemapperStatus, _ := (*C.nvmlEccBankRemapperStatus_v1_t)(unsafe.Pointer(PBankRemapperStatus)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetBankRemapperStatus_v1(cnvmlDevice, cPBankRemapperStatus)
 	__v := (Return)(__ret)
 	return __v
 }

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h
@@ -1,5 +1,3 @@
-/*** NVML VERSION: 13.3.29 ***/
-/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.3.29-archive.tar.xz ***/
 /*
  * Copyright 1993-2026 NVIDIA Corporation.  All rights reserved.
  *
@@ -281,6 +279,59 @@ typedef struct nvmlMemory_v2_st
 } nvmlMemory_v2_t;
 
 #define nvmlMemory_v2 NVML_STRUCT_VERSION(Memory, 2) //!< Version macro for \a nvmlMemory_v2_t
+
+/**
+ * Value for "maximum" memory limit.
+ */
+#define NVML_DEVICE_MEMORY_LIMIT_MAX 0xFFFFFFFFFFFFFFFF
+
+/**
+ * @brief Describes the memory limits that can be set for the device
+ *
+ * This structure holds the necessary information that can be used to set the soft
+ * and hard memory limits of a device.
+ *
+ * The softLimit is the amount of memory that is guaranteed before allocations
+ * may fail due to memory pressure.
+ *
+ * The hardLimit is the maximum amount of memory that can be allocated.
+ *
+ * This should be cross-referenced with \ref nvmlDeviceGetMemoryInfo_v2 while in
+ * that cgroup to see how much memory is actually available to allocate for the device.
+ *
+ * To clear the limits, set softLimit to 0, and hardLimit to \ref NVML_DEVICE_MEMORY_LIMIT_MAX.
+ * Removing the cgroup will also clear any limits.
+ */
+typedef struct
+{
+    const char* nameSpace;         //!<[in] Full path to sysfs cgroup file name
+    unsigned long long softLimit;  //!<[in] Soft memory limit in Bytes.
+    unsigned long long hardLimit;  //!<[in] Hard memory limit in Bytes.
+} nvmlSetMemoryLimits_v1_t;
+
+/**
+ * @brief Describes the current memory limits that are set for the device
+ *
+ * This structure holds the necessary information that can be used to get the
+ * current soft and hard memory limits of a device.
+ *
+ * The softLimit is the amount of memory that is guaranteed before allocations
+ * may fail due to memory pressure.
+ *
+ * The hardLimit is the maximum amount of memory that can be allocated.
+ *
+ * This should be cross-referenced with \ref nvmlDeviceGetMemoryInfo_v2 while in
+ * that cgroup to see how much memory is actually available to allocate for the device.
+ *
+ * No limit is set when softLimit is 0 and hardLimit is \ref NVML_DEVICE_MEMORY_LIMIT_MAX.
+ */
+typedef struct
+{
+    const char* nameSpace;           //!<[in]  Full path to sysfs cgroup file name
+    unsigned long long softLimit;    //!<[out] Currently set soft memory limit in Bytes.
+    unsigned long long hardLimit;    //!<[out] Currently set hard memory limit in Bytes.
+    unsigned long long currentUsed;  //!<[out] Currently used memory in Bytes.
+} nvmlGetMemoryLimits_v1_t;
 
 /**
  * BAR1 Memory allocation Information for a device
@@ -870,6 +921,165 @@ typedef nvmlPdi_v1_t nvmlPdi_t;
 
 #define nvmlPdi_v1 NVML_STRUCT_VERSION(Pdi, 1) //!< Version macro for \a nvmlPdi_v1_t
 
+#define NVML_PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS                                2  //!< Maximum number of core rails for DLPPM 1x power model
+#define NVML_PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX                                     8  //!< Maximum number of NNE descriptor inference loops
+#define NVML_PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX 3  //!< Maximum number of initial DRAMCLK estimates for DLPPM 1x observed metrics
+#define NVML_PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX       4  //!< Maximum number of power policy relationship set limits for DLPPC 2x controller
+#define NVML_PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM                           3  //!< Number of DRAMCLK frequencies tracked by DLPPC 2x controller status
+#define NVML_PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM                             4  //!< Maximum number of controllers that can be sampled
+#define NVML_PERF_METRICS_SAMPLE_COUNT                                                    13  //!< Total number of performance metrics samples that can be collected
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X                               32  //!< Maximum number of power model scale loops for PFPP 1x
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX                               16  //!< Maximum number of power model scale metrics inputs
+#define NVML_PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X                                         0  //!< Controller type identifier for DLPPC 2x
+#define NVML_PERF_METRICS_CONTROLLER_TYPE_PFPP_1X                                          1  //!< Controller type identifier for PFPP 1x
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX                       0  //!< Index for GPCCLK frequency in PFPP 1x scale metrics
+#define NVML_PERF_CF_PM_SENSOR_MAX_SIGNALS                                              1024  //!< Maximum number of BA PM sensor signals
+
+/**
+ * Power tuple containing power consumption in milliwatts.
+ */
+typedef struct
+{
+    unsigned int pwrmW;                                     //!< Power consumption in milliwatts
+} nvmlPmgrPwrTuple_t;
+
+/**
+ * Metrics for a single power rail, including frequency and utilization.
+ */
+typedef struct
+{
+    unsigned int freqkHz;                                   //!< Frequency in kilohertz
+    unsigned long long utilPct;                             //!< Utilization percentage (fixed-point)
+} nvmlRailMetrics_t;
+
+/**
+ * Metrics for all core rails in the system.
+ */
+typedef struct
+{
+    nvmlRailMetrics_t rails[NVML_PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS];  //!< Array of core rail metrics
+} nvmlCoreRailMetrics_t;
+
+/**
+ * Performance metrics for DLPPM 1x power model.
+ */
+typedef struct
+{
+    unsigned int perfms;                                    //!< Performance metric in milliseconds
+} nvmlPwrModelMetricsDlppm1xPerf_t;
+
+/**
+ * Complete power model metrics for DLPPM 1x, including rail metrics and TGP power.
+ */
+typedef struct
+{
+    unsigned char bValid;                                   //!< Validity flag: non-zero if metrics are valid
+    nvmlCoreRailMetrics_t coreRail;                         //!< Core rail metrics
+    nvmlRailMetrics_t fbRail;                               //!< Fb rail metrics
+    nvmlPmgrPwrTuple_t tgpPwrTuple;                         //!< Total Graphics Power (TGP) in milliwatts
+    nvmlPwrModelMetricsDlppm1xPerf_t perfMetrics;           //!< Performance metrics
+} nvmlPwrModelMetricsDlppm1x_t;
+
+/**
+ * DRAMCLK estimates containing multiple estimated metrics for different DRAMCLK frequencies.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsDlppm1x_t estimatedMetrics[NVML_PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX];  //!< Array of estimated metrics for each inference loop
+    unsigned char numEstimatedMetrics;                                                              //!< Number of valid entries in estimatedMetrics array
+} nvmlPwrModelMetricsDlppm1xDramclkEstimates_t;
+
+/**
+ * Observed metrics from the power model, including initial DRAMCLK estimates and current measurements.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsDlppm1xDramclkEstimates_t initialDramclkEst[NVML_PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX];  //!< Initial DRAMCLK estimates for different scenarios
+    unsigned char bValid;                                                                                                                                //!< Validity flag: non-zero if observed metrics are valid
+    nvmlCoreRailMetrics_t coreRail;                                                                                                                      //!< Observed core rail metrics
+    nvmlRailMetrics_t fbRail;                                                                                                                            //!< Observed fb rail metrics
+    nvmlPmgrPwrTuple_t tgpPwrTuple;                                                                                                                      //!< Observed Total Graphics Power (TGP) in milliwatts
+    nvmlPwrModelMetricsDlppm1xPerf_t perfMetrics;                                                                                                        //!< Observed performance metrics
+} nvmlObservedMetrics_t;
+
+/**
+ * Performance metrics sample for DLPPC 2x controller.
+ */
+typedef struct
+{
+    nvmlObservedMetrics_t observedMetrics;                  //!< Observed metrics from the DLPPC 2x controller
+} nvmlPerfMetricsDlppc2xSample_t;
+
+/**
+ * Power model metrics sample for PFPP 1x, containing frequency inputs and estimated TGP.
+ */
+typedef struct
+{
+    unsigned int freqkHz[NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX];  //!< Array of input frequencies in kilohertz for each domain
+    unsigned int estTgpPwrmW;                                                   //!< Estimated Total Graphics Power in milliwatts
+} nvmlPwrModelMetricsSamplePfpp1x_t;
+
+/**
+ * Operating point for PFPP 1x power model, defining a frequency-power pair.
+ */
+typedef struct
+{
+    unsigned int freqkHz;                                   //!< Operating frequency in kilohertz
+    unsigned int pwrmW;                                     //!< Power consumption at this frequency in milliwatts
+} nvmlPwrModelOperatingPointPfpp1x_t;
+
+/**
+ * Complete power model metrics for PFPP 1x, including estimated metrics and key operating points.
+ */
+typedef struct
+{
+    unsigned char numVfPoints;                                                                                //!< Number of valid vf points
+    nvmlPwrModelMetricsSamplePfpp1x_t estimatedMetrics[NVML_PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X];  //!< Array of estimated metrics for different operating points
+    unsigned char bValid;                                                                                     //!< Validity flag: non-zero if metrics are valid
+    nvmlPwrModelOperatingPointPfpp1x_t maxPerfPerWattPoint;                                                   //!< Operating point with maximum performance per watt
+    nvmlPwrModelOperatingPointPfpp1x_t fmaxAtVmaxPoint;                                                       //!< Operating point at maximum frequency and voltage
+    unsigned int tgpHeadroommW;                                                                               //!< TGP headroom in milliwatts
+} nvmlPwrModelMetricsPfpp1x_t;
+
+/**
+ * Performance metrics sample for PFPP 1x controller.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsPfpp1x_t estimatedMetrics;           //!< Estimated metrics from the PFPP 1x controller
+} nvmlPerfMetricsPfpp1xSample_t;
+
+/**
+ * Performance metrics sample from a controller, which can be either DLPPC 2x or PFPP 1x.
+ */
+typedef struct
+{
+    unsigned int controllerType;                            //!< Controller type: NVML_PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X or NVML_PERF_METRICS_CONTROLLER_TYPE_PFPP_1X
+    union{
+        nvmlPerfMetricsDlppc2xSample_t dlppc2x;             //!< DLPPC 2x controller sample data
+        nvmlPerfMetricsPfpp1xSample_t  pfpp1x;              //!< PFPP 1x controller sample data
+    } data;                                                 //!< Union containing controller-specific data
+} nvmlPerfMetricControllerSample_t;
+
+/**
+ * Single performance metrics sample containing data from one or more controllers.
+ */
+typedef struct
+{
+    unsigned char numControllerData;                                                                          //!< Number of valid controller samples in this sample
+    nvmlPerfMetricControllerSample_t controllerData[NVML_PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM];  //!< Array of controller samples
+} nvmlPerfMetricsSample_t;
+
+/**
+ * Collection of performance metrics samples (version 1).
+ * This structure contains multiple samples for performance monitoring and profiling.
+ */
+typedef struct
+{
+    unsigned int numSamples;                                          //!< Number of samples in the samples array
+    nvmlPerfMetricsSample_t samples[NVML_PERF_METRICS_SAMPLE_COUNT];  //!< Array of performance metrics samples
+} nvmlPerfMetricsSamples_v1_t;
+
 /**
  * BBX Time Data
  */
@@ -880,7 +1090,7 @@ typedef nvmlPdi_v1_t nvmlPdi_t;
 /** @} */
 
 /***************************************************************************************************/
-/** @defgroup nvmlDeviceEnumvs Device Enums
+/** @defgroup nvmlDeviceEnums Device Enums
  *  @{
  */
 /***************************************************************************************************/
@@ -934,8 +1144,11 @@ typedef enum nvmlBrandType_enum
     NVML_BRAND_NVIDIA               = 14,
     NVML_BRAND_GEFORCE_RTX          = 15,  // Unused
     NVML_BRAND_TITAN_RTX            = 16,  // Unused
+    NVML_BRAND_NVIDIA_DLA           = 17,  // Deprecated NVIDIA Deep Learning Accelerator
+    NVML_BRAND_NVIDIA_VGAMEDEV      = 18,  // NVIDIA RTX Virtual Game Dev
+    NVML_BRAND_NVIDIA_NPU           = 19,  // NVIDIA NPU
     // Keep this last
-    NVML_BRAND_COUNT                = 18,
+    NVML_BRAND_COUNT                = 20,
 } nvmlBrandType_t;
 
 /**
@@ -943,22 +1156,22 @@ typedef enum nvmlBrandType_enum
  */
 typedef enum nvmlTemperatureThresholds_enum
 {
-    NVML_TEMPERATURE_THRESHOLD_SHUTDOWN      = 0, // Temperature at which the GPU will
-                                                  // shut down for HW protection
-    NVML_TEMPERATURE_THRESHOLD_SLOWDOWN      = 1, // Temperature at which the GPU will
-                                                  // begin HW slowdown
-    NVML_TEMPERATURE_THRESHOLD_MEM_MAX       = 2, // Memory Temperature at which the GPU will
-                                                  // begin SW slowdown
-    NVML_TEMPERATURE_THRESHOLD_GPU_MAX       = 3, // GPU Temperature at which the GPU
-                                                  // can be throttled below base clock
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN  = 4, // Minimum GPU Temperature that can be
-                                                  // set as acoustic threshold
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR = 5, // Current temperature that is set as
-                                                  // acoustic threshold.
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX  = 6, // Maximum GPU temperature that can be
-                                                  // set as acoustic threshold.
-    NVML_TEMPERATURE_THRESHOLD_GPS_CURR      = 7, // Current temperature that is set as
-                                                  // gps threshold.
+    NVML_TEMPERATURE_THRESHOLD_SHUTDOWN       = 0, //!< Temperature at which the GPU will
+                                                   //!< shut down for HW protection
+    NVML_TEMPERATURE_THRESHOLD_SLOWDOWN       = 1, //!< Temperature at which the GPU will
+                                                   //!< begin HW slowdown
+    NVML_TEMPERATURE_THRESHOLD_MEM_MAX        = 2, //!< Memory Temperature at which the GPU will
+                                                   //!< begin SW slowdown
+    NVML_TEMPERATURE_THRESHOLD_GPU_MAX        = 3, //!< GPU Temperature at which the GPU
+                                                   //!< can be throttled below base clock
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN   = 4, //!< Minimum GPU Temperature that can be
+                                                   //!< set as acoustic threshold
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR  = 5, //!< Current temperature that is set as
+                                                   //!< acoustic threshold.
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX   = 6, //!< Maximum GPU temperature that can be
+                                                   //!< set as acoustic threshold.
+    NVML_TEMPERATURE_THRESHOLD_GPS_CURR       = 7, //!< Current temperature that is set as
+                                                   //!< gps threshold.
     // Keep this last
     NVML_TEMPERATURE_THRESHOLD_COUNT
 } nvmlTemperatureThresholds_t;
@@ -969,6 +1182,8 @@ typedef enum nvmlTemperatureThresholds_enum
 typedef enum nvmlTemperatureSensors_enum
 {
     NVML_TEMPERATURE_GPU      = 0,    //!< Temperature sensor for the GPU die
+
+    NVML_TEMPERATURE_GPU_MAX  = 1,    //!< Temperature from the hottest part of the GPU die
 
     // Keep this last
     NVML_TEMPERATURE_COUNT
@@ -1559,7 +1774,12 @@ typedef struct
 
 #define NVML_DEVICE_ARCH_BLACKWELL 10 //!< Devices based on the NVIDIA Blackwell architecture
 
+#define NVML_DEVICE_ARCH_DLA       11 //!< Devices based on the NVIDIA DLA architecture.
+#define NVML_DEVICE_ARCH_DLA2      12 //!< Devices based on the NVIDIA DLA2 architecture.
+
 #define NVML_DEVICE_ARCH_RUBIN     13 //!< Devices based on the NVIDIA Rubin architecture.
+
+#define NVML_DEVICE_ARCH_NPU3      15 //!< Devices based on the NVIDIA NPU3 architecture.
 
 #define NVML_DEVICE_ARCH_UNKNOWN   0xffffffff //!< Anything else, presumably something newer
 
@@ -1675,6 +1895,15 @@ typedef struct
 
 #define nvmlPowerValue_v2 NVML_STRUCT_VERSION(PowerValue, 2) //!< Version macro for \a nvmlPowerValue_v2_t
 
+typedef struct
+{
+    nvmlEnableState_t inBandEnableRequest;    //!< [out] In-band enable requested (NVML_FEATURE_ENABLED) or not requested (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t featureAllowedByAdmin;  //!< [out] Feature allowed by out-of-band/admin (NVML_FEATURE_ENABLED) or not allowed (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t adminOverrideEnabled;   //!< [out] Out-of-band/admin override active (NVML_FEATURE_ENABLED) or inactive (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t enablementStatus;       //!< [out] Enablement after arbitration: active (NVML_FEATURE_ENABLED) or inactive (NVML_FEATURE_DISABLED)
+    unsigned int adjustedLimitMw;             //!< [out] Adjusted TGP limit in milliwatts (valid only when feature is enabled)
+} nvmlAdaptiveTgpModeInfo_v1_t;
+
 /** @} */
 
 /***************************************************************************************************/
@@ -1733,7 +1962,8 @@ typedef enum {
     NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX   = 2,                                         //!< Nvidia RTX
     NVML_GRID_LICENSE_FEATURE_CODE_VWORKSTATION = NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX, //!< Deprecated, do not use.
     NVML_GRID_LICENSE_FEATURE_CODE_GAMING       = 3,                                         //!< Gaming
-    NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4                                          //!< Compute
+    NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4,                                         //!< Compute
+    NVML_GRID_LICENSE_FEATURE_CODE_VGAMEDEV     = 5                                          //!< vGameDev
 } nvmlGridLicenseFeatureCode_t;
 
 /**
@@ -2210,6 +2440,8 @@ typedef enum nvmlDeviceGpuRecoveryAction_s  {
     NVML_GPU_RECOVERY_ACTION_DRAIN_P2P = 3,           //!< Drain P2P
     NVML_GPU_RECOVERY_ACTION_DRAIN_AND_RESET = 4,     //!< Drain P2P and Reset Gpu
     NVML_GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN = 5, //!< Recover IMEX Domain.
+    NVML_GPU_RECOVERY_ACTION_BUS_RESET = 6,           //!< Reset the GPU's PCIe bus
+    NVML_GPU_RECOVERY_ACTION_SYSTEM_REBOOT = 7,       //!< Reboot the system
 } nvmlDeviceGpuRecoveryAction_t;
 
 /**
@@ -2685,7 +2917,7 @@ typedef struct
  * Link ID needs to be specified in the scopeId field in nvmlFieldValue_t.
  */
 #define NVML_FI_DEV_NVLINK_GET_SPEED                  164 //!< NVLink Speed in MBps
-#define NVML_FI_DEV_NVLINK_GET_STATE                  165 //!< NVLink State - Active,Inactive
+#define NVML_FI_DEV_NVLINK_GET_STATE                  165 //!< NVLink State - one of NVML_NVLINK_STATE_* values
 #define NVML_FI_DEV_NVLINK_GET_VERSION                166 //!< NVLink Version
 
 #define NVML_FI_DEV_NVLINK_GET_POWER_STATE            167 //!< NVLink Power state. 0=HIGH_SPEED 1=LOW_SPEED
@@ -2805,7 +3037,7 @@ typedef struct
 #define NVML_FI_DEV_DRAIN_AND_RESET_STATUS                       227 //!< Deprecated, do not use (use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead)
 #define NVML_FI_DEV_PCIE_OUTBOUND_ATOMICS_MASK                   228
 #define NVML_FI_DEV_PCIE_INBOUND_ATOMICS_MASK                    229
-#define NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      230 //!< GPU Recovery action - None/Reset/Reboot/Drain P2P/Drain and Reset
+#define NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      230 //!< GPU Recovery action. See \ref nvmlDeviceGpuRecoveryAction_t
 #define NVML_FI_DEV_C2C_LINK_ERROR_INTR                          231 //!< C2C Link CRC Error Counter
 #define NVML_FI_DEV_C2C_LINK_ERROR_REPLAY                        232 //!< C2C Link Replay Error Counter
 #define NVML_FI_DEV_C2C_LINK_ERROR_REPLAY_B2B                    233 //!< C2C Link Back to Back Replay Error Counter
@@ -2964,9 +3196,17 @@ typedef struct
 #define NVML_FI_DEV_MCLK_SWITCH_TYPE                             298 //!< See NVML_MCLK_SWITCH_TYPE_<XYZ> for all enumerations
 #define NVML_FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS        299 //!< minimum required elapsed time between runtime mclk switches, 0 = no rate limit
 #define NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED        300 //!< State-Of-Charge Power Smoothing Enabled (0/DISABLED or 1/ENABLED)
+
 #define NVML_FI_DEV_REMAPPED_ROWS_COR_INACTIVE                  301 //!< Number of inactive row remappings due to correctable errors
 #define NVML_FI_DEV_REMAPPED_ROWS_UNC_INACTIVE                  302 //!< Number of inactive row remappings due to uncorrectable errors
-#define NVML_FI_MAX                                             303 //!< One greater than the largest field ID defined above
+
+/* Bank Remapper */
+#define NVML_FI_DEV_ACTIVE_BANK_REMAPPINGS          303 //!< Number of active bank remappings
+#define NVML_FI_DEV_INACTIVE_BANK_REMAPPINGS        304 //!< Number of inactive bank remappings
+#define NVML_FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX     305 //!< Number of groups with full bank remap availability.
+#define NVML_FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE    306 //!< Number of groups with no spare bankremap availability.
+#define NVML_FI_DEV_PENDING_BANK_REMAPPING          307 //!< If any banks are pending remapping. 1=yes 0=no
+#define NVML_FI_MAX                                 308 //!< One greater than the largest field ID defined above
 
 /**
  * NVML_FI_DEV_MCLK_SWITCH_TYPE enumerations
@@ -3255,6 +3495,108 @@ typedef struct nvmlEventData_st
 } nvmlEventData_t;
 
 /**
+ * @brief Log-level values used by GPU Operational Events.
+ *
+ * These values are used both for event reporting in \ref nvmlEventData_v2_t and for subscription
+ * filtering in \ref nvmlGpuOperationalEventConfig_v1_t. Higher numeric values represent more
+ * selective log levels. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL disables log-level filtering
+ * when used as a subscription threshold. Event data may contain newer log-level values that are
+ * not named in this header; clients should handle unrecognized numeric values.
+ */
+typedef enum
+{
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL       = 0,  //!< Matches all GPU Operational Event log levels.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_TELEMETRY = 10, //!< High-volume telemetry events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_DIAG      = 20, //!< Diagnostic events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_NOTICE    = 30, //!< Notable operational events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_WARNING   = 40, //!< Warning events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ERROR     = 50, //!< Error events.
+} nvmlGpuOperationalEventLogLevel_t;
+
+/**
+ * @brief Severity values used by Operational Events.
+ *
+ * These values are used both for event reporting in \ref nvmlEventData_v2_t and for subscription
+ * filtering in \ref nvmlGpuOperationalEventConfig_v1_t. Higher numeric values represent more
+ * selective severities. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL disables severity filtering when
+ * used as a subscription threshold. Event data may contain newer severity values that are not
+ * named in this header; clients should handle unrecognized numeric values.
+ */
+typedef enum
+{
+    NVML_OPERATIONAL_EVENT_SEVERITY_ALL           = 0,  //!< Matches all Operational Event severities.
+    NVML_OPERATIONAL_EVENT_SEVERITY_INFORMATIONAL = 10, //!< Informational event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_CORRECTED     = 20, //!< Corrected error event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_RECOVERABLE   = 30, //!< Recoverable error event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_FATAL         = 40, //!< Fatal error event.
+} nvmlOperationalEventSeverity_t;
+
+/**
+ * @brief Event data formats returned by \ref nvmlEventSetWait_v3.
+ */
+typedef enum
+{
+    NVML_EVENT_DATA_TYPE_NVML_EVENT            = 0, //!< NVML event-bit data. \c eventType contains an NVML event bit.
+    NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT = 1, //!< Structured GPU Operational Event data.
+} nvmlEventDataType_t;
+
+#define NVML_GPU_INSTANCE_ID_ANY      0xFFFFFFFFU //!< Sentinel value used when no MIG GPU instance ID applies.
+#define NVML_COMPUTE_INSTANCE_ID_ANY  0xFFFFFFFFU //!< Sentinel value used when no MIG compute instance ID applies.
+
+#define NVML_OPERATIONAL_EVENT_ATTR_UNCONTAINED        (1u << 0) //!< Event reports an uncontained condition.
+#define NVML_OPERATIONAL_EVENT_ATTR_LATENT             (1u << 1) //!< Event reports a latent condition.
+#define NVML_OPERATIONAL_EVENT_ATTR_PROPAGATED         (1u << 2) //!< Event was propagated from another source.
+#define NVML_OPERATIONAL_EVENT_ATTR_COMPONENT_RESET    (1u << 3) //!< Event involved a component reset.
+#define NVML_OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED (1u << 4) //!< Event reports an exceeded threshold.
+#define NVML_OPERATIONAL_EVENT_ATTR_PRIMARY            (1u << 5) //!< Event is the primary event in its group.
+#define NVML_OPERATIONAL_EVENT_ATTR_OVERFLOW           (1u << 6) //!< One or more events or associated payloads were dropped before this event was returned.
+
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED    (1u << 0) //!< Event group reports a recovered condition.
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_PREVERR      (1u << 1) //!< Event group reports a previous error condition.
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED    (1u << 2) //!< Event group was generated by simulation or testing.
+
+/**
+ * @brief NVML-defined GPU Operational Event context classifications.
+ *
+ * These values describe the NVML public interpretation of a context payload. The
+ * original source-defined context type is returned separately in
+ * \ref nvmlOperationalEventContextInfo_v1_t::sourceEventContextType.
+ */
+typedef enum
+{
+    NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_UNKNOWN    = 0, //!< No NVML public interpretation is defined for this context payload.
+    NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID = 1, //!< Context payload can be decoded with \ref nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1.
+} nvmlGpuOperationalEventContextType_t;
+
+/**
+ * @brief Metadata for a context record associated with the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * The context payload itself is returned by \ref nvmlEventSetGetContextData_v1. Context metadata
+ * remains valid until the next successful call to \ref nvmlEventSetWait_v3 on the same event set or
+ * until the event set is freed.
+ */
+typedef struct nvmlOperationalEventContextInfo_v1_st
+{
+    unsigned int   nvmlGpuOperationalEventContextType;  //!< [out] \ref nvmlGpuOperationalEventContextType_t value describing the NVML public interpretation of the context payload.
+    unsigned int   sourceEventContextType;              //!< [out] Source-defined context payload type identifier carried by the event.
+    unsigned int   dataSize;                            //!< [out] Context payload size in bytes, excluding alignment padding.
+    unsigned short dataFormatVersion;                   //!< [out] Payload format version for \c sourceEventContextType.
+} nvmlOperationalEventContextInfo_v1_t;
+
+/**
+ * @brief Decoded GPU legacy-Xid context data.
+ *
+ * This structure is returned by \ref nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1 for
+ * context records whose \c nvmlGpuOperationalEventContextType is
+ * \ref NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID.
+ */
+typedef struct nvmlGpuOperationalEventContextLegacyXid_v1_st
+{
+    unsigned int xidCode;                               //!< [out] Legacy Xid code carried in a GPU Operational Event context.
+} nvmlGpuOperationalEventContextLegacyXid_v1_t;
+
+/**
  * System Event Set
  */
 typedef struct
@@ -3424,6 +3766,20 @@ typedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t;
  */
 #define nvmlClocksEventReasonDisplayClockSetting       0x0000000000000100LL //!< Display clock setting limited.
 
+/** Board limit
+ *
+ * The board limit (operating) policy is currently limiting the GPU clocks.
+ *
+ */
+#define nvmlClocksEventReasonBoardLimit                0x0000000000000200LL //!< Board limit policy is limiting clocks.
+
+/** Reliability
+ *
+ * The reliability policy is currently limiting the GPU clocks.
+ *
+ */
+#define nvmlClocksEventReasonReliability              0x0000000000000400LL //!< Reliability policy is limiting clocks.
+
 /** Bit mask representing no clocks throttling
  *
  * Clocks are as high as possible.
@@ -3437,12 +3793,14 @@ typedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t;
       | nvmlClocksEventReasonGpuIdle                           \
       | nvmlClocksEventReasonApplicationsClocksSetting         \
       | nvmlClocksEventReasonSwPowerCap                        \
-      | nvmlClocksThrottleReasonHwSlowdown                        \
+      | nvmlClocksThrottleReasonHwSlowdown                     \
       | nvmlClocksEventReasonSyncBoost                         \
       | nvmlClocksEventReasonSwThermalSlowdown                 \
-      | nvmlClocksThrottleReasonHwThermalSlowdown                 \
-      | nvmlClocksThrottleReasonHwPowerBrakeSlowdown              \
+      | nvmlClocksThrottleReasonHwThermalSlowdown              \
+      | nvmlClocksThrottleReasonHwPowerBrakeSlowdown           \
       | nvmlClocksEventReasonDisplayClockSetting               \
+      | nvmlClocksEventReasonBoardLimit                        \
+      | nvmlClocksEventReasonReliability                       \
 ) //!< Bitmask of all clock event reasons.
 
 /**
@@ -3906,6 +4264,16 @@ typedef struct
 #define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED 0x3       //!< Fabric Health Mask Width for Partition Assigned
 
 /**
+ * Global Fabric Manager State
+ */
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED  0 //!< Fabric Health Mask: Global Fabric Manager State not supported
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED      1 //!< Fabric Health Mask: Global Fabric Manager State is Connected
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED   2 //!< Fabric Health Mask: Global Fabric Manager State is Disconnected
+
+#define NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE  14        //!< Fabric Health Mask Bit Shift for Global Fabric Manager State
+#define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE  0x3       //!< Fabric Health Mask Width for Global Fabric Manager State
+
+/**
  * Fabric Health
  */
 #define NVML_GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED 0    //!< Fabric Health Summary: Not supported
@@ -3958,11 +4326,14 @@ typedef struct
 #define nvmlGpuFabricInfo_v2 NVML_STRUCT_VERSION(GpuFabricInfo, 2) //!< Version macro for \a nvmlGpuFabricInfo_v2_t
 
 /**
-* GPU Fabric information (v3).
-*/
+ * GPU Fabric information (v3).
+ *
+ * @deprecated  nvmlGpuFabricInfo_v3_t is deprecated and will be removed in a future release.
+ *              Use nvmlGpuFabricInfo_v4_t instead.
+ */
 typedef struct
 {
-    unsigned int         version;                               //!< Structure version identifier (set to nvmlGpuFabricInfo_v2)
+    unsigned int         version;                               //!< Structure version identifier (set to nvmlGpuFabricInfo_v3)
     unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
     nvmlReturn_t         status;                                //!< Probe Error status, if any. Must be checked only if Probe state returns "complete".
     unsigned int         cliqueId;                              //!< ID of the fabric clique to which this GPU belongs
@@ -3978,81 +4349,134 @@ typedef nvmlGpuFabricInfo_v3_t nvmlGpuFabricInfoV_t;
 */
 #define nvmlGpuFabricInfo_v3 NVML_STRUCT_VERSION(GpuFabricInfo, 3) //!< Version macro for \a nvmlGpuFabricInfo_v3_t
 
-/** @} */
-
-/***************************************************************************************************/
-/** @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
- * This chapter describes the methods that handle NVML initialization and cleanup.
- * It is the user's responsibility to call \ref nvmlInit_v2() before calling any other methods, and
- * nvmlShutdown() once NVML is no longer being used.
- *  @{
+/**
+ * Maximum number of fabric clique entries.
  */
-/***************************************************************************************************/
+#define NVML_GPU_FABRIC_CLIQUE_MAX       64
 
-#define NVML_INIT_FLAG_NO_GPUS      (1 << 0)   //!< Don't fail nvmlInit() when no GPUs are found
-#define NVML_INIT_FLAG_NO_ATTACH    (1 << 1)   //!< Don't attach GPUs
-#define NVML_INIT_FLAG_FORCE_INIT   (1 << 2)   //!< Force GPU initialization when a previous nvmlInit was called with NO_GPUS and NO_ATTACH flags
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER                         0 //!< Unicast pointer-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER                       1 //!< Multicast pointer-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT                2 //!< Unicast logical-endpoint-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT              3 //!< Multicast logical-endpoint-based access
 
 /**
- * Initialize NVML, but don't initialize any GPUs yet.
+ * Fabric clique entry. Each entry represents a single (type, id) pair
+ * describing a clique assignment for a given fabric operation type.
+ */
+typedef struct
+{
+    unsigned char type;  //!< Clique type. See NVML_GPU_FABRIC_CLIQUE_TYPE_*
+    unsigned int  id;    //!< Clique ID assigned by the Fabric Manager
+} nvmlGpuFabricClique_v1_t;
+
+/**
+ * GPU Fabric information (v4).
  *
- * \note nvmlInit_v3 introduces a "flags" argument, that allows passing boolean values
- *       modifying the behaviour of nvmlInit().
- * \note In NVML 5.319 new nvmlInit_v2 has replaced nvmlInit"_v1" (default in NVML 4.304 and older) that
- *       did initialize all GPU devices in the system.
+ * Extends v3 by replacing the single \a cliqueId field with a flat array
+ * of (type, id) clique entries. The legacy v3 \a cliqueId maps to the
+ * \a id of the first \ref NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER entry.
+ */
+typedef struct
+{
+    unsigned char            clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
+    nvmlReturn_t             status;                               //!< Probe Error status, if any. Must be checked only if state returns "complete".
+    nvmlGpuFabricClique_v1_t cliques[NVML_GPU_FABRIC_CLIQUE_MAX];  //!< Clique entries, sorted by ascending type then ascending id
+    unsigned int             numCliques;                           //!< Number of valid entries in \a cliques[]
+    nvmlGpuFabricState_t     state;                                //!< Current Probe State. See NVML_GPU_FABRIC_STATE_*
+    unsigned int             healthMask;                           //!< GPU Fabric health Status Mask. See NVML_GPU_FABRIC_HEALTH_MASK_*
+    unsigned char            healthSummary;                        //!< GPU Fabric health summary. See NVML_GPU_FABRIC_HEALTH_SUMMARY_*
+} nvmlGpuFabricInfo_v4_t;
+
+/** @} */
+
+/**
+ * @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
+ * @brief NVML Methods that handle the NVML Library initialization and cleanup.
  *
- * This allows NVML to communicate with a GPU
- * when other GPUs in the system are unstable or in a bad state.  When using this API, GPUs are
- * discovered and initialized in nvmlDeviceGetHandleBy* functions instead.
+ * This chapter describes the methods that handle NVML initialization and cleanup.
+ * It is the user's responsibility to call \ref nvmlInit_v2() before calling any
+ * other methods, and \ref nvmlShutdown() once NVML is no longer being used.
+ * @{
+ */
+
+#define NVML_INIT_FLAG_NO_GPUS      (1 << 0)   //!< Initialize the NVML Library even when no devices are found.
+#define NVML_INIT_FLAG_NO_ATTACH    (1 << 1)   //!< Initialize the NVML Library without attaching any discovered devices.
+#define NVML_INIT_FLAG_FORCE_INIT   (1 << 2)   //!< Force device initialization even when a previous nvmlInit was called with the NO_GPUS and NO_ATTACH flags.
+
+/**
+ * @brief Initialize the NVML Library lazily, without allocating any device state.
  *
- * \note To contrast nvmlInit_v2 with nvmlInit"_v1", NVML 4.304 nvmlInit"_v1" will fail when any detected GPU is in
- *       a bad or unstable state.
+ * This will initialize the NVML Library state without enumerating any discovered
+ * devices. This will allow NVML to communicate with a device, even if other devices
+ * are in an unstable or bad state. Enumeration of a device can be done by obtaining
+ * the device handle via the nvmlDeviceGetHandleBy* class of APIs.
+ *
+ * This method needs to be called once before any usage of NVML Library APIs.
  *
  * For all products.
  *
- * This method, should be called once before invoking any other methods in the library.
- * A reference count of the number of initializations is maintained.  Shutdown only occurs
- * when the reference count reaches zero.
- *
  * @return
- *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
- *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
- *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
- *         - \ref NVML_ERROR_UNKNOWN             on any unexpected error
+ * - \ref NVML_SUCCESS                   if the NVML Library was properly initialized.
+ * - \ref NVML_ERROR_DRIVER_NOT_LOADED   if the NVIDIA driver is not running.
+ * - \ref NVML_ERROR_NO_PERMISSION       if the NVML Library does not have permission to talk to the driver.
+ * - \ref NVML_ERROR_UNKNOWN             if there is an unexpected error.
+ *
+ * @note  A reference count of the number of initializations is maintained, and
+ *        a corresponding call to \ref nvmlShutdown() needs to be issued once usage
+ *        of the NVML Library is complete. Shutdown will only occur after the
+ *        reference count reaches zero.
+ *
+ * @see nvmlShutdown()
  */
 nvmlReturn_t DECLDIR nvmlInit_v2(void);
 
 /**
- * nvmlInitWithFlags is a variant of nvmlInit(), that allows passing a set of boolean values
- *       modifying the behaviour of nvmlInit().
- *       Other than the "flags" parameter it is completely similar to \ref nvmlInit_v2.
+ * @brief Initialize the NVML Library lazily, without allocating any device state, with additional init flags.
+ *
+ * A variant of \ref nvmlInit_v2(), this will initialize the NVML Library state without
+ * enumerating any discovered devices. An option to pass in additional flags
+ * is provided to modify the behavior of NVML Library init. The usage of these
+ * flags can be obtained from NVML_INIT_FLAG_*. These flags can be combined together.
+ *
+ * Other than the "flags" parameter, this method is completely identical to \ref nvmlInit_v2().
  *
  * For all products.
  *
- * @param flags                                 behaviour modifier flags
+ * @param[in]  flags                     NVML_INIT_FLAG_* flags that can modify NVML Init behavior.
  *
  * @return
- *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
- *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
- *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
- *         - \ref NVML_ERROR_UNKNOWN             on any unexpected error
+ * - \ref NVML_SUCCESS                   if the NVML Library was properly initialized.
+ * - \ref NVML_ERROR_DRIVER_NOT_LOADED   if the NVIDIA driver is not running.
+ * - \ref NVML_ERROR_NO_PERMISSION       if the NVML Library does not have permission to talk to the driver.
+ * - \ref NVML_ERROR_UNKNOWN             if there is an unexpected error.
+ *
+ * @note  A reference count of the number of initializations is maintained, and
+ *        a corresponding call to \ref nvmlShutdown() needs to be issued once usage
+ *        of the NVML Library is complete. Shutdown will only occur after the
+ *        reference count reaches zero.
+ *
+ * @see nvmlShutdown()
  */
 nvmlReturn_t DECLDIR nvmlInitWithFlags(unsigned int flags);
 
 /**
- * Shut down NVML by releasing all GPU resources previously allocated with \ref nvmlInit_v2().
+ * @brief Shut down and cleanup NVML Library state.
+ *
+ * This will shut down and cleanup NVML Library state by releasing all device and
+ * library resources previously allocated with \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
+ * This should be called after all NVML work is done, and once for each call to
+ * \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
+ *
+ * Complete shutdown will only occur when the reference count of all prior NVML
+ * initializations reaches zero. No error will be reported if this is called
+ * more times than \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
  *
  * For all products.
  *
- * This method should be called after NVML work is done, once for each call to \ref nvmlInit_v2()
- * A reference count of the number of initializations is maintained.  Shutdown only occurs
- * when the reference count reaches zero.  For backwards compatibility, no error is reported if
- * nvmlShutdown() is called more times than nvmlInit().
- *
  * @return
- *         - \ref NVML_SUCCESS                 if NVML has been properly shut down
- *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ * - \ref NVML_SUCCESS                 if the NVML Library was properly shut down.
+ * - \ref NVML_ERROR_UNINITIALIZED     if the NVML Library was not previously initialized.
+ * - \ref NVML_ERROR_UNKNOWN           if there is an unexpected error.
  */
 nvmlReturn_t DECLDIR nvmlShutdown(void);
 
@@ -4136,6 +4560,68 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
 #define NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE         32
 
 /** @} */
+
+/**
+ * @brief Configuration for registering structured GPU Operational Events with
+ * \ref nvmlEventSetRegisterGpuOperationalEvents_v1.
+ *
+ * Initialize the structure to zero and then set \c uuid to select the target GPU. Default values
+ * register new device-wide events with log-level and severity filters disabled.
+ */
+typedef struct nvmlGpuOperationalEventConfig_v1_st
+{
+    char                                uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE]; //!< [in] Target GPU UUID string. Must be a NULL-terminated "GPU-..." UUID.
+    unsigned int                        minLogLevel;                           //!< [in] \ref nvmlGpuOperationalEventLogLevel_t value for the minimum GPU Operational Event log level. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL means no filter.
+    unsigned int                        minSeverity;                           //!< [in] \ref nvmlOperationalEventSeverity_t value for the minimum Operational Event severity threshold. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL means no filter.
+} nvmlGpuOperationalEventConfig_v1_t;
+
+/**
+ * @brief Extended event payload returned by \ref nvmlEventSetWait_v3.
+ *
+ * This structure is used for both NVML event-bit and structured formats. For NVML event-bit data,
+ * \c dataType is \ref NVML_EVENT_DATA_TYPE_NVML_EVENT, \c eventType contains the NVML event bit,
+ * fields such as \c eventData, \c gpuInstanceId, and \c computeInstanceId preserve existing
+ * semantics, and structured-only fields are set to 0 or empty values. For structured GPU Operational
+ * Events, \c dataType is \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT, \c eventType is set to
+ * \ref nvmlEventTypeNone, and the structured metadata fields are populated.
+ *
+ * Clients that subscribe to both NVML event-bit and structured formats on the same event set should branch
+ * on \c dataType to determine which format was returned. During the transition period, the
+ * same underlying incident may generate both an NVML event-bit notification and a structured notification;
+ * NVML does not deduplicate those notifications.
+ *
+ * Fields such as \c categoryId, \c sourceModule, \c moduleEventCode, \c scope,
+ * \c originator, \c moduleInstance, and \c chipletId are structured event metadata identifiers.
+ * NVML transports these identifiers but does not define the event catalog or source-defined
+ * metadata values.
+ */
+typedef struct nvmlEventData_v2_st
+{
+    char                uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE]; //!< [out] UUID for the GPU where the event occurred. Empty if unavailable.
+    char                sourceModule[16];                      //!< [out] Source module signature for structured events. Not guaranteed to be NULL-terminated. Empty for NVML event-bit events.
+    unsigned long long  eventType;                             //!< [out] NVML event bit for \ref NVML_EVENT_DATA_TYPE_NVML_EVENT events; \ref nvmlEventTypeNone for structured events.
+    unsigned long long  eventData;                             //!< [out] Xid code for \ref nvmlEventTypeXidCriticalError, or 0 when not applicable.
+    unsigned long long  groupCursor;                           //!< [out] Structured event group identifier. 0 for NVML event-bit events.
+    unsigned long long  instanceId;                            //!< [out] Structured event sequence identifier. 0 for NVML event-bit events.
+    unsigned long long  timestampUsec;                         //!< [out] Event timestamp in microseconds. 0 if unavailable.
+    unsigned long long  traceId;                               //!< [out] Structured event trace identifier. 0 for NVML event-bit events.
+    unsigned int        dataType;                              //!< [out] \ref nvmlEventDataType_t value indicating which event-data format is populated.
+    unsigned int        gpuInstanceId;                         //!< [out] MIG GPU instance ID for NVML event-bit data, or \c NVML_GPU_INSTANCE_ID_ANY when not applicable.
+    unsigned int        computeInstanceId;                     //!< [out] MIG compute instance ID for NVML event-bit data, or \c NVML_COMPUTE_INSTANCE_ID_ANY when not applicable.
+    unsigned int        severity;                              //!< [out] \ref nvmlOperationalEventSeverity_t value for structured events. May contain newer severity values not named in this header. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL for NVML event-bit events.
+    unsigned int        categoryId;                            //!< [out] Source-defined structured event category identifier. 0 for NVML event-bit events.
+    unsigned int        moduleEventCode;                       //!< [out] Source-module-defined event code. Interpret with \c sourceModule. 0 for NVML event-bit events.
+    unsigned int        scope;                                 //!< [out] Structured event scope identifier. 0 for NVML event-bit events.
+    unsigned int        originator;                            //!< [out] Structured event originator identifier. 0 for NVML event-bit events.
+    unsigned int        moduleInstance;                        //!< [out] Structured event module instance identifier. 0 for NVML event-bit events.
+    unsigned int        chipletId;                             //!< [out] Structured event chiplet identifier. 0 for NVML event-bit events.
+    unsigned int        logLevel;                              //!< [out] \ref nvmlGpuOperationalEventLogLevel_t value for structured GPU Operational Events. May contain newer log-level values not named in this header. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL for NVML event-bit events.
+    unsigned int        attributes;                            //!< [out] Bitmask of \c NVML_OPERATIONAL_EVENT_ATTR_* values for structured events. May contain newer bits not named in this header. 0 for NVML event-bit events. May include \c NVML_OPERATIONAL_EVENT_ATTR_OVERFLOW if events or associated payloads were dropped.
+    unsigned int        groupCperSize;                         //!< [out] Associated CPER record size in bytes. 0 when unavailable.
+    unsigned int        groupAttributes;                       //!< [out] Bitmask of \c NVML_OPERATIONAL_EVENT_GROUP_ATTR_* values for structured events. May contain newer bits not named in this header. 0 for NVML event-bit events.
+    unsigned char       groupSize;                             //!< [out] Total number of events in the structured event group. 0 for NVML event-bit events.
+    unsigned char       groupIndex;                            //!< [out] Zero-based index within the structured event group. 0 for NVML event-bit events.
+} nvmlEventData_v2_t;
 
 /***************************************************************************************************/
 /** @defgroup nvmlCPER CPER (Common Platform Error Record)
@@ -6618,7 +7104,6 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerMizerMode_v1(nvmlDevice_t device, nvmlDev
 
 nvmlReturn_t DECLDIR nvmlDeviceSetPowerMizerMode_v1(nvmlDevice_t device, nvmlDevicePowerMizerModes_v1_t *powerMizerMode);
 
-
 /**
  * Retrieves total energy consumption for this GPU in millijoules (mJ) since the driver was last reloaded
  *
@@ -6657,6 +7142,58 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTotalEnergyConsumption(nvmlDevice_t device, un
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetEnforcedPowerLimit(nvmlDevice_t device, unsigned int *limit);
+
+/**
+ * Request to enable or disable Adaptive TGP Mode for a GPU.
+ *
+ * %RUBIN_OR_NEWER%
+ * Requires root/admin privileges.
+ *
+ * Adaptive TGP Mode assigns tailored power budgets to two binned GPU parts within the same
+ * module, reducing node-to-node and rack-to-rack performance variation.
+ * An out-of-band administrator policy may override the in-band request;
+ * use \ref nvmlDeviceGetAdaptiveTgpModeInfo_v1 to query the arbitrated state.
+ *
+ * @param device     The identifier of the target device
+ * @param mode       NVML_FEATURE_ENABLED or NVML_FEATURE_DISABLED
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the request was accepted
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is not a valid \ref nvmlEnableState_t
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support Adaptive TGP Mode
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the caller lacks root/admin privileges
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetAdaptiveTgpModeInfo_v1()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetAdaptiveTgpMode_v1(nvmlDevice_t device, nvmlEnableState_t mode);
+
+/**
+ * Retrieves Adaptive TGP Mode state and telemetry for a GPU.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * Populates \a info with the in-band request, out-of-band enablement status, out-of-band
+ * override status, arbitrated enablement state, and adjusted base power limit. The adjusted base
+ * power is valid only when feature is enabled.
+ * See \ref nvmlAdaptiveTgpModeInfo_v1_t for field details.
+ *
+ * @param device     The identifier of the target device
+ * @param info       Reference in which to return the Adaptive TGP Mode information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a info has been populated
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a info is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support Adaptive TGP Mode
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceSetAdaptiveTgpMode_v1()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetAdaptiveTgpModeInfo_v1(nvmlDevice_t device, nvmlAdaptiveTgpModeInfo_v1_t *info);
 
 /**
  * Retrieves the current GOM and pending GOM (the one that GPU will switch to after reboot).
@@ -6769,6 +7306,60 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
+
+/**
+ * @brief Set the memory limits of the device for the cgroup partition.
+ *
+ * This method will set the memory limits of the device for the specified cgroup
+ * partition. The limits will indicate the amount of memory that can be allocated
+ * for the device for use of an application in that cgroup.
+ *
+ * For all products.
+ * For Linux only.
+ * Requires root/admin permissions.
+ *
+ * @param[in] device                               The identifier of the target device
+ * @param[in] limits                               A pointer to \ref nvmlSetMemoryLimits_v1_t where the limits can be set
+ *
+ * @return
+ *  - \ref NVML_SUCCESS                 if the operation was successful
+ *  - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *  - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
+ *  - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a limits is NULL,
+ *                                      the softLimit exceeds the hardLimit, or a limit
+ *                                      exceeds total device memory
+ *  - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *  - \ref NVML_ERROR_OPERATING_SYSTEM  if the cgroup path cannot be opened
+ *  - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @note MIG handles are not supported
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetMemoryLimits_v1(nvmlDevice_t device, nvmlSetMemoryLimits_v1_t *limits);
+
+/**
+ * @brief Get the memory limits of the device for the cgroup partition.
+ *
+ * This method will get the current memory limits of the device for the specified
+ * cgroup partition, as well as the current memory used against the limits.
+ *
+ * For all products.
+ * For Linux only.
+ *
+ * @param[in]     device                           The identifier of the target device
+ * @param[in,out] limits                           A pointer to \ref nvmlGetMemoryLimits_v1_t
+ *
+ * @return
+ *  - \ref NVML_SUCCESS                 if the operation was successful
+ *  - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *  - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a limits is NULL
+ *  - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *  - \ref NVML_ERROR_NOT_FOUND         if the limits were not found for this device and cgroup
+ *  - \ref NVML_ERROR_OPERATING_SYSTEM  if the cgroup path cannot be opened
+ *  - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @note MIG handles are not supported
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMemoryLimits_v1(nvmlDevice_t device, nvmlGetMemoryLimits_v1_t *limits);
 
 /**
  * Retrieves the current compute mode for the device or MIG device.
@@ -7318,6 +7909,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFBCSessions(nvmlDevice_t device, unsigned int 
  *
  * On Windows platforms the device driver can run in either WDDM, MCDM or WDM (TCC) modes. If a display is attached
  * to the device it must run in WDDM mode. MCDM mode is preferred if a display is not attached. TCC mode is deprecated.
+ * Driver-model availability is architecture-specific; attempting to set an unsupported driver model returns
+ * NVML_ERROR_NOT_SUPPORTED.
  *
  * See \ref nvmlDriverModel_t for details on available driver models.
  *
@@ -7872,6 +8465,37 @@ DEPRECATED(13.0) nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfo(nvmlDevice_t de
 */
 nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device,
                                                  nvmlGpuFabricInfoV_t *gpuFabricInfo);
+
+/**
+ * Retrieves GPU fabric information including per-type clique assignments.
+ *
+ * Returns fabric clique data via \ref nvmlGpuFabricInfo_v4_t.
+ * Each entry in the \a cliques array is a (type, id) pair representing a single
+ * clique assignment. The number of valid entries is given by \a numCliques.
+ * Entries are sorted by ascending type (NVML_GPU_FABRIC_CLIQUE_TYPE_*), then by
+ * ascending clique id within each type.
+ *
+ * On Hopper systems, the driver reports Unicast Pointer and Multicast Pointer cliques.
+ * On Blackwell and Rubin, Unicast Logical Endpoint and Multicast Logical Endpoint
+ * are additionally reported.
+ *
+ * \code
+ *     nvmlGpuFabricInfo_v4_t fabricInfo = {0};
+ *     nvmlReturn_t result = nvmlDeviceGetGpuFabricInfo_v4(device, &fabricInfo);
+ * \endcode
+ *
+ * For Hopper &tm; or newer fully supported devices.
+ *
+ * @param device                               The identifier of the target device
+ * @param gpuFabricInfo                        Information about GPU fabric state including per-type cliques
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Upon success
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If \a device doesn't support gpu fabric
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a device or \a gpuFabricInfo is invalid
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfo_v4(nvmlDevice_t device,
+                                                   nvmlGpuFabricInfo_v4_t *gpuFabricInfo);
 
 /**
  * Get Conf Computing System capabilities.
@@ -8686,6 +9310,20 @@ nvmlReturn_t DECLDIR nvmlDeviceSetHostname_v1(nvmlDevice_t device, nvmlHostname_
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetHostname_v1(nvmlDevice_t device, nvmlHostname_v1_t *hostname);
 
+/**
+    * Get Performance Metric samples
+    *
+    * See \ref nvmlPerfMetricsSamples_v1_t for more information on the struct.
+    *
+    * @param[in] device                            The identifier of the target device
+    * @param[out] samples                          Reference to \a nvmlPerfMetricsSamples_v1_t.
+    *
+    * @return
+    *        - \ref NVML_SUCCESS                         if the query is successful
+    *        - \ref NVML_ERROR_NOT_SUPPORTED             if this query is not supported by the device
+    **/
+nvmlReturn_t DECLDIR nvmlDevicePerfMetricsGetSamples_v1(nvmlDevice_t device, nvmlPerfMetricsSamples_v1_t *samples);
+
 /** @} */
 
 /***************************************************************************************************/
@@ -8881,6 +9519,9 @@ nvmlReturn_t DECLDIR nvmlDeviceClearEccErrorCounts(nvmlDevice_t device, nvmlEccC
  *
  * On Windows platforms the device driver can run in either WDDM or WDM (TCC) mode. If a display is attached
  * to the device it must run in WDDM mode.
+ *
+ * Driver-model availability is architecture-specific; attempting to set an unsupported driver model returns
+ * NVML_ERROR_NOT_SUPPORTED.
  *
  * It is possible to force the change to WDM (TCC) while the display is still attached with a force flag (nvmlFlagForce).
  * This should only be done if the host is subsequently powered down and the display is detached from the device
@@ -9408,9 +10049,10 @@ nvmlReturn_t DECLDIR nvmlDeviceClearAccountingPids(nvmlDevice_t device);
 /*
  * NVML_FI_DEV_NVLINK_GET_STATE state enums
  */
-#define NVML_NVLINK_STATE_INACTIVE 0x0 //!< NVLink is inactive.
-#define NVML_NVLINK_STATE_ACTIVE   0x1 //!< NVLink is active.
-#define NVML_NVLINK_STATE_SLEEP    0x2 //!< NVLink is in sleep state.
+#define NVML_NVLINK_STATE_INACTIVE 0x0          //!< NVLink is inactive.
+#define NVML_NVLINK_STATE_ACTIVE   0x1          //!< NVLink is active.
+#define NVML_NVLINK_STATE_SLEEP    0x2          //!< NVLink is in sleep state.
+#define NVML_NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED 0x3 //!< NVLink is active, but not usable for traffic
 
 /**
  * Represents Nvlink Version
@@ -9456,6 +10098,21 @@ typedef struct
 } nvmlNvlinkSetBwMode_v1_t;
 typedef nvmlNvlinkSetBwMode_v1_t nvmlNvlinkSetBwMode_t;
 #define nvmlNvlinkSetBwMode_v1 NVML_STRUCT_VERSION(NvlinkSetBwMode, 1) //!< Version macro for \a nvmlNvlinkSetBwMode_v1_t
+
+/**
+ * @brief Describes the parameters involved to setting Nvlink RBM mode asynchronously.
+ *
+ * This structure holds the parameters needed to correctly set a Device's Nvlink
+ * Reduced Bandwidth Mode asynchronously. Polling for NVML_GPU_FABRIC_STATE_COMPLETED
+ * from \ref nvmlDeviceGetGpuFabricInfoV() is needed to check if the setting was applied.
+ *
+ */
+typedef struct
+{
+    unsigned int bSetBest;           //!< [in]  - Set to the best available Bandwidth mode
+    unsigned int bwMode;             //!< [in]  - Requested Bandwidth mode to set. Values can be found from \ref nvmlDeviceGetNvlinkSupportedBwModes()
+    unsigned int asyncPollTimeoutMs; //!< [out] - Time in ms to poll to validate bandwidth setting.
+} nvmlNvlinkSetBwModeAsync_v1_t;
 
 /**
  * Struct to represent per device NVLINK information v1
@@ -9859,6 +10516,26 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwMode(nvmlDevice_t device,
                                                nvmlNvlinkSetBwMode_t *setBwMode);
 
 /**
+ * Set the NvLink Reduced Bandwidth Mode asynchronously for the device. Polling should be
+ * done by checking for \a NVML_GPU_FABRIC_STATE_COMPLETED from \ref nvmlDeviceGetGpuFabricInfoV().
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param[in]     device                              The identifier of the target device
+ * @param[in,out] setBwModeAsync                      Reference to \ref nvmlNvlinkSetBwModeAsync_v1_t
+ *
+ * @return
+ *        - \ref NVML_SUCCESS                         if the Bandwidth mode was successfully set
+ *        - \ref NVML_ERROR_INVALID_ARGUMENT          if device or \p setBwModeAsync is invalid
+ *        - \ref NVML_ERROR_NO_PERMISSION             if user does not have permission to change Bandwidth mode
+ *        - \ref NVML_ERROR_NOT_SUPPORTED             if this feature is not supported by the device
+ *
+ * @see nvmlDeviceGetGpuFabricInfoV()
+ *
+ **/
+nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwModeAsync_v1(nvmlDevice_t device, nvmlNvlinkSetBwModeAsync_v1_t *setBwModeAsync);
+
+/**
  * Query NVLINK information associated with this device.
  *
  * @param[in]  device                              The identifier of the target device
@@ -9874,6 +10551,66 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwMode(nvmlDevice_t device,
  *         - \ref NVML_ERROR_UNKNOWN                    on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkInfo(nvmlDevice_t device, nvmlNvLinkInfo_t *info);
+
+/**
+ * Per-link NVLink telemetry sample types.
+ */
+typedef enum
+{
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_TX = 0, //!< Raw TX flit counter for a single link
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_RX = 1, //!< Raw RX flit counter for a single link
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_COUNT             = 2  //!< Number of valid sample types
+} nvmlNvlinkTelemetrySampleType_t;
+
+/**
+ * Struct representing one (link, metric) telemetry request / response slot.
+ */
+typedef struct
+{
+    unsigned int linkId;         //!<[in] LinkId
+    unsigned int sampleType;     //!<[in] Type of telemetry to sample, specified by `nvmlNvlinkTelemetrySampleType_t`
+    unsigned int sampleCount;    //!<[in,out]: Number of samples users need to allocate. If set to 0, will return max
+                                 //! supported count of samples without touching the `samples` pointer.
+    unsigned long long *samples; //!<[in,out]: Array of samples allocated by the user. Can be set to NULL when getting count
+    nvmlReturn_t nvmlReturn;     //!<[out]: Return code for retrieving this sample. This must be checked by the client
+                                 //! before looking at any output values, as they are invalid if `nvmlReturn != NVML_SUCCESS`.
+} nvmlNvlinkTelemetrySample_v1_t;
+
+/**
+ * Batched NVLink telemetry request.
+ */
+typedef struct
+{
+    unsigned int telemetryCount;                      //!<[in]     Number of valid entries in \a telemetrySamples
+    nvmlNvlinkTelemetrySample_v1_t *telemetrySamples; //!<[in,out] Caller-allocated array of \a telemetryCount request slots
+} nvmlNvlinkTelemetrySamples_v1_t;
+
+/**
+ * \brief Retrieve a batch of historical NVLink per-link telemetry samples.
+ *
+ * Samples are taken at approximately 100 ms intervals.
+ * Intended for use with periodic polling every ~2 seconds.
+ * Longer polling intervals are possible, but can result in dropped samples
+ * if the supported `sampleCount` is too low for the given polling interval.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param[in]     device  The device handle of the GPU to retrieve samples for
+ * @param[in,out] samples Request/response batch (see \ref nvmlNvlinkTelemetrySamples_v1_t)
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 If the call succeeded.
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If any required pointer is NULL,
+ *                                             a given enum value is out of range,
+ *                                             a slot's `linkId` is out of range,
+ *                                             a slot's `sampleCount` is non-zero with a NULL `samples` pointer, or
+ *                                             a slot's `sampleCount` is greater than the supported `sampleCount` for the given link.
+ *         - \ref NVML_ERROR_GPU_IS_LOST       If the target GPU has fallen off the bus or is otherwise inaccessible.
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If the given device does not support this API.
+ *         - \ref NVML_ERROR_UNKNOWN           On any unexpected error.
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkTelemetrySamples_v1(nvmlDevice_t device,
+                                                            nvmlNvlinkTelemetrySamples_v1_t *samples);
 
 /** @} */ // @defgroup NvLink NvLink Methods
 
@@ -9989,7 +10726,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @return
  *         - \ref NVML_SUCCESS                 if the data has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a data is NULL
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a data is NULL
  *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
  *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -9998,6 +10735,227 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @see nvmlDeviceRegisterEvents
  */
 nvmlReturn_t DECLDIR nvmlEventSetWait_v2(nvmlEventSet_t set, nvmlEventData_t * data, unsigned int timeoutms);
+
+/**
+ * @brief Adds a GPU Operational Event subscription to an event set.
+ *
+ * This API is separate from \ref nvmlDeviceRegisterEvents. Calling this API opts the event set into
+ * the structured GPU Operational Event format for the target GPU UUID. Subscriptions are identified
+ * by \a config; registering the same subscription more than once is treated as success.
+ *
+ * \ref nvmlDeviceRegisterEvents and \ref nvmlEventSetRegisterGpuOperationalEvents_v1 may both be used on the same
+ * event set. In that mixed-subscription model, NVML event-bit subscriptions continue to deliver event
+ * bits such as \ref nvmlEventTypeXidCriticalError, while GPU Operational Event subscriptions deliver
+ * \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT records through \ref nvmlEventSetWait_v3 with
+ * \c eventType set to \ref nvmlEventTypeNone. The same underlying incident may generate both an NVML
+ * event-bit notification and a structured notification; NVML does not deduplicate those notifications.
+ *
+ * This API supports GPU UUID subscriptions. MIG UUIDs are not supported by this version.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] eventSet                         Event set created by \ref nvmlEventSetCreate
+ * @param[in] config                           GPU Operational Event subscription configuration
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the GPU Operational Event subscription was registered
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a eventSet or \a config is invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if structured GPU Operational Events are not supported on this platform,
+ *                                             or if the requested subscription is not supported
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the caller lacks permission for the requested scope
+ *         - \ref NVML_ERROR_INSUFFICIENT_RESOURCES
+ *                                             if the event set cannot accept another subscription
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlGpuOperationalEventConfig_v1_t
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetFree
+ */
+nvmlReturn_t DECLDIR nvmlEventSetRegisterGpuOperationalEvents_v1(nvmlEventSet_t eventSet,
+                                                                  const nvmlGpuOperationalEventConfig_v1_t *config);
+
+/**
+ * @brief Waits on an event set and returns the next event in the extended event format.
+ *
+ * This API is the unified wait surface for NVML event-bit subscriptions registered with
+ * \ref nvmlDeviceRegisterEvents and structured GPU Operational Event subscriptions registered with
+ * \ref nvmlEventSetRegisterGpuOperationalEvents_v1.
+ *
+ * The returned format is distinguished by \c dataType in \a data. If \c dataType is
+ * \ref NVML_EVENT_DATA_TYPE_NVML_EVENT, the event came from the \ref nvmlDeviceRegisterEvents path,
+ * \c eventType is an NVML event bit such as \ref nvmlEventTypeXidCriticalError, and the existing
+ * fields preserve their historical semantics. If \c dataType is
+ * \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT, the event came from the structured format,
+ * \c eventType is \ref nvmlEventTypeNone, and the structured metadata fields are populated.
+ *
+ * When an event set contains only NVML event-bit subscriptions, this API normalizes those events into
+ * \ref nvmlEventData_v2_t. When an event set contains both NVML event-bit and structured subscriptions,
+ * each successful call returns the next available event from either path. Clients should branch on
+ * \c dataType to determine which format was returned. An event set is not required to have
+ * structured GPU Operational Event subscriptions to be used with this API.
+ *
+ * During the transition period, if a client subscribes to both NVML event-bit and structured notifications
+ * for the same GPU, the same underlying incident may generate both an NVML event-bit notification and a
+ * structured notification. NVML does not deduplicate those notifications.
+ *
+ * Context records for the returned event, if any, are made available through
+ * \ref nvmlEventSetGetContextCount_v1, \ref nvmlEventSetGetContextInfo_v1, and
+ * \ref nvmlEventSetGetContextData_v1. Context records remain associated with the event set until the
+ * next successful call to \ref nvmlEventSetWait_v3 on the same event set or until the event set is freed.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Reference to set of events to wait on
+ * @param[out] data                            Reference in which to return extended event data
+ * @param[in] timeoutms                        Maximum amount of wait time in milliseconds for registered event
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the data has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a data is NULL
+ *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_MEMORY            if system memory is insufficient
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventData_v2_t
+ * @see nvmlDeviceRegisterEvents
+ * @see nvmlEventSetRegisterGpuOperationalEvents_v1
+ * @see nvmlEventSetGetContextCount_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetWait_v3(nvmlEventSet_t set, nvmlEventData_v2_t *data, unsigned int timeoutms);
+
+/**
+ * @brief Gets the number of context records for the most recent event returned by
+ * \ref nvmlEventSetWait_v3 on this event set.
+ *
+ * This count is tied to the event set, not to a caller-owned copy of \ref nvmlEventData_v2_t. It is
+ * replaced by the next successful call to \ref nvmlEventSetWait_v3 on the same event set.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[out] count                           Reference in which to return the number of context records
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a count has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a count is NULL
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetGetContextInfo_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextCount_v1(nvmlEventSet_t set, unsigned int *count);
+
+/**
+ * @brief Gets metadata for a context record from the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * The returned metadata identifies the NVML public interpretation, the source-defined context payload
+ * type, payload size, and payload format version. The raw payload for any context record can be
+ * copied with \ref nvmlEventSetGetContextData_v1 and decoded using the public operational event
+ * schema or documentation for
+ * \ref nvmlOperationalEventContextInfo_v1_t::sourceEventContextType. When
+ * \c nvmlGpuOperationalEventContextType names a type-specific accessor, callers may use that
+ * accessor instead. Metadata is replaced by the next successful call to \ref nvmlEventSetWait_v3
+ * on the same event set.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in] index                            Zero-based context index
+ * @param[out] info                            Reference in which to return context metadata
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the context metadata has been returned
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \a index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlOperationalEventContextInfo_v1_t
+ * @see nvmlEventSetGetContextCount_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextInfo_v1(nvmlEventSet_t set, unsigned int index,
+                                                   nvmlOperationalEventContextInfo_v1_t *info);
+
+/**
+ * @brief Copies the raw payload for a context record from the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * Passing \a data as NULL performs a size query. In that case \a dataSize is set to the required
+ * payload size and the function returns \ref NVML_ERROR_INSUFFICIENT_SIZE when the payload is
+ * non-empty. If the context payload is empty, \a dataSize is set to 0 and the function returns
+ * \ref NVML_SUCCESS.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in] index                            Zero-based context index
+ * @param[out] data                            Optional caller-owned buffer for raw context payload
+ * @param[in,out] dataSize                     Size of \a data on input; actual or required size on output
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the raw context payload has been copied
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \a index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a data is NULL or too small for a non-empty payload
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetGetContextCount_v1
+ * @see nvmlEventSetGetContextInfo_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextData_v1(nvmlEventSet_t set, unsigned int index,
+                                                   void *data, unsigned int *dataSize);
+
+/**
+ * @brief Gets decoded GPU legacy-Xid context data for a context record from the most recent event returned
+ * by \ref nvmlEventSetWait_v3.
+ *
+ * This helper succeeds only for context records whose \c nvmlGpuOperationalEventContextType is
+ * \ref NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID. Other context records remain available
+ * through \ref nvmlEventSetGetContextData_v1.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in] index                            Zero-based context index
+ * @param[out] xid                             Reference in which to return legacy-Xid context data
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the GPU legacy-Xid context has been returned
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \a index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned or the context is not a GPU legacy-Xid context
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlGpuOperationalEventContextLegacyXid_v1_t
+ * @see nvmlEventSetGetContextInfo_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(nvmlEventSet_t set, unsigned int index,
+                                                                           nvmlGpuOperationalEventContextLegacyXid_v1_t *xid);
 
 /**
  * Releases events in the set
@@ -12404,33 +13362,44 @@ typedef struct
  */
 nvmlReturn_t DECLDIR nvmlDeviceReadWritePRM_v1(nvmlDevice_t device, nvmlPRMTLV_v1_t *buffer);
 
-/** @} */
-
 /**
  * PRM Counter IDs
  */
 typedef enum
 {
-    NVML_PRM_COUNTER_ID_NONE = 0,
+    NVML_PRM_COUNTER_ID_NONE = 0,                                                                       //!< Sentinel
+                                                                                                        //
     /* Physical Layer Counters (PPCNT group 0x12) */
-    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS = 1,
-    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS = 2,
+    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS = 1,                                 //!< PPCNT group 0x12, link_down_events
+    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS = 2,                       //!< PPCNT group 0x12, successful_recovery_events
+
     /* Recovery counters (PPCNT group 0x1A) */
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS = 101,
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY = 102,
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES = 103,
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS = 101,                     //!< PPCNT group 0x1A, total_successful_recovery_events
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY = 102,                             //!< PPCNT group 0x1A, time_since_last_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES = 103,                     //!< PPCNT group 0x1A, time_between_last_two_recoveries
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_IN_LAST_HOST_SERDES_FEQ_RECOVERY = 104,                //!< PPCNT group 0x1A, time_in_last_host_serdes_feq_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_TIME_IN_HOST_SERDES_FEQ_RECOVERY = 105,               //!< PPCNT group 0x1A, total_time_in_host_serdes_feq_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_RECOVERY_COUNT = 106,                 //!< PPCNT group 0x1A, total_host_serdes_feq_recovery_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_SUCCESSFUL_RECOVERY_COUNT = 107,      //!< PPCNT group 0x1A, total_host_serdes_feq_successful_recovery_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_HOST_SERDES_FEQ_ATTEMPTS_COUNT = 108,                  //!< PPCNT group 0x1A, last_host_serdes_feq_attempts_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_STEP_ATTEMPTS = 109,               //!< PPCNT group 0x1A, last_successful_recovery_step_attempts
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_TIME = 110,                        //!< PPCNT group 0x1A, last_successful_recovery_time
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_TIME = 111,                       //!< PPCNT group 0x1A, total_successful_recovery_time
+
     /* Infiniband PortCounters Attribute (PPCNT group 0x20) */
-    NVML_PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT = 201,
+    NVML_PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT = 201,                                        //!< PPCNT group 0x20, port_xmit_wait
+
     /* PLR counters (PPCNT group 0x22) */
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES = 301,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR = 302,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE = 303,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES = 304,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES = 305,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS = 306,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS = 307,
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES = 301,                                                      //!< PPCNT group 0x22, plr_rcv_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR = 302,                                                   //!< PPCNT group 0x22, plr_rcv_code_err
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE = 303,                                         //!< PPCNT group 0x22, plr_rcv_uncorrectable_code
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES = 304,                                                     //!< PPCNT group 0x22, plr_xmit_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES = 305,                                               //!< PPCNT group 0x22, plr_xmit_retry_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS = 306,                                              //!< PPCNT group 0x22, plr_xmit_retry_events
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS = 307,                                                    //!< PPCNT group 0x22, plr_sync_events
+
     /* PPRM counters */
-    NVML_PRM_COUNTER_ID_PPRM_OPER_RECOVERY = 1001,
+    NVML_PRM_COUNTER_ID_PPRM_OPER_RECOVERY = 1001,                                                      //!< PPRM, oper_recovery
 } nvmlPRMCounterId_t;
 
 /**
@@ -12490,6 +13459,7 @@ typedef struct
  *        - \ref NVML_ERROR_UNKNOWN                     on any other error
  */
 nvmlReturn_t DECLDIR nvmlDeviceReadPRMCounters_v1(nvmlDevice_t device, nvmlPRMCounterList_v1_t *counterList);
+/** @} */
 
 /***************************************************************************************************/
 /** @defgroup nvmlMultiInstanceGPU Multi Instance GPU Management
@@ -13574,152 +14544,152 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L16_TX_PER_SEC       = 95,   //!< NvLink write bandwidth for link 16 in MiB/sec
     NVML_GPM_METRIC_NVLINK_L17_RX_PER_SEC       = 96,   //!< NvLink read bandwidth for link 17 in MiB/sec
     NVML_GPM_METRIC_NVLINK_L17_TX_PER_SEC       = 97,   //!< NvLink write bandwidth for link 17 in MiB/sec
-    NVML_GPM_METRIC_C2C_TOTAL_TX_PER_SEC        = 100,
-    NVML_GPM_METRIC_C2C_TOTAL_RX_PER_SEC        = 101,
-    NVML_GPM_METRIC_C2C_DATA_TX_PER_SEC         = 102,
-    NVML_GPM_METRIC_C2C_DATA_RX_PER_SEC         = 103,
-    NVML_GPM_METRIC_C2C_LINK0_TOTAL_TX_PER_SEC  = 104,
-    NVML_GPM_METRIC_C2C_LINK0_TOTAL_RX_PER_SEC  = 105,
-    NVML_GPM_METRIC_C2C_LINK0_DATA_TX_PER_SEC   = 106,
-    NVML_GPM_METRIC_C2C_LINK0_DATA_RX_PER_SEC   = 107,
-    NVML_GPM_METRIC_C2C_LINK1_TOTAL_TX_PER_SEC  = 108,
-    NVML_GPM_METRIC_C2C_LINK1_TOTAL_RX_PER_SEC  = 109,
-    NVML_GPM_METRIC_C2C_LINK1_DATA_TX_PER_SEC   = 110,
-    NVML_GPM_METRIC_C2C_LINK1_DATA_RX_PER_SEC   = 111,
-    NVML_GPM_METRIC_C2C_LINK2_TOTAL_TX_PER_SEC  = 112,
-    NVML_GPM_METRIC_C2C_LINK2_TOTAL_RX_PER_SEC  = 113,
-    NVML_GPM_METRIC_C2C_LINK2_DATA_TX_PER_SEC   = 114,
-    NVML_GPM_METRIC_C2C_LINK2_DATA_RX_PER_SEC   = 115,
-    NVML_GPM_METRIC_C2C_LINK3_TOTAL_TX_PER_SEC  = 116,
-    NVML_GPM_METRIC_C2C_LINK3_TOTAL_RX_PER_SEC  = 117,
-    NVML_GPM_METRIC_C2C_LINK3_DATA_TX_PER_SEC   = 118,
-    NVML_GPM_METRIC_C2C_LINK3_DATA_RX_PER_SEC   = 119,
-    NVML_GPM_METRIC_C2C_LINK4_TOTAL_TX_PER_SEC  = 120,
-    NVML_GPM_METRIC_C2C_LINK4_TOTAL_RX_PER_SEC  = 121,
-    NVML_GPM_METRIC_C2C_LINK4_DATA_TX_PER_SEC   = 122,
-    NVML_GPM_METRIC_C2C_LINK4_DATA_RX_PER_SEC   = 123,
-    NVML_GPM_METRIC_C2C_LINK5_TOTAL_TX_PER_SEC  = 124,
-    NVML_GPM_METRIC_C2C_LINK5_TOTAL_RX_PER_SEC  = 125,
-    NVML_GPM_METRIC_C2C_LINK5_DATA_TX_PER_SEC   = 126,
-    NVML_GPM_METRIC_C2C_LINK5_DATA_RX_PER_SEC   = 127,
-    NVML_GPM_METRIC_C2C_LINK6_TOTAL_TX_PER_SEC  = 128,
-    NVML_GPM_METRIC_C2C_LINK6_TOTAL_RX_PER_SEC  = 129,
-    NVML_GPM_METRIC_C2C_LINK6_DATA_TX_PER_SEC   = 130,
-    NVML_GPM_METRIC_C2C_LINK6_DATA_RX_PER_SEC   = 131,
-    NVML_GPM_METRIC_C2C_LINK7_TOTAL_TX_PER_SEC  = 132,
-    NVML_GPM_METRIC_C2C_LINK7_TOTAL_RX_PER_SEC  = 133,
-    NVML_GPM_METRIC_C2C_LINK7_DATA_TX_PER_SEC   = 134,
-    NVML_GPM_METRIC_C2C_LINK7_DATA_RX_PER_SEC   = 135,
-    NVML_GPM_METRIC_C2C_LINK8_TOTAL_TX_PER_SEC  = 136,
-    NVML_GPM_METRIC_C2C_LINK8_TOTAL_RX_PER_SEC  = 137,
-    NVML_GPM_METRIC_C2C_LINK8_DATA_TX_PER_SEC   = 138,
-    NVML_GPM_METRIC_C2C_LINK8_DATA_RX_PER_SEC   = 139,
-    NVML_GPM_METRIC_C2C_LINK9_TOTAL_TX_PER_SEC  = 140,
-    NVML_GPM_METRIC_C2C_LINK9_TOTAL_RX_PER_SEC  = 141,
-    NVML_GPM_METRIC_C2C_LINK9_DATA_TX_PER_SEC   = 142,
-    NVML_GPM_METRIC_C2C_LINK9_DATA_RX_PER_SEC   = 143,
-    NVML_GPM_METRIC_C2C_LINK10_TOTAL_TX_PER_SEC = 144,
-    NVML_GPM_METRIC_C2C_LINK10_TOTAL_RX_PER_SEC = 145,
-    NVML_GPM_METRIC_C2C_LINK10_DATA_TX_PER_SEC  = 146,
-    NVML_GPM_METRIC_C2C_LINK10_DATA_RX_PER_SEC  = 147,
-    NVML_GPM_METRIC_C2C_LINK11_TOTAL_TX_PER_SEC = 148,
-    NVML_GPM_METRIC_C2C_LINK11_TOTAL_RX_PER_SEC = 149,
-    NVML_GPM_METRIC_C2C_LINK11_DATA_TX_PER_SEC  = 150,
-    NVML_GPM_METRIC_C2C_LINK11_DATA_RX_PER_SEC  = 151,
-    NVML_GPM_METRIC_C2C_LINK12_TOTAL_TX_PER_SEC = 152,
-    NVML_GPM_METRIC_C2C_LINK12_TOTAL_RX_PER_SEC = 153,
-    NVML_GPM_METRIC_C2C_LINK12_DATA_TX_PER_SEC  = 154,
-    NVML_GPM_METRIC_C2C_LINK12_DATA_RX_PER_SEC  = 155,
-    NVML_GPM_METRIC_C2C_LINK13_TOTAL_TX_PER_SEC = 156,
-    NVML_GPM_METRIC_C2C_LINK13_TOTAL_RX_PER_SEC = 157,
-    NVML_GPM_METRIC_C2C_LINK13_DATA_TX_PER_SEC  = 158,
-    NVML_GPM_METRIC_C2C_LINK13_DATA_RX_PER_SEC  = 159,
-    NVML_GPM_METRIC_HOSTMEM_CACHE_HIT           = 160,
-    NVML_GPM_METRIC_HOSTMEM_CACHE_MISS          = 161,
-    NVML_GPM_METRIC_PEERMEM_CACHE_HIT           = 162,
-    NVML_GPM_METRIC_PEERMEM_CACHE_MISS          = 163,
-    NVML_GPM_METRIC_DRAM_CACHE_HIT              = 164,
-    NVML_GPM_METRIC_DRAM_CACHE_MISS             = 165,
-    NVML_GPM_METRIC_NVENC_0_UTIL                = 166,
-    NVML_GPM_METRIC_NVENC_1_UTIL                = 167,
-    NVML_GPM_METRIC_NVENC_2_UTIL                = 168,
-    NVML_GPM_METRIC_NVENC_3_UTIL                = 169,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ELAPSED    = 170,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ACTIVE     = 171,
-    NVML_GPM_METRIC_GR0_CTXSW_REQUESTS          = 172,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_PER_REQ    = 173,
-    NVML_GPM_METRIC_GR0_CTXSW_ACTIVE_PCT        = 174,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ELAPSED    = 175,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ACTIVE     = 176,
-    NVML_GPM_METRIC_GR1_CTXSW_REQUESTS          = 177,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_PER_REQ    = 178,
-    NVML_GPM_METRIC_GR1_CTXSW_ACTIVE_PCT        = 179,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ELAPSED    = 180,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ACTIVE     = 181,
-    NVML_GPM_METRIC_GR2_CTXSW_REQUESTS          = 182,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_PER_REQ    = 183,
-    NVML_GPM_METRIC_GR2_CTXSW_ACTIVE_PCT        = 184,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ELAPSED    = 185,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ACTIVE     = 186,
-    NVML_GPM_METRIC_GR3_CTXSW_REQUESTS          = 187,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_PER_REQ    = 188,
-    NVML_GPM_METRIC_GR3_CTXSW_ACTIVE_PCT        = 189,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ELAPSED    = 190,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ACTIVE     = 191,
-    NVML_GPM_METRIC_GR4_CTXSW_REQUESTS          = 192,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_PER_REQ    = 193,
-    NVML_GPM_METRIC_GR4_CTXSW_ACTIVE_PCT        = 194,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ELAPSED    = 195,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ACTIVE     = 196,
-    NVML_GPM_METRIC_GR5_CTXSW_REQUESTS          = 197,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_PER_REQ    = 198,
-    NVML_GPM_METRIC_GR5_CTXSW_ACTIVE_PCT        = 199,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ELAPSED    = 200,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ACTIVE     = 201,
-    NVML_GPM_METRIC_GR6_CTXSW_REQUESTS          = 202,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_PER_REQ    = 203,
-    NVML_GPM_METRIC_GR6_CTXSW_ACTIVE_PCT        = 204,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ELAPSED    = 205,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ACTIVE     = 206,
-    NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,
-    NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,
-    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,
-    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,
-    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,
-    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,
-    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,
-    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,
-    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,
-    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,
-    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,
-    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,
-    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,
-    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,
-    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,
-    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,
-    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,
-    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,
-    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,
-    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,
-    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,
-    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,
-    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,
-    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,
-    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,
-    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,
-    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,
-    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,
-    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,
-    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,
-    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,
-    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,
-    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,
-    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,
-    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,
-    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,
-    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,
-    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,
+    NVML_GPM_METRIC_C2C_TOTAL_TX_PER_SEC        = 100,  //!< C2C total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_TOTAL_RX_PER_SEC        = 101,  //!< C2C total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_DATA_TX_PER_SEC         = 102,  //!< C2C data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_DATA_RX_PER_SEC         = 103,  //!< C2C data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_TOTAL_TX_PER_SEC  = 104,  //!< C2C link 0 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_TOTAL_RX_PER_SEC  = 105,  //!< C2C link 0 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_DATA_TX_PER_SEC   = 106,  //!< C2C link 0 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_DATA_RX_PER_SEC   = 107,  //!< C2C link 0 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_TOTAL_TX_PER_SEC  = 108,  //!< C2C link 1 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_TOTAL_RX_PER_SEC  = 109,  //!< C2C link 1 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_DATA_TX_PER_SEC   = 110,  //!< C2C link 1 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_DATA_RX_PER_SEC   = 111,  //!< C2C link 1 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_TOTAL_TX_PER_SEC  = 112,  //!< C2C link 2 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_TOTAL_RX_PER_SEC  = 113,  //!< C2C link 2 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_DATA_TX_PER_SEC   = 114,  //!< C2C link 2 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_DATA_RX_PER_SEC   = 115,  //!< C2C link 2 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_TOTAL_TX_PER_SEC  = 116,  //!< C2C link 3 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_TOTAL_RX_PER_SEC  = 117,  //!< C2C link 3 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_DATA_TX_PER_SEC   = 118,  //!< C2C link 3 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_DATA_RX_PER_SEC   = 119,  //!< C2C link 3 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_TOTAL_TX_PER_SEC  = 120,  //!< C2C link 4 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_TOTAL_RX_PER_SEC  = 121,  //!< C2C link 4 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_DATA_TX_PER_SEC   = 122,  //!< C2C link 4 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_DATA_RX_PER_SEC   = 123,  //!< C2C link 4 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_TOTAL_TX_PER_SEC  = 124,  //!< C2C link 5 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_TOTAL_RX_PER_SEC  = 125,  //!< C2C link 5 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_DATA_TX_PER_SEC   = 126,  //!< C2C link 5 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_DATA_RX_PER_SEC   = 127,  //!< C2C link 5 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_TOTAL_TX_PER_SEC  = 128,  //!< C2C link 6 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_TOTAL_RX_PER_SEC  = 129,  //!< C2C link 6 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_DATA_TX_PER_SEC   = 130,  //!< C2C link 6 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_DATA_RX_PER_SEC   = 131,  //!< C2C link 6 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_TOTAL_TX_PER_SEC  = 132,  //!< C2C link 7 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_TOTAL_RX_PER_SEC  = 133,  //!< C2C link 7 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_DATA_TX_PER_SEC   = 134,  //!< C2C link 7 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_DATA_RX_PER_SEC   = 135,  //!< C2C link 7 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_TOTAL_TX_PER_SEC  = 136,  //!< C2C link 8 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_TOTAL_RX_PER_SEC  = 137,  //!< C2C link 8 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_DATA_TX_PER_SEC   = 138,  //!< C2C link 8 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_DATA_RX_PER_SEC   = 139,  //!< C2C link 8 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_TOTAL_TX_PER_SEC  = 140,  //!< C2C link 9 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_TOTAL_RX_PER_SEC  = 141,  //!< C2C link 9 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_DATA_TX_PER_SEC   = 142,  //!< C2C link 9 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_DATA_RX_PER_SEC   = 143,  //!< C2C link 9 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_TOTAL_TX_PER_SEC = 144,  //!< C2C link 10 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_TOTAL_RX_PER_SEC = 145,  //!< C2C link 10 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_DATA_TX_PER_SEC  = 146,  //!< C2C link 10 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_DATA_RX_PER_SEC  = 147,  //!< C2C link 10 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_TOTAL_TX_PER_SEC = 148,  //!< C2C link 11 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_TOTAL_RX_PER_SEC = 149,  //!< C2C link 11 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_DATA_TX_PER_SEC  = 150,  //!< C2C link 11 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_DATA_RX_PER_SEC  = 151,  //!< C2C link 11 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_TOTAL_TX_PER_SEC = 152,  //!< C2C link 12 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_TOTAL_RX_PER_SEC = 153,  //!< C2C link 12 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_DATA_TX_PER_SEC  = 154,  //!< C2C link 12 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_DATA_RX_PER_SEC  = 155,  //!< C2C link 12 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_TOTAL_TX_PER_SEC = 156,  //!< C2C link 13 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_TOTAL_RX_PER_SEC = 157,  //!< C2C link 13 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_DATA_TX_PER_SEC  = 158,  //!< C2C link 13 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_DATA_RX_PER_SEC  = 159,  //!< C2C link 13 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_HOSTMEM_CACHE_HIT           = 160,  //!< Percentage of host memory cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_HOSTMEM_CACHE_MISS          = 161,  //!< Percentage of host memory cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_PEERMEM_CACHE_HIT           = 162,  //!< Percentage of peer memory cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_PEERMEM_CACHE_MISS          = 163,  //!< Percentage of peer memory cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_DRAM_CACHE_HIT              = 164,  //!< Percentage of DRAM cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_DRAM_CACHE_MISS             = 165,  //!< Percentage of DRAM cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_0_UTIL                = 166,  //!< Percent utilization of NVENC 0. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_1_UTIL                = 167,  //!< Percent utilization of NVENC 1. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_2_UTIL                = 168,  //!< Percent utilization of NVENC 2. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_3_UTIL                = 169,  //!< Percent utilization of NVENC 3. 0.0 - 100.0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ELAPSED    = 170,  //!< Total context switch cycles elapsed for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ACTIVE     = 171,  //!< Active context switch cycles for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_REQUESTS          = 172,  //!< Number of context switch requests for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_PER_REQ    = 173,  //!< Average context switch cycles per request for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_ACTIVE_PCT        = 174,  //!< Percentage of time GR engine 0 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ELAPSED    = 175,  //!< Total context switch cycles elapsed for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ACTIVE     = 176,  //!< Active context switch cycles for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_REQUESTS          = 177,  //!< Number of context switch requests for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_PER_REQ    = 178,  //!< Average context switch cycles per request for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_ACTIVE_PCT        = 179,  //!< Percentage of time GR engine 1 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ELAPSED    = 180,  //!< Total context switch cycles elapsed for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ACTIVE     = 181,  //!< Active context switch cycles for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_REQUESTS          = 182,  //!< Number of context switch requests for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_PER_REQ    = 183,  //!< Average context switch cycles per request for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_ACTIVE_PCT        = 184,  //!< Percentage of time GR engine 2 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ELAPSED    = 185,  //!< Total context switch cycles elapsed for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ACTIVE     = 186,  //!< Active context switch cycles for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_REQUESTS          = 187,  //!< Number of context switch requests for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_PER_REQ    = 188,  //!< Average context switch cycles per request for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_ACTIVE_PCT        = 189,  //!< Percentage of time GR engine 3 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ELAPSED    = 190,  //!< Total context switch cycles elapsed for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ACTIVE     = 191,  //!< Active context switch cycles for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_REQUESTS          = 192,  //!< Number of context switch requests for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_PER_REQ    = 193,  //!< Average context switch cycles per request for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_ACTIVE_PCT        = 194,  //!< Percentage of time GR engine 4 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ELAPSED    = 195,  //!< Total context switch cycles elapsed for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ACTIVE     = 196,  //!< Active context switch cycles for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_REQUESTS          = 197,  //!< Number of context switch requests for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_PER_REQ    = 198,  //!< Average context switch cycles per request for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_ACTIVE_PCT        = 199,  //!< Percentage of time GR engine 5 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ELAPSED    = 200,  //!< Total context switch cycles elapsed for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ACTIVE     = 201,  //!< Active context switch cycles for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_REQUESTS          = 202,  //!< Number of context switch requests for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_PER_REQ    = 203,  //!< Average context switch cycles per request for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_ACTIVE_PCT        = 204,  //!< Percentage of time GR engine 6 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ELAPSED    = 205,  //!< Total context switch cycles elapsed for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ACTIVE     = 206,  //!< Active context switch cycles for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,  //!< Number of context switch requests for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,  //!< Average context switch cycles per request for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,  //!< Percentage of time GR engine 7 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,  //!< NvLink read bandwidth for link 18 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,  //!< NvLink write bandwidth for link 18 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,  //!< NvLink read bandwidth for link 19 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,  //!< NvLink write bandwidth for link 19 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,  //!< NvLink read bandwidth for link 20 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,  //!< NvLink write bandwidth for link 20 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,  //!< NvLink read bandwidth for link 21 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,  //!< NvLink write bandwidth for link 21 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,  //!< NvLink read bandwidth for link 22 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,  //!< NvLink write bandwidth for link 22 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,  //!< NvLink read bandwidth for link 23 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,  //!< NvLink write bandwidth for link 23 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,  //!< NvLink read bandwidth for link 24 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,  //!< NvLink write bandwidth for link 24 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,  //!< NvLink read bandwidth for link 25 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,  //!< NvLink write bandwidth for link 25 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,  //!< NvLink read bandwidth for link 26 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,  //!< NvLink write bandwidth for link 26 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,  //!< NvLink read bandwidth for link 27 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,  //!< NvLink write bandwidth for link 27 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,  //!< NvLink read bandwidth for link 28 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,  //!< NvLink write bandwidth for link 28 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,  //!< NvLink read bandwidth for link 29 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,  //!< NvLink write bandwidth for link 29 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,  //!< NvLink read bandwidth for link 30 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,  //!< NvLink write bandwidth for link 30 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,  //!< NvLink read bandwidth for link 31 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,  //!< NvLink write bandwidth for link 31 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,  //!< NvLink read bandwidth for link 32 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,  //!< NvLink write bandwidth for link 32 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,  //!< NvLink read bandwidth for link 33 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,  //!< NvLink write bandwidth for link 33 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,  //!< NvLink read bandwidth for link 34 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,  //!< NvLink write bandwidth for link 34 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,  //!< NvLink read bandwidth for link 35 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,  //!< NvLink write bandwidth for link 35 in MiB/sec
     NVML_GPM_METRIC_SM_CYCLES_ELAPSED           = 248,  //!< The GPU's SM cycles elapsed since reboot
     NVML_GPM_METRIC_SM_CYCLES_ACTIVE            = 249,  //!< The GPU's SM activity since reboot
     NVML_GPM_METRIC_MMA_CYCLES_ACTIVE           = 250,  //!< The GPU's SM MMA tensor activity since reboot
@@ -13731,8 +14701,8 @@ typedef enum
     NVML_GPM_METRIC_PCIE_RX                     = 256,  //!< The PCIe RX traffic since reboot
     NVML_GPM_METRIC_INTEGER_CYCLES_ACTIVE       = 257,  //!< The GPU's SM integer activity since reboot
     NVML_GPM_METRIC_FP64_CYCLES_ACTIVE          = 258,  //!< The GPU's SM FP64 activity since reboot
-    NVML_GPM_METRIC_FP32_CYCLES_ACTIVE          = 259,  //!< The GPU's SM FP64 activity since reboot
-    NVML_GPM_METRIC_FP16_CYCLES_ACTIVE          = 260,  //!< The GPU's SM FP64 activity since reboot
+    NVML_GPM_METRIC_FP32_CYCLES_ACTIVE          = 259,  //!< The GPU's SM FP32 activity since reboot
+    NVML_GPM_METRIC_FP16_CYCLES_ACTIVE          = 260,  //!< The GPU's SM FP16 activity since reboot
     NVML_GPM_METRIC_NVLINK_L0_RX                = 261,  //!< NvLink read for link 0 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L0_TX                = 262,  //!< NvLink write for link 0 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L1_RX                = 263,  //!< NvLink read for link 1 in bytes since reboot
@@ -13805,7 +14775,151 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L34_TX               = 330,  //!< NvLink write for link 34 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L35_RX               = 331,  //!< NvLink read for link 35 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L35_TX               = 332,  //!< NvLink write for link 35 in bytes since reboot
-    NVML_GPM_METRIC_MAX                         = 333,  //!< Maximum value above +1
+    NVML_GPM_METRIC_NVLINK_L36_RX               = 333,  //!< NvLink read for link 36 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L36_TX               = 334,  //!< NvLink write for link 36 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L37_RX               = 335,  //!< NvLink read for link 37 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L37_TX               = 336,  //!< NvLink write for link 37 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L38_RX               = 337,  //!< NvLink read for link 38 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L38_TX               = 338,  //!< NvLink write for link 38 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L39_RX               = 339,  //!< NvLink read for link 39 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L39_TX               = 340,  //!< NvLink write for link 39 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L40_RX               = 341,  //!< NvLink read for link 40 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L40_TX               = 342,  //!< NvLink write for link 40 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L41_RX               = 343,  //!< NvLink read for link 41 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L41_TX               = 344,  //!< NvLink write for link 41 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L42_RX               = 345,  //!< NvLink read for link 42 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L42_TX               = 346,  //!< NvLink write for link 42 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L43_RX               = 347,  //!< NvLink read for link 43 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L43_TX               = 348,  //!< NvLink write for link 43 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L44_RX               = 349,  //!< NvLink read for link 44 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L44_TX               = 350,  //!< NvLink write for link 44 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L45_RX               = 351,  //!< NvLink read for link 45 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L45_TX               = 352,  //!< NvLink write for link 45 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L46_RX               = 353,  //!< NvLink read for link 46 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L46_TX               = 354,  //!< NvLink write for link 46 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L47_RX               = 355,  //!< NvLink read for link 47 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L47_TX               = 356,  //!< NvLink write for link 47 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L48_RX               = 357,  //!< NvLink read for link 48 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L48_TX               = 358,  //!< NvLink write for link 48 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L49_RX               = 359,  //!< NvLink read for link 49 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L49_TX               = 360,  //!< NvLink write for link 49 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L50_RX               = 361,  //!< NvLink read for link 50 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L50_TX               = 362,  //!< NvLink write for link 50 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L51_RX               = 363,  //!< NvLink read for link 51 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L51_TX               = 364,  //!< NvLink write for link 51 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L52_RX               = 365,  //!< NvLink read for link 52 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L52_TX               = 366,  //!< NvLink write for link 52 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L53_RX               = 367,  //!< NvLink read for link 53 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L53_TX               = 368,  //!< NvLink write for link 53 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L54_RX               = 369,  //!< NvLink read for link 54 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L54_TX               = 370,  //!< NvLink write for link 54 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L55_RX               = 371,  //!< NvLink read for link 55 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L55_TX               = 372,  //!< NvLink write for link 55 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L56_RX               = 373,  //!< NvLink read for link 56 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L56_TX               = 374,  //!< NvLink write for link 56 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L57_RX               = 375,  //!< NvLink read for link 57 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L57_TX               = 376,  //!< NvLink write for link 57 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L58_RX               = 377,  //!< NvLink read for link 58 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L58_TX               = 378,  //!< NvLink write for link 58 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L59_RX               = 379,  //!< NvLink read for link 59 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L59_TX               = 380,  //!< NvLink write for link 59 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L60_RX               = 381,  //!< NvLink read for link 60 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L60_TX               = 382,  //!< NvLink write for link 60 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L61_RX               = 383,  //!< NvLink read for link 61 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L61_TX               = 384,  //!< NvLink write for link 61 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L62_RX               = 385,  //!< NvLink read for link 62 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L62_TX               = 386,  //!< NvLink write for link 62 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L63_RX               = 387,  //!< NvLink read for link 63 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L63_TX               = 388,  //!< NvLink write for link 63 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L64_RX               = 389,  //!< NvLink read for link 64 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L64_TX               = 390,  //!< NvLink write for link 64 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L65_RX               = 391,  //!< NvLink read for link 65 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L65_TX               = 392,  //!< NvLink write for link 65 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L66_RX               = 393,  //!< NvLink read for link 66 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L66_TX               = 394,  //!< NvLink write for link 66 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L67_RX               = 395,  //!< NvLink read for link 67 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L67_TX               = 396,  //!< NvLink write for link 67 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L68_RX               = 397,  //!< NvLink read for link 68 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L68_TX               = 398,  //!< NvLink write for link 68 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L69_RX               = 399,  //!< NvLink read for link 69 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L69_TX               = 400,  //!< NvLink write for link 69 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L70_RX               = 401,  //!< NvLink read for link 70 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L70_TX               = 402,  //!< NvLink write for link 70 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L71_RX               = 403,  //!< NvLink read for link 71 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L71_TX               = 404,  //!< NvLink write for link 71 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L36_RX_PER_SEC       = 405,  //!< NvLink read bandwidth for link 36 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L36_TX_PER_SEC       = 406,  //!< NvLink write bandwidth for link 36 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L37_RX_PER_SEC       = 407,  //!< NvLink read bandwidth for link 37 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L37_TX_PER_SEC       = 408,  //!< NvLink write bandwidth for link 37 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L38_RX_PER_SEC       = 409,  //!< NvLink read bandwidth for link 38 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L38_TX_PER_SEC       = 410,  //!< NvLink write bandwidth for link 38 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L39_RX_PER_SEC       = 411,  //!< NvLink read bandwidth for link 39 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L39_TX_PER_SEC       = 412,  //!< NvLink write bandwidth for link 39 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L40_RX_PER_SEC       = 413,  //!< NvLink read bandwidth for link 40 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L40_TX_PER_SEC       = 414,  //!< NvLink write bandwidth for link 40 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L41_RX_PER_SEC       = 415,  //!< NvLink read bandwidth for link 41 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L41_TX_PER_SEC       = 416,  //!< NvLink write bandwidth for link 41 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L42_RX_PER_SEC       = 417,  //!< NvLink read bandwidth for link 42 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L42_TX_PER_SEC       = 418,  //!< NvLink write bandwidth for link 42 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L43_RX_PER_SEC       = 419,  //!< NvLink read bandwidth for link 43 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L43_TX_PER_SEC       = 420,  //!< NvLink write bandwidth for link 43 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L44_RX_PER_SEC       = 421,  //!< NvLink read bandwidth for link 44 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L44_TX_PER_SEC       = 422,  //!< NvLink write bandwidth for link 44 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L45_RX_PER_SEC       = 423,  //!< NvLink read bandwidth for link 45 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L45_TX_PER_SEC       = 424,  //!< NvLink write bandwidth for link 45 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L46_RX_PER_SEC       = 425,  //!< NvLink read bandwidth for link 46 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L46_TX_PER_SEC       = 426,  //!< NvLink write bandwidth for link 46 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L47_RX_PER_SEC       = 427,  //!< NvLink read bandwidth for link 47 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L47_TX_PER_SEC       = 428,  //!< NvLink write bandwidth for link 47 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L48_RX_PER_SEC       = 429,  //!< NvLink read bandwidth for link 48 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L48_TX_PER_SEC       = 430,  //!< NvLink write bandwidth for link 48 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L49_RX_PER_SEC       = 431,  //!< NvLink read bandwidth for link 49 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L49_TX_PER_SEC       = 432,  //!< NvLink write bandwidth for link 49 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L50_RX_PER_SEC       = 433,  //!< NvLink read bandwidth for link 50 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L50_TX_PER_SEC       = 434,  //!< NvLink write bandwidth for link 50 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L51_RX_PER_SEC       = 435,  //!< NvLink read bandwidth for link 51 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L51_TX_PER_SEC       = 436,  //!< NvLink write bandwidth for link 51 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L52_RX_PER_SEC       = 437,  //!< NvLink read bandwidth for link 52 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L52_TX_PER_SEC       = 438,  //!< NvLink write bandwidth for link 52 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L53_RX_PER_SEC       = 439,  //!< NvLink read bandwidth for link 53 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L53_TX_PER_SEC       = 440,  //!< NvLink write bandwidth for link 53 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L54_RX_PER_SEC       = 441,  //!< NvLink read bandwidth for link 54 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L54_TX_PER_SEC       = 442,  //!< NvLink write bandwidth for link 54 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L55_RX_PER_SEC       = 443,  //!< NvLink read bandwidth for link 55 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L55_TX_PER_SEC       = 444,  //!< NvLink write bandwidth for link 55 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L56_RX_PER_SEC       = 445,  //!< NvLink read bandwidth for link 56 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L56_TX_PER_SEC       = 446,  //!< NvLink write bandwidth for link 56 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L57_RX_PER_SEC       = 447,  //!< NvLink read bandwidth for link 57 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L57_TX_PER_SEC       = 448,  //!< NvLink write bandwidth for link 57 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L58_RX_PER_SEC       = 449,  //!< NvLink read bandwidth for link 58 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L58_TX_PER_SEC       = 450,  //!< NvLink write bandwidth for link 58 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L59_RX_PER_SEC       = 451,  //!< NvLink read bandwidth for link 59 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L59_TX_PER_SEC       = 452,  //!< NvLink write bandwidth for link 59 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L60_RX_PER_SEC       = 453,  //!< NvLink read bandwidth for link 60 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L60_TX_PER_SEC       = 454,  //!< NvLink write bandwidth for link 60 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L61_RX_PER_SEC       = 455,  //!< NvLink read bandwidth for link 61 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L61_TX_PER_SEC       = 456,  //!< NvLink write bandwidth for link 61 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L62_RX_PER_SEC       = 457,  //!< NvLink read bandwidth for link 62 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L62_TX_PER_SEC       = 458,  //!< NvLink write bandwidth for link 62 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L63_RX_PER_SEC       = 459,  //!< NvLink read bandwidth for link 63 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L63_TX_PER_SEC       = 460,  //!< NvLink write bandwidth for link 63 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L64_RX_PER_SEC       = 461,  //!< NvLink read bandwidth for link 64 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L64_TX_PER_SEC       = 462,  //!< NvLink write bandwidth for link 64 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L65_RX_PER_SEC       = 463,  //!< NvLink read bandwidth for link 65 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L65_TX_PER_SEC       = 464,  //!< NvLink write bandwidth for link 65 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L66_RX_PER_SEC       = 465,  //!< NvLink read bandwidth for link 66 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L66_TX_PER_SEC       = 466,  //!< NvLink write bandwidth for link 66 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L67_RX_PER_SEC       = 467,  //!< NvLink read bandwidth for link 67 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L67_TX_PER_SEC       = 468,  //!< NvLink write bandwidth for link 67 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L68_RX_PER_SEC       = 469,  //!< NvLink read bandwidth for link 68 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L68_TX_PER_SEC       = 470,  //!< NvLink write bandwidth for link 68 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L69_RX_PER_SEC       = 471,  //!< NvLink read bandwidth for link 69 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L69_TX_PER_SEC       = 472,  //!< NvLink write bandwidth for link 69 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L70_RX_PER_SEC       = 473,  //!< NvLink read bandwidth for link 70 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L70_TX_PER_SEC       = 474,  //!< NvLink write bandwidth for link 70 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L71_RX_PER_SEC       = 475,  //!< NvLink read bandwidth for link 71 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L71_TX_PER_SEC       = 476,  //!< NvLink write bandwidth for link 71 in MiB/sec
+    NVML_GPM_METRIC_MAX                         = 477,  //!< Maximum value above +1
 } nvmlGpmMetricId_t;
 
 /** @} */ // @defgroup nvmlGpmEnums
@@ -14090,23 +15204,33 @@ typedef struct
 #define NVML_WORKLOAD_POWER_MAX_PROFILES        (255)
 typedef enum
 {
-    NVML_POWER_PROFILE_MAX_P            = 0,
-    NVML_POWER_PROFILE_MAX_Q            = 1,
-    NVML_POWER_PROFILE_COMPUTE          = 2,
-    NVML_POWER_PROFILE_MEMORY_BOUND     = 3,
-    NVML_POWER_PROFILE_NETWORK          = 4,
-    NVML_POWER_PROFILE_BALANCED         = 5,
-    NVML_POWER_PROFILE_LLM_INFERENCE    = 6,
-    NVML_POWER_PROFILE_LLM_TRAINING     = 7,
-    NVML_POWER_PROFILE_RBM              = 8,
-    NVML_POWER_PROFILE_DCPCIE           = 9,
-    NVML_POWER_PROFILE_HMMA_SPARSE      = 10,
-    NVML_POWER_PROFILE_HMMA_DENSE       = 11,
-    NVML_POWER_PROFILE_SYNC_BALANCED    = 12,
-    NVML_POWER_PROFILE_HPC              = 13,
-    NVML_POWER_PROFILE_MIG              = 14,
+    NVML_POWER_PROFILE_MAX_P                       = 0,
+    NVML_POWER_PROFILE_MAX_Q                       = 1,
+    NVML_POWER_PROFILE_COMPUTE                     = 2,
+    NVML_POWER_PROFILE_MEMORY_BOUND                = 3,
+    NVML_POWER_PROFILE_NETWORK                     = 4,
+    NVML_POWER_PROFILE_BALANCED                    = 5,
+    NVML_POWER_PROFILE_LLM_INFERENCE               = 6,
+    NVML_POWER_PROFILE_LLM_TRAINING                = 7,
+    NVML_POWER_PROFILE_RBM                         = 8,
+    NVML_POWER_PROFILE_DCPCIE                      = 9,
+    NVML_POWER_PROFILE_HMMA_SPARSE                 = 10,
+    NVML_POWER_PROFILE_HMMA_DENSE                  = 11,
+    NVML_POWER_PROFILE_SYNC_BALANCED               = 12,
+    NVML_POWER_PROFILE_HPC                         = 13,
+    NVML_POWER_PROFILE_MIG                         = 14,
+    NVML_POWER_PROFILE_MAX_Q_1                     = 15,
+    NVML_POWER_PROFILE_NETWORK_BOUND               = 16,
+    NVML_POWER_PROFILE_HIGH_THROUGHPUT_INFERENCE   = 17,
+    NVML_POWER_PROFILE_MEDIUM_THROUGHPUT_INFERENCE = 18,
+    NVML_POWER_PROFILE_LOW_LATENCY_INFERENCE       = 19,
+    NVML_POWER_PROFILE_TRAINING                    = 20,
+    NVML_POWER_PROFILE_INFERENCE                   = 21,
+    NVML_POWER_PROFILE_MAX_Q_2                     = 22,
+    NVML_POWER_PROFILE_MAX_Q_3                     = 23,
+    NVML_POWER_PROFILE_LOW_PRIORITY_BACKGROUND     = 24,
 
-    NVML_POWER_PROFILE_MAX              = 15,
+    NVML_POWER_PROFILE_MAX                         = 25,
 } nvmlPowerProfileType_t;
 
 /**
@@ -14237,7 +15361,7 @@ nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileGetCurrentProfiles(nvmlDevice
  *
  * For Blackwell &tm; or newer fully supported devices.
  * See \ref nvmlWorkloadPowerProfileRequestedProfiles_v1_t for more information on the struct.
- * Reuqest one or more performance profiles be activated using the input bitmask
+ * Request one or more performance profiles be activated using the input bitmask
  * \a requestedProfilesMask, where each bit set corresponds to a supported bit from
  * the \a perfProfilesMask. These profiles will be added to existing list of
  * currently requested profiles.
@@ -14293,7 +15417,7 @@ DEPRECATED(13.1) nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileClearRequest
  * \a updateProfilesMask, where each bit set corresponds to a supported bit from
  * the \a perfProfilesMask.
  * The \a operation parameter specifies the operation to perform, see \ref nvmlPowerProfileOperation_t for more information.
- * Requires root/admin permissions.
+ * Requires root/admin permissions or access to the NVIDIA WPPS capability.
  *
  * @param device                The identifier of the target device
  * @param updateProfiles        Reference to struct \a nvmlWorkloadPowerProfileUpdateProfiles_v1_t
@@ -14510,6 +15634,45 @@ nvmlReturn_t DECLDIR nvmlDeviceGetRemappedRows_v2(nvmlDevice_t device, nvmlRemap
  *
  **/
 nvmlReturn_t DECLDIR nvmlDeviceSetRusdSettings_v1(nvmlDevice_t device, nvmlRusdSettings_v1_t *settings);
+
+/**
+ * Structure to store bank remapper histogram
+ */
+typedef struct
+{
+    unsigned int maxSpareGroupCount;    //!< Number of groups that have maximum spare.
+    unsigned int noSpareGroupCount;     //!< Number of groups that have not spare.
+} nvmlEccBankRemapperHistogram_v1_t;
+
+/**
+ * Structure to store bank remapper status
+ */
+typedef struct
+{
+    unsigned int activeRemappings;                      //!< Number of active remappings
+    unsigned int inactiveRemappings;                    //!< Number of inactive remappings
+    unsigned int bPending;                              //!< Whether there exists any pending bank remapping. 0 for no pending remapping, 1 for pending remapping.
+    nvmlEccBankRemapperHistogram_v1_t histogram;        //!< Bank remapper histogram
+} nvmlEccBankRemapperStatus_v1_t;
+
+/**
+ * Get bank remapper status.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param device                 The identifier of the target device
+ * @param pBankRemapperStatus    Reference to \a nvmlEccBankRemapperStatus_t
+ *
+ * @return
+ * - \ref NVML_SUCCESS if \a pBankRemapperStatus was populated
+ * - \ref NVML_ERROR_UNINITIALIZED if the library has not been successfully initialized
+ * - \ref NVML_ERROR_INVALID_ARGUMENT if \a device is invalid or \a pBankRemapperStatus is NULL
+ * - \ref NVML_ERROR_NOT_SUPPORTED if the device doesn't support this feature
+ * - \ref NVML_ERROR_GPU_IS_LOST if the target GPU has fallen off the bus or is otherwise inaccessible
+ * - \ref NVML_ERROR_UNKNOWN on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetBankRemapperStatus_v1(nvmlDevice_t device,
+                                                        nvmlEccBankRemapperStatus_v1_t *pBankRemapperStatus);
 
 /**
  * NVML API versioning support

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/types_gen.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/types_gen.go
@@ -73,6 +73,19 @@ type Memory_v2 struct {
 	Used     uint64
 }
 
+type SetMemoryLimits_v1 struct {
+	NameSpace *int8
+	SoftLimit uint64
+	HardLimit uint64
+}
+
+type GetMemoryLimits_v1 struct {
+	NameSpace   *int8
+	SoftLimit   uint64
+	HardLimit   uint64
+	CurrentUsed uint64
+}
+
 type BAR1Memory struct {
 	Bar1Total uint64
 	Bar1Free  uint64
@@ -252,6 +265,91 @@ type Pdi_v1 struct {
 type Pdi struct {
 	Version uint32
 	Value   uint64
+}
+
+type PmgrPwrTuple struct {
+	PwrmW uint32
+}
+
+type RailMetrics struct {
+	FreqkHz uint32
+	UtilPct uint64
+}
+
+type CoreRailMetrics struct {
+	Rails [2]RailMetrics
+}
+
+type PwrModelMetricsDlppm1xPerf struct {
+	Perfms uint32
+}
+
+type PwrModelMetricsDlppm1x struct {
+	BValid      uint8
+	CoreRail    CoreRailMetrics
+	FbRail      RailMetrics
+	TgpPwrTuple PmgrPwrTuple
+	PerfMetrics PwrModelMetricsDlppm1xPerf
+}
+
+type PwrModelMetricsDlppm1xDramclkEstimates struct {
+	EstimatedMetrics    [8]PwrModelMetricsDlppm1x
+	NumEstimatedMetrics uint8
+	Pad_cgo_0           [7]byte
+}
+
+type ObservedMetrics struct {
+	InitialDramclkEst [3]PwrModelMetricsDlppm1xDramclkEstimates
+	BValid            uint8
+	CoreRail          CoreRailMetrics
+	FbRail            RailMetrics
+	TgpPwrTuple       PmgrPwrTuple
+	PerfMetrics       PwrModelMetricsDlppm1xPerf
+}
+
+type PerfMetricsDlppc2xSample struct {
+	ObservedMetrics ObservedMetrics
+}
+
+type PwrModelMetricsSamplePfpp1x struct {
+	FreqkHz     [16]uint32
+	EstTgpPwrmW uint32
+}
+
+type PwrModelOperatingPointPfpp1x struct {
+	FreqkHz uint32
+	PwrmW   uint32
+}
+
+type PwrModelMetricsPfpp1x struct {
+	NumVfPoints         uint8
+	EstimatedMetrics    [32]PwrModelMetricsSamplePfpp1x
+	BValid              uint8
+	MaxPerfPerWattPoint PwrModelOperatingPointPfpp1x
+	FmaxAtVmaxPoint     PwrModelOperatingPointPfpp1x
+	TgpHeadroommW       uint32
+}
+
+type PerfMetricsPfpp1xSample struct {
+	EstimatedMetrics PwrModelMetricsPfpp1x
+}
+
+type PerfMetricControllerSample struct {
+	ControllerType uint32
+	Pad_cgo_0      [4]byte
+	Data           [2208]byte
+}
+
+type PerfMetricsSample struct {
+	NumControllerData uint8
+	Pad_cgo_0         [7]byte
+	ControllerData    [4]PerfMetricControllerSample
+}
+
+type PerfMetricsSamples_v1 struct {
+	NumSamples uint32
+	Pad_cgo_0  [4]byte
+	Samples    [13]PerfMetricsSample
 }
 
 type BBXTimeData_v1 struct {
@@ -516,6 +614,14 @@ type PowerValue_v2 struct {
 	Version      uint32
 	PowerScope   uint8
 	PowerValueMw uint32
+}
+
+type AdaptiveTgpModeInfo_v1 struct {
+	InBandEnableRequest   uint32
+	FeatureAllowedByAdmin uint32
+	AdminOverrideEnabled  uint32
+	EnablementStatus      uint32
+	AdjustedLimitMw       uint32
 }
 
 type nvmlVgpuTypeId uint32
@@ -976,6 +1082,18 @@ type nvmlEventData struct {
 	ComputeInstanceId uint32
 }
 
+type OperationalEventContextInfo_v1 struct {
+	NvmlGpuOperationalEventContextType uint32
+	SourceEventContextType             uint32
+	DataSize                           uint32
+	DataFormatVersion                  uint16
+	Pad_cgo_0                          [2]byte
+}
+
+type GpuOperationalEventContextLegacyXid_v1 struct {
+	XidCode uint32
+}
+
 type SystemEventSet struct {
 	Handle *_Ctype_struct_nvmlSystemEventSet_st
 }
@@ -1200,6 +1318,56 @@ type GpuFabricInfoV struct {
 	Pad_cgo_0     [3]byte
 }
 
+type GpuFabricClique_v1 struct {
+	Type uint8
+	Id   uint32
+}
+
+type GpuFabricInfo_v4 struct {
+	ClusterUuid   [16]uint8
+	Status        uint32
+	Cliques       [64]GpuFabricClique_v1
+	NumCliques    uint32
+	State         uint8
+	HealthMask    uint32
+	HealthSummary uint8
+	Pad_cgo_0     [3]byte
+}
+
+type GpuOperationalEventConfig_v1 struct {
+	Uuid        [96]int8
+	MinLogLevel uint32
+	MinSeverity uint32
+}
+
+type EventData_v2 struct {
+	Uuid              [96]int8
+	SourceModule      [16]int8
+	EventType         uint64
+	EventData         uint64
+	GroupCursor       uint64
+	InstanceId        uint64
+	TimestampUsec     uint64
+	TraceId           uint64
+	DataType          uint32
+	GpuInstanceId     uint32
+	ComputeInstanceId uint32
+	Severity          uint32
+	CategoryId        uint32
+	ModuleEventCode   uint32
+	Scope             uint32
+	Originator        uint32
+	ModuleInstance    uint32
+	ChipletId         uint32
+	LogLevel          uint32
+	Attributes        uint32
+	GroupCperSize     uint32
+	GroupAttributes   uint32
+	GroupSize         uint8
+	GroupIndex        uint8
+	Pad_cgo_0         [6]byte
+}
+
 type CPERCursorHandle uint64
 
 type CPERCursor_v1 struct {
@@ -1279,6 +1447,12 @@ type NvlinkSetBwMode struct {
 	Pad_cgo_0 [3]byte
 }
 
+type NvlinkSetBwModeAsync_v1 struct {
+	BSetBest           uint32
+	BwMode             uint32
+	AsyncPollTimeoutMs uint32
+}
+
 type NvLinkInfo_v1 struct {
 	Version       uint32
 	IsNvleEnabled uint32
@@ -1306,6 +1480,20 @@ type NvLinkInfo struct {
 	Version       uint32
 	IsNvleEnabled uint32
 	FirmwareInfo  NvlinkFirmwareInfo
+}
+
+type NvlinkTelemetrySample_v1 struct {
+	LinkId      uint32
+	SampleType  uint32
+	SampleCount uint32
+	Samples     *uint64
+	NvmlReturn  uint32
+	Pad_cgo_0   [4]byte
+}
+
+type NvlinkTelemetrySamples_v1 struct {
+	TelemetryCount   uint32
+	TelemetrySamples *NvlinkTelemetrySample_v1
 }
 
 type VgpuVersion struct {
@@ -1513,7 +1701,7 @@ type nvmlGpmMetricsGetType struct {
 	NumMetrics uint32
 	Sample1    nvmlGpmSample
 	Sample2    nvmlGpmSample
-	Metrics    [333]GpmMetric
+	Metrics    [477]GpmMetric
 }
 
 type GpmSupport struct {
@@ -1612,4 +1800,16 @@ type PowerSmoothingState_v1 struct {
 type PowerSmoothingState struct {
 	Version uint32
 	State   uint32
+}
+
+type EccBankRemapperHistogram_v1 struct {
+	MaxSpareGroupCount uint32
+	NoSpareGroupCount  uint32
+}
+
+type EccBankRemapperStatus_v1 struct {
+	ActiveRemappings   uint32
+	InactiveRemappings uint32
+	BPending           uint32
+	Histogram          EccBankRemapperHistogram_v1
 }

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/vgpu.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/vgpu.go
@@ -42,6 +42,19 @@ func (vgpuTypeId nvmlVgpuTypeId) GetClass() (string, Return) {
 	return string(vgpuTypeClass[:clen(vgpuTypeClass)]), ret
 }
 
+// nvml.VgpuTypeGetID()
+// It doesn't have an NVML C API symbol because the base type `nvmlVgpuTypeId`
+// is a non-exported type defined as `uint32`. When using the `VgpuTypeId` type,
+// it is not possible to read the underlying value without using reflection.
+// This method adds an idiomatic Go getter to access the type's value.
+func (l *library) VgpuTypeGetID(vgpuTypeId VgpuTypeId) uint32 {
+	return vgpuTypeId.GetID()
+}
+
+func (vgpuTypeId nvmlVgpuTypeId) GetID() uint32 {
+	return uint32(vgpuTypeId)
+}
+
 // nvml.VgpuTypeGetName()
 func (l *library) VgpuTypeGetName(vgpuTypeId VgpuTypeId) (string, Return) {
 	return vgpuTypeId.GetName()

--- a/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/zz_generated.api.go
+++ b/vendor/github.com/NVIDIA/go-nvml/pkg/nvml/zz_generated.api.go
@@ -20,397 +20,413 @@ package nvml
 
 // The variables below represent package level methods from the library type.
 var (
-	ComputeInstanceDestroy                           = libnvml.ComputeInstanceDestroy
-	ComputeInstanceGetInfo                           = libnvml.ComputeInstanceGetInfo
-	DeviceClearAccountingPids                        = libnvml.DeviceClearAccountingPids
-	DeviceClearCpuAffinity                           = libnvml.DeviceClearCpuAffinity
-	DeviceClearEccErrorCounts                        = libnvml.DeviceClearEccErrorCounts
-	DeviceClearFieldValues                           = libnvml.DeviceClearFieldValues
-	DeviceCreateGpuInstance                          = libnvml.DeviceCreateGpuInstance
-	DeviceCreateGpuInstanceWithPlacement             = libnvml.DeviceCreateGpuInstanceWithPlacement
-	DeviceDiscoverGpus                               = libnvml.DeviceDiscoverGpus
-	DeviceFreezeNvLinkUtilizationCounter             = libnvml.DeviceFreezeNvLinkUtilizationCounter
-	DeviceGetAPIRestriction                          = libnvml.DeviceGetAPIRestriction
-	DeviceGetAccountingBufferSize                    = libnvml.DeviceGetAccountingBufferSize
-	DeviceGetAccountingMode                          = libnvml.DeviceGetAccountingMode
-	DeviceGetAccountingPids                          = libnvml.DeviceGetAccountingPids
-	DeviceGetAccountingStats                         = libnvml.DeviceGetAccountingStats
-	DeviceGetAccountingStats_v2                      = libnvml.DeviceGetAccountingStats_v2
-	DeviceGetActiveVgpus                             = libnvml.DeviceGetActiveVgpus
-	DeviceGetAdaptiveClockInfoStatus                 = libnvml.DeviceGetAdaptiveClockInfoStatus
-	DeviceGetAddressingMode                          = libnvml.DeviceGetAddressingMode
-	DeviceGetApplicationsClock                       = libnvml.DeviceGetApplicationsClock
-	DeviceGetArchitecture                            = libnvml.DeviceGetArchitecture
-	DeviceGetAttributes                              = libnvml.DeviceGetAttributes
-	DeviceGetAutoBoostedClocksEnabled                = libnvml.DeviceGetAutoBoostedClocksEnabled
-	DeviceGetBAR1MemoryInfo                          = libnvml.DeviceGetBAR1MemoryInfo
-	DeviceGetBBXTimeData_v1                          = libnvml.DeviceGetBBXTimeData_v1
-	DeviceGetBoardId                                 = libnvml.DeviceGetBoardId
-	DeviceGetBoardPartNumber                         = libnvml.DeviceGetBoardPartNumber
-	DeviceGetBrand                                   = libnvml.DeviceGetBrand
-	DeviceGetBridgeChipInfo                          = libnvml.DeviceGetBridgeChipInfo
-	DeviceGetBusType                                 = libnvml.DeviceGetBusType
-	DeviceGetC2cModeInfoV                            = libnvml.DeviceGetC2cModeInfoV
-	DeviceGetCapabilities                            = libnvml.DeviceGetCapabilities
-	DeviceGetClkMonStatus                            = libnvml.DeviceGetClkMonStatus
-	DeviceGetClock                                   = libnvml.DeviceGetClock
-	DeviceGetClockInfo                               = libnvml.DeviceGetClockInfo
-	DeviceGetClockOffsets                            = libnvml.DeviceGetClockOffsets
-	DeviceGetComputeInstanceId                       = libnvml.DeviceGetComputeInstanceId
-	DeviceGetComputeMode                             = libnvml.DeviceGetComputeMode
-	DeviceGetComputeRunningProcesses                 = libnvml.DeviceGetComputeRunningProcesses
-	DeviceGetConfComputeGpuAttestationReport         = libnvml.DeviceGetConfComputeGpuAttestationReport
-	DeviceGetConfComputeGpuCertificate               = libnvml.DeviceGetConfComputeGpuCertificate
-	DeviceGetConfComputeMemSizeInfo                  = libnvml.DeviceGetConfComputeMemSizeInfo
-	DeviceGetConfComputeProtectedMemoryUsage         = libnvml.DeviceGetConfComputeProtectedMemoryUsage
-	DeviceGetCoolerInfo                              = libnvml.DeviceGetCoolerInfo
-	DeviceGetCount                                   = libnvml.DeviceGetCount
-	DeviceGetCpuAffinity                             = libnvml.DeviceGetCpuAffinity
-	DeviceGetCpuAffinityWithinScope                  = libnvml.DeviceGetCpuAffinityWithinScope
-	DeviceGetCreatableVgpus                          = libnvml.DeviceGetCreatableVgpus
-	DeviceGetCudaComputeCapability                   = libnvml.DeviceGetCudaComputeCapability
-	DeviceGetCurrPcieLinkGeneration                  = libnvml.DeviceGetCurrPcieLinkGeneration
-	DeviceGetCurrPcieLinkWidth                       = libnvml.DeviceGetCurrPcieLinkWidth
-	DeviceGetCurrentClockFreqs                       = libnvml.DeviceGetCurrentClockFreqs
-	DeviceGetCurrentClocksEventReasons               = libnvml.DeviceGetCurrentClocksEventReasons
-	DeviceGetCurrentClocksThrottleReasons            = libnvml.DeviceGetCurrentClocksThrottleReasons
-	DeviceGetDecoderUtilization                      = libnvml.DeviceGetDecoderUtilization
-	DeviceGetDefaultApplicationsClock                = libnvml.DeviceGetDefaultApplicationsClock
-	DeviceGetDefaultEccMode                          = libnvml.DeviceGetDefaultEccMode
-	DeviceGetDetailedEccErrors                       = libnvml.DeviceGetDetailedEccErrors
-	DeviceGetDeviceHandleFromMigDeviceHandle         = libnvml.DeviceGetDeviceHandleFromMigDeviceHandle
-	DeviceGetDisplayActive                           = libnvml.DeviceGetDisplayActive
-	DeviceGetDisplayMode                             = libnvml.DeviceGetDisplayMode
-	DeviceGetDramEncryptionMode                      = libnvml.DeviceGetDramEncryptionMode
-	DeviceGetDriverModel                             = libnvml.DeviceGetDriverModel
-	DeviceGetDriverModel_v2                          = libnvml.DeviceGetDriverModel_v2
-	DeviceGetDynamicPstatesInfo                      = libnvml.DeviceGetDynamicPstatesInfo
-	DeviceGetEccMode                                 = libnvml.DeviceGetEccMode
-	DeviceGetEncoderCapacity                         = libnvml.DeviceGetEncoderCapacity
-	DeviceGetEncoderSessions                         = libnvml.DeviceGetEncoderSessions
-	DeviceGetEncoderStats                            = libnvml.DeviceGetEncoderStats
-	DeviceGetEncoderUtilization                      = libnvml.DeviceGetEncoderUtilization
-	DeviceGetEnforcedPowerLimit                      = libnvml.DeviceGetEnforcedPowerLimit
-	DeviceGetFBCSessions                             = libnvml.DeviceGetFBCSessions
-	DeviceGetFBCStats                                = libnvml.DeviceGetFBCStats
-	DeviceGetFanControlPolicy_v2                     = libnvml.DeviceGetFanControlPolicy_v2
-	DeviceGetFanSpeed                                = libnvml.DeviceGetFanSpeed
-	DeviceGetFanSpeedRPM                             = libnvml.DeviceGetFanSpeedRPM
-	DeviceGetFanSpeed_v2                             = libnvml.DeviceGetFanSpeed_v2
-	DeviceGetFieldValues                             = libnvml.DeviceGetFieldValues
-	DeviceGetGpcClkMinMaxVfOffset                    = libnvml.DeviceGetGpcClkMinMaxVfOffset
-	DeviceGetGpcClkVfOffset                          = libnvml.DeviceGetGpcClkVfOffset
-	DeviceGetGpuFabricInfo                           = libnvml.DeviceGetGpuFabricInfo
-	DeviceGetGpuFabricInfoV                          = libnvml.DeviceGetGpuFabricInfoV
-	DeviceGetGpuInstanceById                         = libnvml.DeviceGetGpuInstanceById
-	DeviceGetGpuInstanceId                           = libnvml.DeviceGetGpuInstanceId
-	DeviceGetGpuInstancePossiblePlacements           = libnvml.DeviceGetGpuInstancePossiblePlacements
-	DeviceGetGpuInstanceProfileInfo                  = libnvml.DeviceGetGpuInstanceProfileInfo
-	DeviceGetGpuInstanceProfileInfoByIdV             = libnvml.DeviceGetGpuInstanceProfileInfoByIdV
-	DeviceGetGpuInstanceProfileInfoV                 = libnvml.DeviceGetGpuInstanceProfileInfoV
-	DeviceGetGpuInstanceRemainingCapacity            = libnvml.DeviceGetGpuInstanceRemainingCapacity
-	DeviceGetGpuInstances                            = libnvml.DeviceGetGpuInstances
-	DeviceGetGpuMaxPcieLinkGeneration                = libnvml.DeviceGetGpuMaxPcieLinkGeneration
-	DeviceGetGpuOperationMode                        = libnvml.DeviceGetGpuOperationMode
-	DeviceGetGraphicsRunningProcesses                = libnvml.DeviceGetGraphicsRunningProcesses
-	DeviceGetGridLicensableFeatures                  = libnvml.DeviceGetGridLicensableFeatures
-	DeviceGetGspFirmwareMode                         = libnvml.DeviceGetGspFirmwareMode
-	DeviceGetGspFirmwareVersion                      = libnvml.DeviceGetGspFirmwareVersion
-	DeviceGetHandleByIndex                           = libnvml.DeviceGetHandleByIndex
-	DeviceGetHandleByPciBusId                        = libnvml.DeviceGetHandleByPciBusId
-	DeviceGetHandleBySerial                          = libnvml.DeviceGetHandleBySerial
-	DeviceGetHandleByUUID                            = libnvml.DeviceGetHandleByUUID
-	DeviceGetHandleByUUIDV                           = libnvml.DeviceGetHandleByUUIDV
-	DeviceGetHostVgpuMode                            = libnvml.DeviceGetHostVgpuMode
-	DeviceGetHostname_v1                             = libnvml.DeviceGetHostname_v1
-	DeviceGetIndex                                   = libnvml.DeviceGetIndex
-	DeviceGetInforomConfigurationChecksum            = libnvml.DeviceGetInforomConfigurationChecksum
-	DeviceGetInforomImageVersion                     = libnvml.DeviceGetInforomImageVersion
-	DeviceGetInforomVersion                          = libnvml.DeviceGetInforomVersion
-	DeviceGetIrqNum                                  = libnvml.DeviceGetIrqNum
-	DeviceGetJpgUtilization                          = libnvml.DeviceGetJpgUtilization
-	DeviceGetLastBBXFlushTime                        = libnvml.DeviceGetLastBBXFlushTime
-	DeviceGetMPSComputeRunningProcesses              = libnvml.DeviceGetMPSComputeRunningProcesses
-	DeviceGetMarginTemperature                       = libnvml.DeviceGetMarginTemperature
-	DeviceGetMaxClockInfo                            = libnvml.DeviceGetMaxClockInfo
-	DeviceGetMaxCustomerBoostClock                   = libnvml.DeviceGetMaxCustomerBoostClock
-	DeviceGetMaxMigDeviceCount                       = libnvml.DeviceGetMaxMigDeviceCount
-	DeviceGetMaxPcieLinkGeneration                   = libnvml.DeviceGetMaxPcieLinkGeneration
-	DeviceGetMaxPcieLinkWidth                        = libnvml.DeviceGetMaxPcieLinkWidth
-	DeviceGetMemClkMinMaxVfOffset                    = libnvml.DeviceGetMemClkMinMaxVfOffset
-	DeviceGetMemClkVfOffset                          = libnvml.DeviceGetMemClkVfOffset
-	DeviceGetMemoryAffinity                          = libnvml.DeviceGetMemoryAffinity
-	DeviceGetMemoryBusWidth                          = libnvml.DeviceGetMemoryBusWidth
-	DeviceGetMemoryErrorCounter                      = libnvml.DeviceGetMemoryErrorCounter
-	DeviceGetMemoryInfo                              = libnvml.DeviceGetMemoryInfo
-	DeviceGetMemoryInfo_v2                           = libnvml.DeviceGetMemoryInfo_v2
-	DeviceGetMigDeviceHandleByIndex                  = libnvml.DeviceGetMigDeviceHandleByIndex
-	DeviceGetMigMode                                 = libnvml.DeviceGetMigMode
-	DeviceGetMinMaxClockOfPState                     = libnvml.DeviceGetMinMaxClockOfPState
-	DeviceGetMinMaxFanSpeed                          = libnvml.DeviceGetMinMaxFanSpeed
-	DeviceGetMinorNumber                             = libnvml.DeviceGetMinorNumber
-	DeviceGetModuleId                                = libnvml.DeviceGetModuleId
-	DeviceGetMultiGpuBoard                           = libnvml.DeviceGetMultiGpuBoard
-	DeviceGetName                                    = libnvml.DeviceGetName
-	DeviceGetNumFans                                 = libnvml.DeviceGetNumFans
-	DeviceGetNumGpuCores                             = libnvml.DeviceGetNumGpuCores
-	DeviceGetNumaNodeId                              = libnvml.DeviceGetNumaNodeId
-	DeviceGetNvLinkCapability                        = libnvml.DeviceGetNvLinkCapability
-	DeviceGetNvLinkErrorCounter                      = libnvml.DeviceGetNvLinkErrorCounter
-	DeviceGetNvLinkInfo                              = libnvml.DeviceGetNvLinkInfo
-	DeviceGetNvLinkRemoteDeviceType                  = libnvml.DeviceGetNvLinkRemoteDeviceType
-	DeviceGetNvLinkRemotePciInfo                     = libnvml.DeviceGetNvLinkRemotePciInfo
-	DeviceGetNvLinkState                             = libnvml.DeviceGetNvLinkState
-	DeviceGetNvLinkUtilizationControl                = libnvml.DeviceGetNvLinkUtilizationControl
-	DeviceGetNvLinkUtilizationCounter                = libnvml.DeviceGetNvLinkUtilizationCounter
-	DeviceGetNvLinkVersion                           = libnvml.DeviceGetNvLinkVersion
-	DeviceGetNvlinkBwMode                            = libnvml.DeviceGetNvlinkBwMode
-	DeviceGetNvlinkSupportedBwModes                  = libnvml.DeviceGetNvlinkSupportedBwModes
-	DeviceGetOfaUtilization                          = libnvml.DeviceGetOfaUtilization
-	DeviceGetP2PStatus                               = libnvml.DeviceGetP2PStatus
-	DeviceGetPciInfo                                 = libnvml.DeviceGetPciInfo
-	DeviceGetPciInfoExt                              = libnvml.DeviceGetPciInfoExt
-	DeviceGetPcieLinkMaxSpeed                        = libnvml.DeviceGetPcieLinkMaxSpeed
-	DeviceGetPcieReplayCounter                       = libnvml.DeviceGetPcieReplayCounter
-	DeviceGetPcieSpeed                               = libnvml.DeviceGetPcieSpeed
-	DeviceGetPcieThroughput                          = libnvml.DeviceGetPcieThroughput
-	DeviceGetPdi                                     = libnvml.DeviceGetPdi
-	DeviceGetPerformanceModes                        = libnvml.DeviceGetPerformanceModes
-	DeviceGetPerformanceState                        = libnvml.DeviceGetPerformanceState
-	DeviceGetPersistenceMode                         = libnvml.DeviceGetPersistenceMode
-	DeviceGetPgpuMetadataString                      = libnvml.DeviceGetPgpuMetadataString
-	DeviceGetPlatformInfo                            = libnvml.DeviceGetPlatformInfo
-	DeviceGetPowerManagementDefaultLimit             = libnvml.DeviceGetPowerManagementDefaultLimit
-	DeviceGetPowerManagementLimit                    = libnvml.DeviceGetPowerManagementLimit
-	DeviceGetPowerManagementLimitConstraints         = libnvml.DeviceGetPowerManagementLimitConstraints
-	DeviceGetPowerManagementMode                     = libnvml.DeviceGetPowerManagementMode
-	DeviceGetPowerMizerMode_v1                       = libnvml.DeviceGetPowerMizerMode_v1
-	DeviceGetPowerSource                             = libnvml.DeviceGetPowerSource
-	DeviceGetPowerState                              = libnvml.DeviceGetPowerState
-	DeviceGetPowerUsage                              = libnvml.DeviceGetPowerUsage
-	DeviceGetProcessUtilization                      = libnvml.DeviceGetProcessUtilization
-	DeviceGetProcessesUtilizationInfo                = libnvml.DeviceGetProcessesUtilizationInfo
-	DeviceGetRemappedRows                            = libnvml.DeviceGetRemappedRows
-	DeviceGetRemappedRows_v2                         = libnvml.DeviceGetRemappedRows_v2
-	DeviceGetRepairStatus                            = libnvml.DeviceGetRepairStatus
-	DeviceGetRetiredPages                            = libnvml.DeviceGetRetiredPages
-	DeviceGetRetiredPagesPendingStatus               = libnvml.DeviceGetRetiredPagesPendingStatus
-	DeviceGetRetiredPages_v2                         = libnvml.DeviceGetRetiredPages_v2
-	DeviceGetRowRemapperHistogram                    = libnvml.DeviceGetRowRemapperHistogram
-	DeviceGetRunningProcessDetailList                = libnvml.DeviceGetRunningProcessDetailList
-	DeviceGetSamples                                 = libnvml.DeviceGetSamples
-	DeviceGetSerial                                  = libnvml.DeviceGetSerial
-	DeviceGetSramEccErrorStatus                      = libnvml.DeviceGetSramEccErrorStatus
-	DeviceGetSramUniqueUncorrectedEccErrorCounts     = libnvml.DeviceGetSramUniqueUncorrectedEccErrorCounts
-	DeviceGetSupportedClocksEventReasons             = libnvml.DeviceGetSupportedClocksEventReasons
-	DeviceGetSupportedClocksThrottleReasons          = libnvml.DeviceGetSupportedClocksThrottleReasons
-	DeviceGetSupportedEventTypes                     = libnvml.DeviceGetSupportedEventTypes
-	DeviceGetSupportedGraphicsClocks                 = libnvml.DeviceGetSupportedGraphicsClocks
-	DeviceGetSupportedMemoryClocks                   = libnvml.DeviceGetSupportedMemoryClocks
-	DeviceGetSupportedPerformanceStates              = libnvml.DeviceGetSupportedPerformanceStates
-	DeviceGetSupportedVgpus                          = libnvml.DeviceGetSupportedVgpus
-	DeviceGetTargetFanSpeed                          = libnvml.DeviceGetTargetFanSpeed
-	DeviceGetTemperature                             = libnvml.DeviceGetTemperature
-	DeviceGetTemperatureThreshold                    = libnvml.DeviceGetTemperatureThreshold
-	DeviceGetTemperatureV                            = libnvml.DeviceGetTemperatureV
-	DeviceGetThermalSettings                         = libnvml.DeviceGetThermalSettings
-	DeviceGetTopologyCommonAncestor                  = libnvml.DeviceGetTopologyCommonAncestor
-	DeviceGetTopologyNearestGpus                     = libnvml.DeviceGetTopologyNearestGpus
-	DeviceGetTotalEccErrors                          = libnvml.DeviceGetTotalEccErrors
-	DeviceGetTotalEnergyConsumption                  = libnvml.DeviceGetTotalEnergyConsumption
-	DeviceGetUUID                                    = libnvml.DeviceGetUUID
-	DeviceGetUnrepairableMemoryFlag_v1               = libnvml.DeviceGetUnrepairableMemoryFlag_v1
-	DeviceGetUtilizationRates                        = libnvml.DeviceGetUtilizationRates
-	DeviceGetVbiosVersion                            = libnvml.DeviceGetVbiosVersion
-	DeviceGetVgpuCapabilities                        = libnvml.DeviceGetVgpuCapabilities
-	DeviceGetVgpuHeterogeneousMode                   = libnvml.DeviceGetVgpuHeterogeneousMode
-	DeviceGetVgpuInstancesUtilizationInfo            = libnvml.DeviceGetVgpuInstancesUtilizationInfo
-	DeviceGetVgpuMetadata                            = libnvml.DeviceGetVgpuMetadata
-	DeviceGetVgpuProcessUtilization                  = libnvml.DeviceGetVgpuProcessUtilization
-	DeviceGetVgpuProcessesUtilizationInfo            = libnvml.DeviceGetVgpuProcessesUtilizationInfo
-	DeviceGetVgpuSchedulerCapabilities               = libnvml.DeviceGetVgpuSchedulerCapabilities
-	DeviceGetVgpuSchedulerLog                        = libnvml.DeviceGetVgpuSchedulerLog
-	DeviceGetVgpuSchedulerLog_v2                     = libnvml.DeviceGetVgpuSchedulerLog_v2
-	DeviceGetVgpuSchedulerState                      = libnvml.DeviceGetVgpuSchedulerState
-	DeviceGetVgpuSchedulerState_v2                   = libnvml.DeviceGetVgpuSchedulerState_v2
-	DeviceGetVgpuTypeCreatablePlacements             = libnvml.DeviceGetVgpuTypeCreatablePlacements
-	DeviceGetVgpuTypeSupportedPlacements             = libnvml.DeviceGetVgpuTypeSupportedPlacements
-	DeviceGetVgpuUtilization                         = libnvml.DeviceGetVgpuUtilization
-	DeviceGetViolationStatus                         = libnvml.DeviceGetViolationStatus
-	DeviceGetVirtualizationMode                      = libnvml.DeviceGetVirtualizationMode
-	DeviceIsMigDeviceHandle                          = libnvml.DeviceIsMigDeviceHandle
-	DeviceModifyDrainState                           = libnvml.DeviceModifyDrainState
-	DeviceOnSameBoard                                = libnvml.DeviceOnSameBoard
-	DevicePowerSmoothingActivatePresetProfile        = libnvml.DevicePowerSmoothingActivatePresetProfile
-	DevicePowerSmoothingSetState                     = libnvml.DevicePowerSmoothingSetState
-	DevicePowerSmoothingUpdatePresetProfileParam     = libnvml.DevicePowerSmoothingUpdatePresetProfileParam
-	DeviceQueryDrainState                            = libnvml.DeviceQueryDrainState
-	DeviceReadPRMCounters_v1                         = libnvml.DeviceReadPRMCounters_v1
-	DeviceReadWritePRM_v1                            = libnvml.DeviceReadWritePRM_v1
-	DeviceRegisterEvents                             = libnvml.DeviceRegisterEvents
-	DeviceRemoveGpu                                  = libnvml.DeviceRemoveGpu
-	DeviceRemoveGpu_v2                               = libnvml.DeviceRemoveGpu_v2
-	DeviceResetApplicationsClocks                    = libnvml.DeviceResetApplicationsClocks
-	DeviceResetGpuLockedClocks                       = libnvml.DeviceResetGpuLockedClocks
-	DeviceResetMemoryLockedClocks                    = libnvml.DeviceResetMemoryLockedClocks
-	DeviceResetNvLinkErrorCounters                   = libnvml.DeviceResetNvLinkErrorCounters
-	DeviceResetNvLinkUtilizationCounter              = libnvml.DeviceResetNvLinkUtilizationCounter
-	DeviceSetAPIRestriction                          = libnvml.DeviceSetAPIRestriction
-	DeviceSetAccountingMode                          = libnvml.DeviceSetAccountingMode
-	DeviceSetApplicationsClocks                      = libnvml.DeviceSetApplicationsClocks
-	DeviceSetAutoBoostedClocksEnabled                = libnvml.DeviceSetAutoBoostedClocksEnabled
-	DeviceSetClockOffsets                            = libnvml.DeviceSetClockOffsets
-	DeviceSetComputeMode                             = libnvml.DeviceSetComputeMode
-	DeviceSetConfComputeUnprotectedMemSize           = libnvml.DeviceSetConfComputeUnprotectedMemSize
-	DeviceSetCpuAffinity                             = libnvml.DeviceSetCpuAffinity
-	DeviceSetDefaultAutoBoostedClocksEnabled         = libnvml.DeviceSetDefaultAutoBoostedClocksEnabled
-	DeviceSetDefaultFanSpeed_v2                      = libnvml.DeviceSetDefaultFanSpeed_v2
-	DeviceSetDramEncryptionMode                      = libnvml.DeviceSetDramEncryptionMode
-	DeviceSetDriverModel                             = libnvml.DeviceSetDriverModel
-	DeviceSetEccMode                                 = libnvml.DeviceSetEccMode
-	DeviceSetFanControlPolicy                        = libnvml.DeviceSetFanControlPolicy
-	DeviceSetFanSpeed_v2                             = libnvml.DeviceSetFanSpeed_v2
-	DeviceSetGpcClkVfOffset                          = libnvml.DeviceSetGpcClkVfOffset
-	DeviceSetGpuLockedClocks                         = libnvml.DeviceSetGpuLockedClocks
-	DeviceSetGpuOperationMode                        = libnvml.DeviceSetGpuOperationMode
-	DeviceSetHostname_v1                             = libnvml.DeviceSetHostname_v1
-	DeviceSetMemClkVfOffset                          = libnvml.DeviceSetMemClkVfOffset
-	DeviceSetMemoryLockedClocks                      = libnvml.DeviceSetMemoryLockedClocks
-	DeviceSetMigMode                                 = libnvml.DeviceSetMigMode
-	DeviceSetNvLinkDeviceLowPowerThreshold           = libnvml.DeviceSetNvLinkDeviceLowPowerThreshold
-	DeviceSetNvLinkUtilizationControl                = libnvml.DeviceSetNvLinkUtilizationControl
-	DeviceSetNvlinkBwMode                            = libnvml.DeviceSetNvlinkBwMode
-	DeviceSetPersistenceMode                         = libnvml.DeviceSetPersistenceMode
-	DeviceSetPowerManagementLimit                    = libnvml.DeviceSetPowerManagementLimit
-	DeviceSetPowerManagementLimit_v2                 = libnvml.DeviceSetPowerManagementLimit_v2
-	DeviceSetRusdSettings_v1                         = libnvml.DeviceSetRusdSettings_v1
-	DeviceSetTemperatureThreshold                    = libnvml.DeviceSetTemperatureThreshold
-	DeviceSetVgpuCapabilities                        = libnvml.DeviceSetVgpuCapabilities
-	DeviceSetVgpuHeterogeneousMode                   = libnvml.DeviceSetVgpuHeterogeneousMode
-	DeviceSetVgpuSchedulerState                      = libnvml.DeviceSetVgpuSchedulerState
-	DeviceSetVgpuSchedulerState_v2                   = libnvml.DeviceSetVgpuSchedulerState_v2
-	DeviceSetVirtualizationMode                      = libnvml.DeviceSetVirtualizationMode
-	DeviceValidateInforom                            = libnvml.DeviceValidateInforom
-	DeviceVgpuForceGspUnload                         = libnvml.DeviceVgpuForceGspUnload
-	DeviceWorkloadPowerProfileClearRequestedProfiles = libnvml.DeviceWorkloadPowerProfileClearRequestedProfiles
-	DeviceWorkloadPowerProfileGetCurrentProfiles     = libnvml.DeviceWorkloadPowerProfileGetCurrentProfiles
-	DeviceWorkloadPowerProfileGetProfilesInfo        = libnvml.DeviceWorkloadPowerProfileGetProfilesInfo
-	DeviceWorkloadPowerProfileSetRequestedProfiles   = libnvml.DeviceWorkloadPowerProfileSetRequestedProfiles
-	DeviceWorkloadPowerProfileUpdateProfiles_v1      = libnvml.DeviceWorkloadPowerProfileUpdateProfiles_v1
-	ErrorString                                      = libnvml.ErrorString
-	EventSetCreate                                   = libnvml.EventSetCreate
-	EventSetFree                                     = libnvml.EventSetFree
-	EventSetWait                                     = libnvml.EventSetWait
-	Extensions                                       = libnvml.Extensions
-	GetExcludedDeviceCount                           = libnvml.GetExcludedDeviceCount
-	GetExcludedDeviceInfoByIndex                     = libnvml.GetExcludedDeviceInfoByIndex
-	GetVgpuCompatibility                             = libnvml.GetVgpuCompatibility
-	GetVgpuDriverCapabilities                        = libnvml.GetVgpuDriverCapabilities
-	GetVgpuVersion                                   = libnvml.GetVgpuVersion
-	GpmMetricsGet                                    = libnvml.GpmMetricsGet
-	GpmMetricsGetV                                   = libnvml.GpmMetricsGetV
-	GpmMigSampleGet                                  = libnvml.GpmMigSampleGet
-	GpmQueryDeviceSupport                            = libnvml.GpmQueryDeviceSupport
-	GpmQueryDeviceSupportV                           = libnvml.GpmQueryDeviceSupportV
-	GpmQueryIfStreamingEnabled                       = libnvml.GpmQueryIfStreamingEnabled
-	GpmSampleAlloc                                   = libnvml.GpmSampleAlloc
-	GpmSampleFree                                    = libnvml.GpmSampleFree
-	GpmSampleGet                                     = libnvml.GpmSampleGet
-	GpmSetStreamingEnabled                           = libnvml.GpmSetStreamingEnabled
-	GpuInstanceCreateComputeInstance                 = libnvml.GpuInstanceCreateComputeInstance
-	GpuInstanceCreateComputeInstanceWithPlacement    = libnvml.GpuInstanceCreateComputeInstanceWithPlacement
-	GpuInstanceDestroy                               = libnvml.GpuInstanceDestroy
-	GpuInstanceGetActiveVgpus                        = libnvml.GpuInstanceGetActiveVgpus
-	GpuInstanceGetComputeInstanceById                = libnvml.GpuInstanceGetComputeInstanceById
-	GpuInstanceGetComputeInstancePossiblePlacements  = libnvml.GpuInstanceGetComputeInstancePossiblePlacements
-	GpuInstanceGetComputeInstanceProfileInfo         = libnvml.GpuInstanceGetComputeInstanceProfileInfo
-	GpuInstanceGetComputeInstanceProfileInfoV        = libnvml.GpuInstanceGetComputeInstanceProfileInfoV
-	GpuInstanceGetComputeInstanceRemainingCapacity   = libnvml.GpuInstanceGetComputeInstanceRemainingCapacity
-	GpuInstanceGetComputeInstances                   = libnvml.GpuInstanceGetComputeInstances
-	GpuInstanceGetCreatableVgpus                     = libnvml.GpuInstanceGetCreatableVgpus
-	GpuInstanceGetInfo                               = libnvml.GpuInstanceGetInfo
-	GpuInstanceGetVgpuHeterogeneousMode              = libnvml.GpuInstanceGetVgpuHeterogeneousMode
-	GpuInstanceGetVgpuSchedulerLog                   = libnvml.GpuInstanceGetVgpuSchedulerLog
-	GpuInstanceGetVgpuSchedulerLog_v2                = libnvml.GpuInstanceGetVgpuSchedulerLog_v2
-	GpuInstanceGetVgpuSchedulerState                 = libnvml.GpuInstanceGetVgpuSchedulerState
-	GpuInstanceGetVgpuSchedulerState_v2              = libnvml.GpuInstanceGetVgpuSchedulerState_v2
-	GpuInstanceGetVgpuTypeCreatablePlacements        = libnvml.GpuInstanceGetVgpuTypeCreatablePlacements
-	GpuInstanceSetVgpuHeterogeneousMode              = libnvml.GpuInstanceSetVgpuHeterogeneousMode
-	GpuInstanceSetVgpuSchedulerState                 = libnvml.GpuInstanceSetVgpuSchedulerState
-	GpuInstanceSetVgpuSchedulerState_v2              = libnvml.GpuInstanceSetVgpuSchedulerState_v2
-	Init                                             = libnvml.Init
-	InitWithFlags                                    = libnvml.InitWithFlags
-	SetVgpuVersion                                   = libnvml.SetVgpuVersion
-	Shutdown                                         = libnvml.Shutdown
-	SystemEventSetCreate                             = libnvml.SystemEventSetCreate
-	SystemEventSetFree                               = libnvml.SystemEventSetFree
-	SystemEventSetWait                               = libnvml.SystemEventSetWait
-	SystemGetCPER_v1                                 = libnvml.SystemGetCPER_v1
-	SystemGetConfComputeCapabilities                 = libnvml.SystemGetConfComputeCapabilities
-	SystemGetConfComputeGpusReadyState               = libnvml.SystemGetConfComputeGpusReadyState
-	SystemGetConfComputeKeyRotationThresholdInfo     = libnvml.SystemGetConfComputeKeyRotationThresholdInfo
-	SystemGetConfComputeSettings                     = libnvml.SystemGetConfComputeSettings
-	SystemGetConfComputeState                        = libnvml.SystemGetConfComputeState
-	SystemGetCudaDriverVersion                       = libnvml.SystemGetCudaDriverVersion
-	SystemGetCudaDriverVersion_v2                    = libnvml.SystemGetCudaDriverVersion_v2
-	SystemGetDriverBranch                            = libnvml.SystemGetDriverBranch
-	SystemGetDriverVersion                           = libnvml.SystemGetDriverVersion
-	SystemGetHicVersion                              = libnvml.SystemGetHicVersion
-	SystemGetNVMLVersion                             = libnvml.SystemGetNVMLVersion
-	SystemGetNvlinkBwMode                            = libnvml.SystemGetNvlinkBwMode
-	SystemGetProcessName                             = libnvml.SystemGetProcessName
-	SystemGetTopologyGpuSet                          = libnvml.SystemGetTopologyGpuSet
-	SystemRegisterEvents                             = libnvml.SystemRegisterEvents
-	SystemSetConfComputeGpusReadyState               = libnvml.SystemSetConfComputeGpusReadyState
-	SystemSetConfComputeKeyRotationThresholdInfo     = libnvml.SystemSetConfComputeKeyRotationThresholdInfo
-	SystemSetNvlinkBwMode                            = libnvml.SystemSetNvlinkBwMode
-	UnitGetCount                                     = libnvml.UnitGetCount
-	UnitGetDevices                                   = libnvml.UnitGetDevices
-	UnitGetFanSpeedInfo                              = libnvml.UnitGetFanSpeedInfo
-	UnitGetHandleByIndex                             = libnvml.UnitGetHandleByIndex
-	UnitGetLedState                                  = libnvml.UnitGetLedState
-	UnitGetPsuInfo                                   = libnvml.UnitGetPsuInfo
-	UnitGetTemperature                               = libnvml.UnitGetTemperature
-	UnitGetUnitInfo                                  = libnvml.UnitGetUnitInfo
-	UnitSetLedState                                  = libnvml.UnitSetLedState
-	VgpuInstanceClearAccountingPids                  = libnvml.VgpuInstanceClearAccountingPids
-	VgpuInstanceGetAccountingMode                    = libnvml.VgpuInstanceGetAccountingMode
-	VgpuInstanceGetAccountingPids                    = libnvml.VgpuInstanceGetAccountingPids
-	VgpuInstanceGetAccountingStats                   = libnvml.VgpuInstanceGetAccountingStats
-	VgpuInstanceGetEccMode                           = libnvml.VgpuInstanceGetEccMode
-	VgpuInstanceGetEncoderCapacity                   = libnvml.VgpuInstanceGetEncoderCapacity
-	VgpuInstanceGetEncoderSessions                   = libnvml.VgpuInstanceGetEncoderSessions
-	VgpuInstanceGetEncoderStats                      = libnvml.VgpuInstanceGetEncoderStats
-	VgpuInstanceGetFBCSessions                       = libnvml.VgpuInstanceGetFBCSessions
-	VgpuInstanceGetFBCStats                          = libnvml.VgpuInstanceGetFBCStats
-	VgpuInstanceGetFbUsage                           = libnvml.VgpuInstanceGetFbUsage
-	VgpuInstanceGetFrameRateLimit                    = libnvml.VgpuInstanceGetFrameRateLimit
-	VgpuInstanceGetGpuInstanceId                     = libnvml.VgpuInstanceGetGpuInstanceId
-	VgpuInstanceGetGpuPciId                          = libnvml.VgpuInstanceGetGpuPciId
-	VgpuInstanceGetLicenseInfo                       = libnvml.VgpuInstanceGetLicenseInfo
-	VgpuInstanceGetLicenseStatus                     = libnvml.VgpuInstanceGetLicenseStatus
-	VgpuInstanceGetMdevUUID                          = libnvml.VgpuInstanceGetMdevUUID
-	VgpuInstanceGetMetadata                          = libnvml.VgpuInstanceGetMetadata
-	VgpuInstanceGetRuntimeStateSize                  = libnvml.VgpuInstanceGetRuntimeStateSize
-	VgpuInstanceGetType                              = libnvml.VgpuInstanceGetType
-	VgpuInstanceGetUUID                              = libnvml.VgpuInstanceGetUUID
-	VgpuInstanceGetVmDriverVersion                   = libnvml.VgpuInstanceGetVmDriverVersion
-	VgpuInstanceGetVmID                              = libnvml.VgpuInstanceGetVmID
-	VgpuInstanceSetEncoderCapacity                   = libnvml.VgpuInstanceSetEncoderCapacity
-	VgpuTypeGetBAR1Info                              = libnvml.VgpuTypeGetBAR1Info
-	VgpuTypeGetCapabilities                          = libnvml.VgpuTypeGetCapabilities
-	VgpuTypeGetClass                                 = libnvml.VgpuTypeGetClass
-	VgpuTypeGetDeviceID                              = libnvml.VgpuTypeGetDeviceID
-	VgpuTypeGetFrameRateLimit                        = libnvml.VgpuTypeGetFrameRateLimit
-	VgpuTypeGetFramebufferSize                       = libnvml.VgpuTypeGetFramebufferSize
-	VgpuTypeGetGpuInstanceProfileId                  = libnvml.VgpuTypeGetGpuInstanceProfileId
-	VgpuTypeGetLicense                               = libnvml.VgpuTypeGetLicense
-	VgpuTypeGetMaxInstances                          = libnvml.VgpuTypeGetMaxInstances
-	VgpuTypeGetMaxInstancesPerGpuInstance            = libnvml.VgpuTypeGetMaxInstancesPerGpuInstance
-	VgpuTypeGetMaxInstancesPerVm                     = libnvml.VgpuTypeGetMaxInstancesPerVm
-	VgpuTypeGetName                                  = libnvml.VgpuTypeGetName
-	VgpuTypeGetNumDisplayHeads                       = libnvml.VgpuTypeGetNumDisplayHeads
-	VgpuTypeGetResolution                            = libnvml.VgpuTypeGetResolution
+	ComputeInstanceDestroy                            = libnvml.ComputeInstanceDestroy
+	ComputeInstanceGetInfo                            = libnvml.ComputeInstanceGetInfo
+	DeviceClearAccountingPids                         = libnvml.DeviceClearAccountingPids
+	DeviceClearCpuAffinity                            = libnvml.DeviceClearCpuAffinity
+	DeviceClearEccErrorCounts                         = libnvml.DeviceClearEccErrorCounts
+	DeviceClearFieldValues                            = libnvml.DeviceClearFieldValues
+	DeviceCreateGpuInstance                           = libnvml.DeviceCreateGpuInstance
+	DeviceCreateGpuInstanceWithPlacement              = libnvml.DeviceCreateGpuInstanceWithPlacement
+	DeviceDiscoverGpus                                = libnvml.DeviceDiscoverGpus
+	DeviceFreezeNvLinkUtilizationCounter              = libnvml.DeviceFreezeNvLinkUtilizationCounter
+	DeviceGetAPIRestriction                           = libnvml.DeviceGetAPIRestriction
+	DeviceGetAccountingBufferSize                     = libnvml.DeviceGetAccountingBufferSize
+	DeviceGetAccountingMode                           = libnvml.DeviceGetAccountingMode
+	DeviceGetAccountingPids                           = libnvml.DeviceGetAccountingPids
+	DeviceGetAccountingStats                          = libnvml.DeviceGetAccountingStats
+	DeviceGetAccountingStats_v2                       = libnvml.DeviceGetAccountingStats_v2
+	DeviceGetActiveVgpus                              = libnvml.DeviceGetActiveVgpus
+	DeviceGetAdaptiveClockInfoStatus                  = libnvml.DeviceGetAdaptiveClockInfoStatus
+	DeviceGetAdaptiveTgpModeInfo_v1                   = libnvml.DeviceGetAdaptiveTgpModeInfo_v1
+	DeviceGetAddressingMode                           = libnvml.DeviceGetAddressingMode
+	DeviceGetApplicationsClock                        = libnvml.DeviceGetApplicationsClock
+	DeviceGetArchitecture                             = libnvml.DeviceGetArchitecture
+	DeviceGetAttributes                               = libnvml.DeviceGetAttributes
+	DeviceGetAutoBoostedClocksEnabled                 = libnvml.DeviceGetAutoBoostedClocksEnabled
+	DeviceGetBAR1MemoryInfo                           = libnvml.DeviceGetBAR1MemoryInfo
+	DeviceGetBBXTimeData_v1                           = libnvml.DeviceGetBBXTimeData_v1
+	DeviceGetBankRemapperStatus_v1                    = libnvml.DeviceGetBankRemapperStatus_v1
+	DeviceGetBoardId                                  = libnvml.DeviceGetBoardId
+	DeviceGetBoardPartNumber                          = libnvml.DeviceGetBoardPartNumber
+	DeviceGetBrand                                    = libnvml.DeviceGetBrand
+	DeviceGetBridgeChipInfo                           = libnvml.DeviceGetBridgeChipInfo
+	DeviceGetBusType                                  = libnvml.DeviceGetBusType
+	DeviceGetC2cModeInfoV                             = libnvml.DeviceGetC2cModeInfoV
+	DeviceGetCapabilities                             = libnvml.DeviceGetCapabilities
+	DeviceGetClkMonStatus                             = libnvml.DeviceGetClkMonStatus
+	DeviceGetClock                                    = libnvml.DeviceGetClock
+	DeviceGetClockInfo                                = libnvml.DeviceGetClockInfo
+	DeviceGetClockOffsets                             = libnvml.DeviceGetClockOffsets
+	DeviceGetComputeInstanceId                        = libnvml.DeviceGetComputeInstanceId
+	DeviceGetComputeMode                              = libnvml.DeviceGetComputeMode
+	DeviceGetComputeRunningProcesses                  = libnvml.DeviceGetComputeRunningProcesses
+	DeviceGetConfComputeGpuAttestationReport          = libnvml.DeviceGetConfComputeGpuAttestationReport
+	DeviceGetConfComputeGpuCertificate                = libnvml.DeviceGetConfComputeGpuCertificate
+	DeviceGetConfComputeMemSizeInfo                   = libnvml.DeviceGetConfComputeMemSizeInfo
+	DeviceGetConfComputeProtectedMemoryUsage          = libnvml.DeviceGetConfComputeProtectedMemoryUsage
+	DeviceGetCoolerInfo                               = libnvml.DeviceGetCoolerInfo
+	DeviceGetCount                                    = libnvml.DeviceGetCount
+	DeviceGetCpuAffinity                              = libnvml.DeviceGetCpuAffinity
+	DeviceGetCpuAffinityWithinScope                   = libnvml.DeviceGetCpuAffinityWithinScope
+	DeviceGetCreatableVgpus                           = libnvml.DeviceGetCreatableVgpus
+	DeviceGetCudaComputeCapability                    = libnvml.DeviceGetCudaComputeCapability
+	DeviceGetCurrPcieLinkGeneration                   = libnvml.DeviceGetCurrPcieLinkGeneration
+	DeviceGetCurrPcieLinkWidth                        = libnvml.DeviceGetCurrPcieLinkWidth
+	DeviceGetCurrentClockFreqs                        = libnvml.DeviceGetCurrentClockFreqs
+	DeviceGetCurrentClocksEventReasons                = libnvml.DeviceGetCurrentClocksEventReasons
+	DeviceGetCurrentClocksThrottleReasons             = libnvml.DeviceGetCurrentClocksThrottleReasons
+	DeviceGetDecoderUtilization                       = libnvml.DeviceGetDecoderUtilization
+	DeviceGetDefaultApplicationsClock                 = libnvml.DeviceGetDefaultApplicationsClock
+	DeviceGetDefaultEccMode                           = libnvml.DeviceGetDefaultEccMode
+	DeviceGetDetailedEccErrors                        = libnvml.DeviceGetDetailedEccErrors
+	DeviceGetDeviceHandleFromMigDeviceHandle          = libnvml.DeviceGetDeviceHandleFromMigDeviceHandle
+	DeviceGetDisplayActive                            = libnvml.DeviceGetDisplayActive
+	DeviceGetDisplayMode                              = libnvml.DeviceGetDisplayMode
+	DeviceGetDramEncryptionMode                       = libnvml.DeviceGetDramEncryptionMode
+	DeviceGetDriverModel                              = libnvml.DeviceGetDriverModel
+	DeviceGetDriverModel_v2                           = libnvml.DeviceGetDriverModel_v2
+	DeviceGetDynamicPstatesInfo                       = libnvml.DeviceGetDynamicPstatesInfo
+	DeviceGetEccMode                                  = libnvml.DeviceGetEccMode
+	DeviceGetEncoderCapacity                          = libnvml.DeviceGetEncoderCapacity
+	DeviceGetEncoderSessions                          = libnvml.DeviceGetEncoderSessions
+	DeviceGetEncoderStats                             = libnvml.DeviceGetEncoderStats
+	DeviceGetEncoderUtilization                       = libnvml.DeviceGetEncoderUtilization
+	DeviceGetEnforcedPowerLimit                       = libnvml.DeviceGetEnforcedPowerLimit
+	DeviceGetFBCSessions                              = libnvml.DeviceGetFBCSessions
+	DeviceGetFBCStats                                 = libnvml.DeviceGetFBCStats
+	DeviceGetFanControlPolicy_v2                      = libnvml.DeviceGetFanControlPolicy_v2
+	DeviceGetFanSpeed                                 = libnvml.DeviceGetFanSpeed
+	DeviceGetFanSpeedRPM                              = libnvml.DeviceGetFanSpeedRPM
+	DeviceGetFanSpeed_v2                              = libnvml.DeviceGetFanSpeed_v2
+	DeviceGetFieldValues                              = libnvml.DeviceGetFieldValues
+	DeviceGetGpcClkMinMaxVfOffset                     = libnvml.DeviceGetGpcClkMinMaxVfOffset
+	DeviceGetGpcClkVfOffset                           = libnvml.DeviceGetGpcClkVfOffset
+	DeviceGetGpuFabricInfo                            = libnvml.DeviceGetGpuFabricInfo
+	DeviceGetGpuFabricInfoV                           = libnvml.DeviceGetGpuFabricInfoV
+	DeviceGetGpuFabricInfo_v4                         = libnvml.DeviceGetGpuFabricInfo_v4
+	DeviceGetGpuInstanceById                          = libnvml.DeviceGetGpuInstanceById
+	DeviceGetGpuInstanceId                            = libnvml.DeviceGetGpuInstanceId
+	DeviceGetGpuInstancePossiblePlacements            = libnvml.DeviceGetGpuInstancePossiblePlacements
+	DeviceGetGpuInstanceProfileInfo                   = libnvml.DeviceGetGpuInstanceProfileInfo
+	DeviceGetGpuInstanceProfileInfoByIdV              = libnvml.DeviceGetGpuInstanceProfileInfoByIdV
+	DeviceGetGpuInstanceProfileInfoV                  = libnvml.DeviceGetGpuInstanceProfileInfoV
+	DeviceGetGpuInstanceRemainingCapacity             = libnvml.DeviceGetGpuInstanceRemainingCapacity
+	DeviceGetGpuInstances                             = libnvml.DeviceGetGpuInstances
+	DeviceGetGpuMaxPcieLinkGeneration                 = libnvml.DeviceGetGpuMaxPcieLinkGeneration
+	DeviceGetGpuOperationMode                         = libnvml.DeviceGetGpuOperationMode
+	DeviceGetGraphicsRunningProcesses                 = libnvml.DeviceGetGraphicsRunningProcesses
+	DeviceGetGridLicensableFeatures                   = libnvml.DeviceGetGridLicensableFeatures
+	DeviceGetGspFirmwareMode                          = libnvml.DeviceGetGspFirmwareMode
+	DeviceGetGspFirmwareVersion                       = libnvml.DeviceGetGspFirmwareVersion
+	DeviceGetHandleByIndex                            = libnvml.DeviceGetHandleByIndex
+	DeviceGetHandleByPciBusId                         = libnvml.DeviceGetHandleByPciBusId
+	DeviceGetHandleBySerial                           = libnvml.DeviceGetHandleBySerial
+	DeviceGetHandleByUUID                             = libnvml.DeviceGetHandleByUUID
+	DeviceGetHandleByUUIDV                            = libnvml.DeviceGetHandleByUUIDV
+	DeviceGetHostVgpuMode                             = libnvml.DeviceGetHostVgpuMode
+	DeviceGetHostname_v1                              = libnvml.DeviceGetHostname_v1
+	DeviceGetIndex                                    = libnvml.DeviceGetIndex
+	DeviceGetInforomConfigurationChecksum             = libnvml.DeviceGetInforomConfigurationChecksum
+	DeviceGetInforomImageVersion                      = libnvml.DeviceGetInforomImageVersion
+	DeviceGetInforomVersion                           = libnvml.DeviceGetInforomVersion
+	DeviceGetIrqNum                                   = libnvml.DeviceGetIrqNum
+	DeviceGetJpgUtilization                           = libnvml.DeviceGetJpgUtilization
+	DeviceGetLastBBXFlushTime                         = libnvml.DeviceGetLastBBXFlushTime
+	DeviceGetMPSComputeRunningProcesses               = libnvml.DeviceGetMPSComputeRunningProcesses
+	DeviceGetMarginTemperature                        = libnvml.DeviceGetMarginTemperature
+	DeviceGetMaxClockInfo                             = libnvml.DeviceGetMaxClockInfo
+	DeviceGetMaxCustomerBoostClock                    = libnvml.DeviceGetMaxCustomerBoostClock
+	DeviceGetMaxMigDeviceCount                        = libnvml.DeviceGetMaxMigDeviceCount
+	DeviceGetMaxPcieLinkGeneration                    = libnvml.DeviceGetMaxPcieLinkGeneration
+	DeviceGetMaxPcieLinkWidth                         = libnvml.DeviceGetMaxPcieLinkWidth
+	DeviceGetMemClkMinMaxVfOffset                     = libnvml.DeviceGetMemClkMinMaxVfOffset
+	DeviceGetMemClkVfOffset                           = libnvml.DeviceGetMemClkVfOffset
+	DeviceGetMemoryAffinity                           = libnvml.DeviceGetMemoryAffinity
+	DeviceGetMemoryBusWidth                           = libnvml.DeviceGetMemoryBusWidth
+	DeviceGetMemoryErrorCounter                       = libnvml.DeviceGetMemoryErrorCounter
+	DeviceGetMemoryInfo                               = libnvml.DeviceGetMemoryInfo
+	DeviceGetMemoryInfo_v2                            = libnvml.DeviceGetMemoryInfo_v2
+	DeviceGetMemoryLimits_v1                          = libnvml.DeviceGetMemoryLimits_v1
+	DeviceGetMigDeviceHandleByIndex                   = libnvml.DeviceGetMigDeviceHandleByIndex
+	DeviceGetMigMode                                  = libnvml.DeviceGetMigMode
+	DeviceGetMinMaxClockOfPState                      = libnvml.DeviceGetMinMaxClockOfPState
+	DeviceGetMinMaxFanSpeed                           = libnvml.DeviceGetMinMaxFanSpeed
+	DeviceGetMinorNumber                              = libnvml.DeviceGetMinorNumber
+	DeviceGetModuleId                                 = libnvml.DeviceGetModuleId
+	DeviceGetMultiGpuBoard                            = libnvml.DeviceGetMultiGpuBoard
+	DeviceGetName                                     = libnvml.DeviceGetName
+	DeviceGetNumFans                                  = libnvml.DeviceGetNumFans
+	DeviceGetNumGpuCores                              = libnvml.DeviceGetNumGpuCores
+	DeviceGetNumaNodeId                               = libnvml.DeviceGetNumaNodeId
+	DeviceGetNvLinkCapability                         = libnvml.DeviceGetNvLinkCapability
+	DeviceGetNvLinkErrorCounter                       = libnvml.DeviceGetNvLinkErrorCounter
+	DeviceGetNvLinkInfo                               = libnvml.DeviceGetNvLinkInfo
+	DeviceGetNvLinkRemoteDeviceType                   = libnvml.DeviceGetNvLinkRemoteDeviceType
+	DeviceGetNvLinkRemotePciInfo                      = libnvml.DeviceGetNvLinkRemotePciInfo
+	DeviceGetNvLinkState                              = libnvml.DeviceGetNvLinkState
+	DeviceGetNvLinkTelemetrySamples_v1                = libnvml.DeviceGetNvLinkTelemetrySamples_v1
+	DeviceGetNvLinkUtilizationControl                 = libnvml.DeviceGetNvLinkUtilizationControl
+	DeviceGetNvLinkUtilizationCounter                 = libnvml.DeviceGetNvLinkUtilizationCounter
+	DeviceGetNvLinkVersion                            = libnvml.DeviceGetNvLinkVersion
+	DeviceGetNvlinkBwMode                             = libnvml.DeviceGetNvlinkBwMode
+	DeviceGetNvlinkSupportedBwModes                   = libnvml.DeviceGetNvlinkSupportedBwModes
+	DeviceGetOfaUtilization                           = libnvml.DeviceGetOfaUtilization
+	DeviceGetP2PStatus                                = libnvml.DeviceGetP2PStatus
+	DeviceGetPciInfo                                  = libnvml.DeviceGetPciInfo
+	DeviceGetPciInfoExt                               = libnvml.DeviceGetPciInfoExt
+	DeviceGetPcieLinkMaxSpeed                         = libnvml.DeviceGetPcieLinkMaxSpeed
+	DeviceGetPcieReplayCounter                        = libnvml.DeviceGetPcieReplayCounter
+	DeviceGetPcieSpeed                                = libnvml.DeviceGetPcieSpeed
+	DeviceGetPcieThroughput                           = libnvml.DeviceGetPcieThroughput
+	DeviceGetPdi                                      = libnvml.DeviceGetPdi
+	DeviceGetPerformanceModes                         = libnvml.DeviceGetPerformanceModes
+	DeviceGetPerformanceState                         = libnvml.DeviceGetPerformanceState
+	DeviceGetPersistenceMode                          = libnvml.DeviceGetPersistenceMode
+	DeviceGetPgpuMetadataString                       = libnvml.DeviceGetPgpuMetadataString
+	DeviceGetPlatformInfo                             = libnvml.DeviceGetPlatformInfo
+	DeviceGetPowerManagementDefaultLimit              = libnvml.DeviceGetPowerManagementDefaultLimit
+	DeviceGetPowerManagementLimit                     = libnvml.DeviceGetPowerManagementLimit
+	DeviceGetPowerManagementLimitConstraints          = libnvml.DeviceGetPowerManagementLimitConstraints
+	DeviceGetPowerManagementMode                      = libnvml.DeviceGetPowerManagementMode
+	DeviceGetPowerMizerMode_v1                        = libnvml.DeviceGetPowerMizerMode_v1
+	DeviceGetPowerSource                              = libnvml.DeviceGetPowerSource
+	DeviceGetPowerState                               = libnvml.DeviceGetPowerState
+	DeviceGetPowerUsage                               = libnvml.DeviceGetPowerUsage
+	DeviceGetProcessUtilization                       = libnvml.DeviceGetProcessUtilization
+	DeviceGetProcessesUtilizationInfo                 = libnvml.DeviceGetProcessesUtilizationInfo
+	DeviceGetRemappedRows                             = libnvml.DeviceGetRemappedRows
+	DeviceGetRemappedRows_v2                          = libnvml.DeviceGetRemappedRows_v2
+	DeviceGetRepairStatus                             = libnvml.DeviceGetRepairStatus
+	DeviceGetRetiredPages                             = libnvml.DeviceGetRetiredPages
+	DeviceGetRetiredPagesPendingStatus                = libnvml.DeviceGetRetiredPagesPendingStatus
+	DeviceGetRetiredPages_v2                          = libnvml.DeviceGetRetiredPages_v2
+	DeviceGetRowRemapperHistogram                     = libnvml.DeviceGetRowRemapperHistogram
+	DeviceGetRunningProcessDetailList                 = libnvml.DeviceGetRunningProcessDetailList
+	DeviceGetSamples                                  = libnvml.DeviceGetSamples
+	DeviceGetSerial                                   = libnvml.DeviceGetSerial
+	DeviceGetSramEccErrorStatus                       = libnvml.DeviceGetSramEccErrorStatus
+	DeviceGetSramUniqueUncorrectedEccErrorCounts      = libnvml.DeviceGetSramUniqueUncorrectedEccErrorCounts
+	DeviceGetSupportedClocksEventReasons              = libnvml.DeviceGetSupportedClocksEventReasons
+	DeviceGetSupportedClocksThrottleReasons           = libnvml.DeviceGetSupportedClocksThrottleReasons
+	DeviceGetSupportedEventTypes                      = libnvml.DeviceGetSupportedEventTypes
+	DeviceGetSupportedGraphicsClocks                  = libnvml.DeviceGetSupportedGraphicsClocks
+	DeviceGetSupportedMemoryClocks                    = libnvml.DeviceGetSupportedMemoryClocks
+	DeviceGetSupportedPerformanceStates               = libnvml.DeviceGetSupportedPerformanceStates
+	DeviceGetSupportedVgpus                           = libnvml.DeviceGetSupportedVgpus
+	DeviceGetTargetFanSpeed                           = libnvml.DeviceGetTargetFanSpeed
+	DeviceGetTemperature                              = libnvml.DeviceGetTemperature
+	DeviceGetTemperatureThreshold                     = libnvml.DeviceGetTemperatureThreshold
+	DeviceGetTemperatureV                             = libnvml.DeviceGetTemperatureV
+	DeviceGetThermalSettings                          = libnvml.DeviceGetThermalSettings
+	DeviceGetTopologyCommonAncestor                   = libnvml.DeviceGetTopologyCommonAncestor
+	DeviceGetTopologyNearestGpus                      = libnvml.DeviceGetTopologyNearestGpus
+	DeviceGetTotalEccErrors                           = libnvml.DeviceGetTotalEccErrors
+	DeviceGetTotalEnergyConsumption                   = libnvml.DeviceGetTotalEnergyConsumption
+	DeviceGetUUID                                     = libnvml.DeviceGetUUID
+	DeviceGetUnrepairableMemoryFlag_v1                = libnvml.DeviceGetUnrepairableMemoryFlag_v1
+	DeviceGetUtilizationRates                         = libnvml.DeviceGetUtilizationRates
+	DeviceGetVbiosVersion                             = libnvml.DeviceGetVbiosVersion
+	DeviceGetVgpuCapabilities                         = libnvml.DeviceGetVgpuCapabilities
+	DeviceGetVgpuHeterogeneousMode                    = libnvml.DeviceGetVgpuHeterogeneousMode
+	DeviceGetVgpuInstancesUtilizationInfo             = libnvml.DeviceGetVgpuInstancesUtilizationInfo
+	DeviceGetVgpuMetadata                             = libnvml.DeviceGetVgpuMetadata
+	DeviceGetVgpuProcessUtilization                   = libnvml.DeviceGetVgpuProcessUtilization
+	DeviceGetVgpuProcessesUtilizationInfo             = libnvml.DeviceGetVgpuProcessesUtilizationInfo
+	DeviceGetVgpuSchedulerCapabilities                = libnvml.DeviceGetVgpuSchedulerCapabilities
+	DeviceGetVgpuSchedulerLog                         = libnvml.DeviceGetVgpuSchedulerLog
+	DeviceGetVgpuSchedulerLog_v2                      = libnvml.DeviceGetVgpuSchedulerLog_v2
+	DeviceGetVgpuSchedulerState                       = libnvml.DeviceGetVgpuSchedulerState
+	DeviceGetVgpuSchedulerState_v2                    = libnvml.DeviceGetVgpuSchedulerState_v2
+	DeviceGetVgpuTypeCreatablePlacements              = libnvml.DeviceGetVgpuTypeCreatablePlacements
+	DeviceGetVgpuTypeSupportedPlacements              = libnvml.DeviceGetVgpuTypeSupportedPlacements
+	DeviceGetVgpuUtilization                          = libnvml.DeviceGetVgpuUtilization
+	DeviceGetViolationStatus                          = libnvml.DeviceGetViolationStatus
+	DeviceGetVirtualizationMode                       = libnvml.DeviceGetVirtualizationMode
+	DeviceIsMigDeviceHandle                           = libnvml.DeviceIsMigDeviceHandle
+	DeviceModifyDrainState                            = libnvml.DeviceModifyDrainState
+	DeviceOnSameBoard                                 = libnvml.DeviceOnSameBoard
+	DevicePerfMetricsGetSamples_v1                    = libnvml.DevicePerfMetricsGetSamples_v1
+	DevicePowerSmoothingActivatePresetProfile         = libnvml.DevicePowerSmoothingActivatePresetProfile
+	DevicePowerSmoothingSetState                      = libnvml.DevicePowerSmoothingSetState
+	DevicePowerSmoothingUpdatePresetProfileParam      = libnvml.DevicePowerSmoothingUpdatePresetProfileParam
+	DeviceQueryDrainState                             = libnvml.DeviceQueryDrainState
+	DeviceReadPRMCounters_v1                          = libnvml.DeviceReadPRMCounters_v1
+	DeviceReadWritePRM_v1                             = libnvml.DeviceReadWritePRM_v1
+	DeviceRegisterEvents                              = libnvml.DeviceRegisterEvents
+	DeviceRemoveGpu                                   = libnvml.DeviceRemoveGpu
+	DeviceRemoveGpu_v2                                = libnvml.DeviceRemoveGpu_v2
+	DeviceResetApplicationsClocks                     = libnvml.DeviceResetApplicationsClocks
+	DeviceResetGpuLockedClocks                        = libnvml.DeviceResetGpuLockedClocks
+	DeviceResetMemoryLockedClocks                     = libnvml.DeviceResetMemoryLockedClocks
+	DeviceResetNvLinkErrorCounters                    = libnvml.DeviceResetNvLinkErrorCounters
+	DeviceResetNvLinkUtilizationCounter               = libnvml.DeviceResetNvLinkUtilizationCounter
+	DeviceSetAPIRestriction                           = libnvml.DeviceSetAPIRestriction
+	DeviceSetAccountingMode                           = libnvml.DeviceSetAccountingMode
+	DeviceSetAdaptiveTgpMode_v1                       = libnvml.DeviceSetAdaptiveTgpMode_v1
+	DeviceSetApplicationsClocks                       = libnvml.DeviceSetApplicationsClocks
+	DeviceSetAutoBoostedClocksEnabled                 = libnvml.DeviceSetAutoBoostedClocksEnabled
+	DeviceSetClockOffsets                             = libnvml.DeviceSetClockOffsets
+	DeviceSetComputeMode                              = libnvml.DeviceSetComputeMode
+	DeviceSetConfComputeUnprotectedMemSize            = libnvml.DeviceSetConfComputeUnprotectedMemSize
+	DeviceSetCpuAffinity                              = libnvml.DeviceSetCpuAffinity
+	DeviceSetDefaultAutoBoostedClocksEnabled          = libnvml.DeviceSetDefaultAutoBoostedClocksEnabled
+	DeviceSetDefaultFanSpeed_v2                       = libnvml.DeviceSetDefaultFanSpeed_v2
+	DeviceSetDramEncryptionMode                       = libnvml.DeviceSetDramEncryptionMode
+	DeviceSetDriverModel                              = libnvml.DeviceSetDriverModel
+	DeviceSetEccMode                                  = libnvml.DeviceSetEccMode
+	DeviceSetFanControlPolicy                         = libnvml.DeviceSetFanControlPolicy
+	DeviceSetFanSpeed_v2                              = libnvml.DeviceSetFanSpeed_v2
+	DeviceSetGpcClkVfOffset                           = libnvml.DeviceSetGpcClkVfOffset
+	DeviceSetGpuLockedClocks                          = libnvml.DeviceSetGpuLockedClocks
+	DeviceSetGpuOperationMode                         = libnvml.DeviceSetGpuOperationMode
+	DeviceSetHostname_v1                              = libnvml.DeviceSetHostname_v1
+	DeviceSetMemClkVfOffset                           = libnvml.DeviceSetMemClkVfOffset
+	DeviceSetMemoryLimits_v1                          = libnvml.DeviceSetMemoryLimits_v1
+	DeviceSetMemoryLockedClocks                       = libnvml.DeviceSetMemoryLockedClocks
+	DeviceSetMigMode                                  = libnvml.DeviceSetMigMode
+	DeviceSetNvLinkDeviceLowPowerThreshold            = libnvml.DeviceSetNvLinkDeviceLowPowerThreshold
+	DeviceSetNvLinkUtilizationControl                 = libnvml.DeviceSetNvLinkUtilizationControl
+	DeviceSetNvlinkBwMode                             = libnvml.DeviceSetNvlinkBwMode
+	DeviceSetNvlinkBwModeAsync_v1                     = libnvml.DeviceSetNvlinkBwModeAsync_v1
+	DeviceSetPersistenceMode                          = libnvml.DeviceSetPersistenceMode
+	DeviceSetPowerManagementLimit                     = libnvml.DeviceSetPowerManagementLimit
+	DeviceSetPowerManagementLimit_v2                  = libnvml.DeviceSetPowerManagementLimit_v2
+	DeviceSetRusdSettings_v1                          = libnvml.DeviceSetRusdSettings_v1
+	DeviceSetTemperatureThreshold                     = libnvml.DeviceSetTemperatureThreshold
+	DeviceSetVgpuCapabilities                         = libnvml.DeviceSetVgpuCapabilities
+	DeviceSetVgpuHeterogeneousMode                    = libnvml.DeviceSetVgpuHeterogeneousMode
+	DeviceSetVgpuSchedulerState                       = libnvml.DeviceSetVgpuSchedulerState
+	DeviceSetVgpuSchedulerState_v2                    = libnvml.DeviceSetVgpuSchedulerState_v2
+	DeviceSetVirtualizationMode                       = libnvml.DeviceSetVirtualizationMode
+	DeviceValidateInforom                             = libnvml.DeviceValidateInforom
+	DeviceVgpuForceGspUnload                          = libnvml.DeviceVgpuForceGspUnload
+	DeviceWorkloadPowerProfileClearRequestedProfiles  = libnvml.DeviceWorkloadPowerProfileClearRequestedProfiles
+	DeviceWorkloadPowerProfileGetCurrentProfiles      = libnvml.DeviceWorkloadPowerProfileGetCurrentProfiles
+	DeviceWorkloadPowerProfileGetProfilesInfo         = libnvml.DeviceWorkloadPowerProfileGetProfilesInfo
+	DeviceWorkloadPowerProfileSetRequestedProfiles    = libnvml.DeviceWorkloadPowerProfileSetRequestedProfiles
+	DeviceWorkloadPowerProfileUpdateProfiles_v1       = libnvml.DeviceWorkloadPowerProfileUpdateProfiles_v1
+	ErrorString                                       = libnvml.ErrorString
+	EventSetCreate                                    = libnvml.EventSetCreate
+	EventSetFree                                      = libnvml.EventSetFree
+	EventSetGetContextCount_v1                        = libnvml.EventSetGetContextCount_v1
+	EventSetGetContextData_v1                         = libnvml.EventSetGetContextData_v1
+	EventSetGetContextInfo_v1                         = libnvml.EventSetGetContextInfo_v1
+	EventSetGetGpuOperationalEventContextLegacyXid_v1 = libnvml.EventSetGetGpuOperationalEventContextLegacyXid_v1
+	EventSetRegisterGpuOperationalEvents_v1           = libnvml.EventSetRegisterGpuOperationalEvents_v1
+	EventSetWait                                      = libnvml.EventSetWait
+	EventSetWait_v3                                   = libnvml.EventSetWait_v3
+	Extensions                                        = libnvml.Extensions
+	GetExcludedDeviceCount                            = libnvml.GetExcludedDeviceCount
+	GetExcludedDeviceInfoByIndex                      = libnvml.GetExcludedDeviceInfoByIndex
+	GetVgpuCompatibility                              = libnvml.GetVgpuCompatibility
+	GetVgpuDriverCapabilities                         = libnvml.GetVgpuDriverCapabilities
+	GetVgpuVersion                                    = libnvml.GetVgpuVersion
+	GpmMetricsGet                                     = libnvml.GpmMetricsGet
+	GpmMetricsGetV                                    = libnvml.GpmMetricsGetV
+	GpmMigSampleGet                                   = libnvml.GpmMigSampleGet
+	GpmQueryDeviceSupport                             = libnvml.GpmQueryDeviceSupport
+	GpmQueryDeviceSupportV                            = libnvml.GpmQueryDeviceSupportV
+	GpmQueryIfStreamingEnabled                        = libnvml.GpmQueryIfStreamingEnabled
+	GpmSampleAlloc                                    = libnvml.GpmSampleAlloc
+	GpmSampleFree                                     = libnvml.GpmSampleFree
+	GpmSampleGet                                      = libnvml.GpmSampleGet
+	GpmSetStreamingEnabled                            = libnvml.GpmSetStreamingEnabled
+	GpuInstanceCreateComputeInstance                  = libnvml.GpuInstanceCreateComputeInstance
+	GpuInstanceCreateComputeInstanceWithPlacement     = libnvml.GpuInstanceCreateComputeInstanceWithPlacement
+	GpuInstanceDestroy                                = libnvml.GpuInstanceDestroy
+	GpuInstanceGetActiveVgpus                         = libnvml.GpuInstanceGetActiveVgpus
+	GpuInstanceGetComputeInstanceById                 = libnvml.GpuInstanceGetComputeInstanceById
+	GpuInstanceGetComputeInstancePossiblePlacements   = libnvml.GpuInstanceGetComputeInstancePossiblePlacements
+	GpuInstanceGetComputeInstanceProfileInfo          = libnvml.GpuInstanceGetComputeInstanceProfileInfo
+	GpuInstanceGetComputeInstanceProfileInfoV         = libnvml.GpuInstanceGetComputeInstanceProfileInfoV
+	GpuInstanceGetComputeInstanceRemainingCapacity    = libnvml.GpuInstanceGetComputeInstanceRemainingCapacity
+	GpuInstanceGetComputeInstances                    = libnvml.GpuInstanceGetComputeInstances
+	GpuInstanceGetCreatableVgpus                      = libnvml.GpuInstanceGetCreatableVgpus
+	GpuInstanceGetInfo                                = libnvml.GpuInstanceGetInfo
+	GpuInstanceGetVgpuHeterogeneousMode               = libnvml.GpuInstanceGetVgpuHeterogeneousMode
+	GpuInstanceGetVgpuSchedulerLog                    = libnvml.GpuInstanceGetVgpuSchedulerLog
+	GpuInstanceGetVgpuSchedulerLog_v2                 = libnvml.GpuInstanceGetVgpuSchedulerLog_v2
+	GpuInstanceGetVgpuSchedulerState                  = libnvml.GpuInstanceGetVgpuSchedulerState
+	GpuInstanceGetVgpuSchedulerState_v2               = libnvml.GpuInstanceGetVgpuSchedulerState_v2
+	GpuInstanceGetVgpuTypeCreatablePlacements         = libnvml.GpuInstanceGetVgpuTypeCreatablePlacements
+	GpuInstanceSetVgpuHeterogeneousMode               = libnvml.GpuInstanceSetVgpuHeterogeneousMode
+	GpuInstanceSetVgpuSchedulerState                  = libnvml.GpuInstanceSetVgpuSchedulerState
+	GpuInstanceSetVgpuSchedulerState_v2               = libnvml.GpuInstanceSetVgpuSchedulerState_v2
+	Init                                              = libnvml.Init
+	InitWithFlags                                     = libnvml.InitWithFlags
+	SetVgpuVersion                                    = libnvml.SetVgpuVersion
+	Shutdown                                          = libnvml.Shutdown
+	SystemEventSetCreate                              = libnvml.SystemEventSetCreate
+	SystemEventSetFree                                = libnvml.SystemEventSetFree
+	SystemEventSetWait                                = libnvml.SystemEventSetWait
+	SystemGetCPER_v1                                  = libnvml.SystemGetCPER_v1
+	SystemGetConfComputeCapabilities                  = libnvml.SystemGetConfComputeCapabilities
+	SystemGetConfComputeGpusReadyState                = libnvml.SystemGetConfComputeGpusReadyState
+	SystemGetConfComputeKeyRotationThresholdInfo      = libnvml.SystemGetConfComputeKeyRotationThresholdInfo
+	SystemGetConfComputeSettings                      = libnvml.SystemGetConfComputeSettings
+	SystemGetConfComputeState                         = libnvml.SystemGetConfComputeState
+	SystemGetCudaDriverVersion                        = libnvml.SystemGetCudaDriverVersion
+	SystemGetCudaDriverVersion_v2                     = libnvml.SystemGetCudaDriverVersion_v2
+	SystemGetDriverBranch                             = libnvml.SystemGetDriverBranch
+	SystemGetDriverVersion                            = libnvml.SystemGetDriverVersion
+	SystemGetHicVersion                               = libnvml.SystemGetHicVersion
+	SystemGetNVMLVersion                              = libnvml.SystemGetNVMLVersion
+	SystemGetNvlinkBwMode                             = libnvml.SystemGetNvlinkBwMode
+	SystemGetProcessName                              = libnvml.SystemGetProcessName
+	SystemGetTopologyGpuSet                           = libnvml.SystemGetTopologyGpuSet
+	SystemRegisterEvents                              = libnvml.SystemRegisterEvents
+	SystemSetConfComputeGpusReadyState                = libnvml.SystemSetConfComputeGpusReadyState
+	SystemSetConfComputeKeyRotationThresholdInfo      = libnvml.SystemSetConfComputeKeyRotationThresholdInfo
+	SystemSetNvlinkBwMode                             = libnvml.SystemSetNvlinkBwMode
+	UnitGetCount                                      = libnvml.UnitGetCount
+	UnitGetDevices                                    = libnvml.UnitGetDevices
+	UnitGetFanSpeedInfo                               = libnvml.UnitGetFanSpeedInfo
+	UnitGetHandleByIndex                              = libnvml.UnitGetHandleByIndex
+	UnitGetLedState                                   = libnvml.UnitGetLedState
+	UnitGetPsuInfo                                    = libnvml.UnitGetPsuInfo
+	UnitGetTemperature                                = libnvml.UnitGetTemperature
+	UnitGetUnitInfo                                   = libnvml.UnitGetUnitInfo
+	UnitSetLedState                                   = libnvml.UnitSetLedState
+	VgpuInstanceClearAccountingPids                   = libnvml.VgpuInstanceClearAccountingPids
+	VgpuInstanceGetAccountingMode                     = libnvml.VgpuInstanceGetAccountingMode
+	VgpuInstanceGetAccountingPids                     = libnvml.VgpuInstanceGetAccountingPids
+	VgpuInstanceGetAccountingStats                    = libnvml.VgpuInstanceGetAccountingStats
+	VgpuInstanceGetEccMode                            = libnvml.VgpuInstanceGetEccMode
+	VgpuInstanceGetEncoderCapacity                    = libnvml.VgpuInstanceGetEncoderCapacity
+	VgpuInstanceGetEncoderSessions                    = libnvml.VgpuInstanceGetEncoderSessions
+	VgpuInstanceGetEncoderStats                       = libnvml.VgpuInstanceGetEncoderStats
+	VgpuInstanceGetFBCSessions                        = libnvml.VgpuInstanceGetFBCSessions
+	VgpuInstanceGetFBCStats                           = libnvml.VgpuInstanceGetFBCStats
+	VgpuInstanceGetFbUsage                            = libnvml.VgpuInstanceGetFbUsage
+	VgpuInstanceGetFrameRateLimit                     = libnvml.VgpuInstanceGetFrameRateLimit
+	VgpuInstanceGetGpuInstanceId                      = libnvml.VgpuInstanceGetGpuInstanceId
+	VgpuInstanceGetGpuPciId                           = libnvml.VgpuInstanceGetGpuPciId
+	VgpuInstanceGetLicenseInfo                        = libnvml.VgpuInstanceGetLicenseInfo
+	VgpuInstanceGetLicenseStatus                      = libnvml.VgpuInstanceGetLicenseStatus
+	VgpuInstanceGetMdevUUID                           = libnvml.VgpuInstanceGetMdevUUID
+	VgpuInstanceGetMetadata                           = libnvml.VgpuInstanceGetMetadata
+	VgpuInstanceGetRuntimeStateSize                   = libnvml.VgpuInstanceGetRuntimeStateSize
+	VgpuInstanceGetType                               = libnvml.VgpuInstanceGetType
+	VgpuInstanceGetUUID                               = libnvml.VgpuInstanceGetUUID
+	VgpuInstanceGetVmDriverVersion                    = libnvml.VgpuInstanceGetVmDriverVersion
+	VgpuInstanceGetVmID                               = libnvml.VgpuInstanceGetVmID
+	VgpuInstanceSetEncoderCapacity                    = libnvml.VgpuInstanceSetEncoderCapacity
+	VgpuTypeGetBAR1Info                               = libnvml.VgpuTypeGetBAR1Info
+	VgpuTypeGetCapabilities                           = libnvml.VgpuTypeGetCapabilities
+	VgpuTypeGetClass                                  = libnvml.VgpuTypeGetClass
+	VgpuTypeGetDeviceID                               = libnvml.VgpuTypeGetDeviceID
+	VgpuTypeGetFrameRateLimit                         = libnvml.VgpuTypeGetFrameRateLimit
+	VgpuTypeGetFramebufferSize                        = libnvml.VgpuTypeGetFramebufferSize
+	VgpuTypeGetGpuInstanceProfileId                   = libnvml.VgpuTypeGetGpuInstanceProfileId
+	VgpuTypeGetID                                     = libnvml.VgpuTypeGetID
+	VgpuTypeGetLicense                                = libnvml.VgpuTypeGetLicense
+	VgpuTypeGetMaxInstances                           = libnvml.VgpuTypeGetMaxInstances
+	VgpuTypeGetMaxInstancesPerGpuInstance             = libnvml.VgpuTypeGetMaxInstancesPerGpuInstance
+	VgpuTypeGetMaxInstancesPerVm                      = libnvml.VgpuTypeGetMaxInstancesPerVm
+	VgpuTypeGetName                                   = libnvml.VgpuTypeGetName
+	VgpuTypeGetNumDisplayHeads                        = libnvml.VgpuTypeGetNumDisplayHeads
+	VgpuTypeGetResolution                             = libnvml.VgpuTypeGetResolution
 )
 
 // Interface represents the interface for the library type.
@@ -435,6 +451,7 @@ type Interface interface {
 	DeviceGetAccountingStats_v2(Device, uint32) (AccountingStats_v2, Return)
 	DeviceGetActiveVgpus(Device) ([]VgpuInstance, Return)
 	DeviceGetAdaptiveClockInfoStatus(Device) (uint32, Return)
+	DeviceGetAdaptiveTgpModeInfo_v1(Device) (AdaptiveTgpModeInfo_v1, Return)
 	DeviceGetAddressingMode(Device) (DeviceAddressingMode, Return)
 	DeviceGetApplicationsClock(Device, ClockType) (uint32, Return)
 	DeviceGetArchitecture(Device) (DeviceArchitecture, Return)
@@ -442,6 +459,7 @@ type Interface interface {
 	DeviceGetAutoBoostedClocksEnabled(Device) (EnableState, EnableState, Return)
 	DeviceGetBAR1MemoryInfo(Device) (BAR1Memory, Return)
 	DeviceGetBBXTimeData_v1(Device) (BBXTimeData_v1, Return)
+	DeviceGetBankRemapperStatus_v1(Device) (EccBankRemapperStatus_v1, Return)
 	DeviceGetBoardId(Device) (uint32, Return)
 	DeviceGetBoardPartNumber(Device) (string, Return)
 	DeviceGetBrand(Device) (BrandType, Return)
@@ -499,6 +517,7 @@ type Interface interface {
 	DeviceGetGpcClkVfOffset(Device) (int, Return)
 	DeviceGetGpuFabricInfo(Device) (GpuFabricInfo, Return)
 	DeviceGetGpuFabricInfoV(Device) GpuFabricInfoHandler
+	DeviceGetGpuFabricInfo_v4(Device) (GpuFabricInfo_v4, Return)
 	DeviceGetGpuInstanceById(Device, int) (GpuInstance, Return)
 	DeviceGetGpuInstanceId(Device) (int, Return)
 	DeviceGetGpuInstancePossiblePlacements(Device, *GpuInstanceProfileInfo) ([]GpuInstancePlacement, Return)
@@ -541,6 +560,7 @@ type Interface interface {
 	DeviceGetMemoryErrorCounter(Device, MemoryErrorType, EccCounterType, MemoryLocation) (uint64, Return)
 	DeviceGetMemoryInfo(Device) (Memory, Return)
 	DeviceGetMemoryInfo_v2(Device) (Memory_v2, Return)
+	DeviceGetMemoryLimits_v1(Device, string) (GetMemoryLimits_v1, Return)
 	DeviceGetMigDeviceHandleByIndex(Device, int) (Device, Return)
 	DeviceGetMigMode(Device) (int, int, Return)
 	DeviceGetMinMaxClockOfPState(Device, ClockType, Pstates) (uint32, uint32, Return)
@@ -558,6 +578,7 @@ type Interface interface {
 	DeviceGetNvLinkRemoteDeviceType(Device, int) (IntNvLinkDeviceType, Return)
 	DeviceGetNvLinkRemotePciInfo(Device, int) (PciInfo, Return)
 	DeviceGetNvLinkState(Device, int) (EnableState, Return)
+	DeviceGetNvLinkTelemetrySamples_v1(Device, *NvlinkTelemetrySamples_v1) Return
 	DeviceGetNvLinkUtilizationControl(Device, int, int) (NvLinkUtilizationControl, Return)
 	DeviceGetNvLinkUtilizationCounter(Device, int, int) (uint64, uint64, Return)
 	DeviceGetNvLinkVersion(Device, int) (uint32, Return)
@@ -638,6 +659,7 @@ type Interface interface {
 	DeviceIsMigDeviceHandle(Device) (bool, Return)
 	DeviceModifyDrainState(*PciInfo, EnableState) Return
 	DeviceOnSameBoard(Device, Device) (int, Return)
+	DevicePerfMetricsGetSamples_v1(Device, *PerfMetricsSamples_v1) Return
 	DevicePowerSmoothingActivatePresetProfile(Device, *PowerSmoothingProfile) Return
 	DevicePowerSmoothingSetState(Device, *PowerSmoothingState) Return
 	DevicePowerSmoothingUpdatePresetProfileParam(Device, *PowerSmoothingProfile) Return
@@ -654,6 +676,7 @@ type Interface interface {
 	DeviceResetNvLinkUtilizationCounter(Device, int, int) Return
 	DeviceSetAPIRestriction(Device, RestrictedAPI, EnableState) Return
 	DeviceSetAccountingMode(Device, EnableState) Return
+	DeviceSetAdaptiveTgpMode_v1(Device, EnableState) Return
 	DeviceSetApplicationsClocks(Device, uint32, uint32) Return
 	DeviceSetAutoBoostedClocksEnabled(Device, EnableState) Return
 	DeviceSetClockOffsets(Device, ClockOffset) Return
@@ -672,11 +695,13 @@ type Interface interface {
 	DeviceSetGpuOperationMode(Device, GpuOperationMode) Return
 	DeviceSetHostname_v1(Device, string) Return
 	DeviceSetMemClkVfOffset(Device, int) Return
+	DeviceSetMemoryLimits_v1(Device, string, int, int) Return
 	DeviceSetMemoryLockedClocks(Device, uint32, uint32) Return
 	DeviceSetMigMode(Device, int) (Return, Return)
 	DeviceSetNvLinkDeviceLowPowerThreshold(Device, *NvLinkPowerThres) Return
 	DeviceSetNvLinkUtilizationControl(Device, int, int, *NvLinkUtilizationControl, bool) Return
 	DeviceSetNvlinkBwMode(Device, *NvlinkSetBwMode) Return
+	DeviceSetNvlinkBwModeAsync_v1(Device, *NvlinkSetBwModeAsync_v1) Return
 	DeviceSetPersistenceMode(Device, EnableState) Return
 	DeviceSetPowerManagementLimit(Device, uint32) Return
 	DeviceSetPowerManagementLimit_v2(Device, *PowerValue_v2) Return
@@ -697,7 +722,13 @@ type Interface interface {
 	ErrorString(Return) string
 	EventSetCreate() (EventSet, Return)
 	EventSetFree(EventSet) Return
+	EventSetGetContextCount_v1(EventSet) (uint32, Return)
+	EventSetGetContextData_v1(EventSet, uint32, []byte) (uint32, Return)
+	EventSetGetContextInfo_v1(EventSet, uint32) (OperationalEventContextInfo_v1, Return)
+	EventSetGetGpuOperationalEventContextLegacyXid_v1(EventSet, uint32) (GpuOperationalEventContextLegacyXid_v1, Return)
+	EventSetRegisterGpuOperationalEvents_v1(EventSet, *GpuOperationalEventConfig_v1) Return
 	EventSetWait(EventSet, uint32) (EventData, Return)
+	EventSetWait_v3(EventSet, uint32) (EventData_v2, Return)
 	Extensions() ExtendedInterface
 	GetExcludedDeviceCount() (int, Return)
 	GetExcludedDeviceInfoByIndex(int) (ExcludedDeviceInfo, Return)
@@ -801,6 +832,7 @@ type Interface interface {
 	VgpuTypeGetFrameRateLimit(VgpuTypeId) (uint32, Return)
 	VgpuTypeGetFramebufferSize(VgpuTypeId) (uint64, Return)
 	VgpuTypeGetGpuInstanceProfileId(VgpuTypeId) (uint32, Return)
+	VgpuTypeGetID(VgpuTypeId) uint32
 	VgpuTypeGetLicense(VgpuTypeId) (string, Return)
 	VgpuTypeGetMaxInstances(Device, VgpuTypeId) (int, Return)
 	VgpuTypeGetMaxInstancesPerGpuInstance(*VgpuTypeMaxInstance) Return
@@ -829,6 +861,7 @@ type Device interface {
 	GetAccountingStats_v2(uint32) (AccountingStats_v2, Return)
 	GetActiveVgpus() ([]VgpuInstance, Return)
 	GetAdaptiveClockInfoStatus() (uint32, Return)
+	GetAdaptiveTgpModeInfo_v1() (AdaptiveTgpModeInfo_v1, Return)
 	GetAddressingMode() (DeviceAddressingMode, Return)
 	GetApplicationsClock(ClockType) (uint32, Return)
 	GetArchitecture() (DeviceArchitecture, Return)
@@ -836,6 +869,7 @@ type Device interface {
 	GetAutoBoostedClocksEnabled() (EnableState, EnableState, Return)
 	GetBAR1MemoryInfo() (BAR1Memory, Return)
 	GetBBXTimeData_v1() (BBXTimeData_v1, Return)
+	GetBankRemapperStatus_v1() (EccBankRemapperStatus_v1, Return)
 	GetBoardId() (uint32, Return)
 	GetBoardPartNumber() (string, Return)
 	GetBrand() (BrandType, Return)
@@ -892,6 +926,7 @@ type Device interface {
 	GetGpcClkVfOffset() (int, Return)
 	GetGpuFabricInfo() (GpuFabricInfo, Return)
 	GetGpuFabricInfoV() GpuFabricInfoHandler
+	GetGpuFabricInfo_v4() (GpuFabricInfo_v4, Return)
 	GetGpuInstanceById(int) (GpuInstance, Return)
 	GetGpuInstanceId() (int, Return)
 	GetGpuInstancePossiblePlacements(*GpuInstanceProfileInfo) ([]GpuInstancePlacement, Return)
@@ -929,6 +964,7 @@ type Device interface {
 	GetMemoryErrorCounter(MemoryErrorType, EccCounterType, MemoryLocation) (uint64, Return)
 	GetMemoryInfo() (Memory, Return)
 	GetMemoryInfo_v2() (Memory_v2, Return)
+	GetMemoryLimits_v1(string) (GetMemoryLimits_v1, Return)
 	GetMigDeviceHandleByIndex(int) (Device, Return)
 	GetMigMode() (int, int, Return)
 	GetMinMaxClockOfPState(ClockType, Pstates) (uint32, uint32, Return)
@@ -946,6 +982,7 @@ type Device interface {
 	GetNvLinkRemoteDeviceType(int) (IntNvLinkDeviceType, Return)
 	GetNvLinkRemotePciInfo(int) (PciInfo, Return)
 	GetNvLinkState(int) (EnableState, Return)
+	GetNvLinkTelemetrySamples_v1(*NvlinkTelemetrySamples_v1) Return
 	GetNvLinkUtilizationControl(int, int) (NvLinkUtilizationControl, Return)
 	GetNvLinkUtilizationCounter(int, int) (uint64, uint64, Return)
 	GetNvLinkVersion(int) (uint32, Return)
@@ -1031,6 +1068,7 @@ type Device interface {
 	GpmSetStreamingEnabled(uint32) Return
 	IsMigDeviceHandle() (bool, Return)
 	OnSameBoard(Device) (int, Return)
+	PerfMetricsGetSamples_v1(*PerfMetricsSamples_v1) Return
 	PowerSmoothingActivatePresetProfile(*PowerSmoothingProfile) Return
 	PowerSmoothingSetState(*PowerSmoothingState) Return
 	PowerSmoothingUpdatePresetProfileParam(*PowerSmoothingProfile) Return
@@ -1044,6 +1082,7 @@ type Device interface {
 	ResetNvLinkUtilizationCounter(int, int) Return
 	SetAPIRestriction(RestrictedAPI, EnableState) Return
 	SetAccountingMode(EnableState) Return
+	SetAdaptiveTgpMode_v1(EnableState) Return
 	SetApplicationsClocks(uint32, uint32) Return
 	SetAutoBoostedClocksEnabled(EnableState) Return
 	SetClockOffsets(ClockOffset) Return
@@ -1062,11 +1101,13 @@ type Device interface {
 	SetGpuOperationMode(GpuOperationMode) Return
 	SetHostname_v1(string) Return
 	SetMemClkVfOffset(int) Return
+	SetMemoryLimits_v1(string, int, int) Return
 	SetMemoryLockedClocks(uint32, uint32) Return
 	SetMigMode(int) (Return, Return)
 	SetNvLinkDeviceLowPowerThreshold(*NvLinkPowerThres) Return
 	SetNvLinkUtilizationControl(int, int, *NvLinkUtilizationControl, bool) Return
 	SetNvlinkBwMode(*NvlinkSetBwMode) Return
+	SetNvlinkBwModeAsync_v1(*NvlinkSetBwModeAsync_v1) Return
 	SetPersistenceMode(EnableState) Return
 	SetPowerManagementLimit(uint32) Return
 	SetPowerManagementLimit_v2(*PowerValue_v2) Return
@@ -1127,7 +1168,13 @@ type ComputeInstance interface {
 //go:generate moq -out mock/eventset.go -pkg mock . EventSet:EventSet
 type EventSet interface {
 	Free() Return
+	GetContextCount_v1() (uint32, Return)
+	GetContextData_v1(uint32, []byte) (uint32, Return)
+	GetContextInfo_v1(uint32) (OperationalEventContextInfo_v1, Return)
+	GetGpuOperationalEventContextLegacyXid_v1(uint32) (GpuOperationalEventContextLegacyXid_v1, Return)
+	RegisterGpuOperationalEvents_v1(*GpuOperationalEventConfig_v1) Return
 	Wait(uint32) (EventData, Return)
+	Wait_v3(uint32) (EventData_v2, Return)
 }
 
 // GpmSample represents the interface for the nvmlGpmSample type.
@@ -1194,6 +1241,7 @@ type VgpuTypeId interface {
 	GetFrameRateLimit() (uint32, Return)
 	GetFramebufferSize() (uint64, Return)
 	GetGpuInstanceProfileId() (uint32, Return)
+	GetID() uint32
 	GetLicense() (string, Return)
 	GetMaxInstances(Device) (int, Return)
 	GetMaxInstancesPerVm() (int, Return)

--- a/vendor/github.com/coreos/go-systemd/v22/LICENSE
+++ b/vendor/github.com/coreos/go-systemd/v22/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-systemd/v22/NOTICE
+++ b/vendor/github.com/coreos/go-systemd/v22/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/dbus.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/dbus.go
@@ -1,0 +1,267 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dbus provides integration with the systemd D-Bus API.
+// See http://www.freedesktop.org/wiki/Software/systemd/dbus/
+package dbus
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	alpha        = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`
+	num          = `0123456789`
+	alphanum     = alpha + num
+	signalBuffer = 100
+)
+
+// needsEscape checks whether a byte in a potential dbus ObjectPath needs to be escaped
+func needsEscape(i int, b byte) bool {
+	// Escape everything that is not a-z-A-Z-0-9
+	// Also escape 0-9 if it's the first character
+	return strings.IndexByte(alphanum, b) == -1 ||
+		(i == 0 && strings.IndexByte(num, b) != -1)
+}
+
+// PathBusEscape sanitizes a constituent string of a dbus ObjectPath using the
+// rules that systemd uses for serializing special characters.
+func PathBusEscape(path string) string {
+	// Special case the empty string
+	if len(path) == 0 {
+		return "_"
+	}
+	n := []byte{}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if needsEscape(i, c) {
+			e := fmt.Sprintf("_%x", c)
+			n = append(n, []byte(e)...)
+		} else {
+			n = append(n, c)
+		}
+	}
+	return string(n)
+}
+
+// pathBusUnescape is the inverse of PathBusEscape.
+func pathBusUnescape(path string) string {
+	if path == "_" {
+		return ""
+	}
+	n := []byte{}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if c == '_' && i+2 < len(path) {
+			res, err := hex.DecodeString(path[i+1 : i+3])
+			if err == nil {
+				n = append(n, res...)
+			}
+			i += 2
+		} else {
+			n = append(n, c)
+		}
+	}
+	return string(n)
+}
+
+// Conn is a connection to systemd's dbus endpoint.
+type Conn struct {
+	// sysconn/sysobj are only used to call dbus methods
+	sysconn *dbus.Conn
+	sysobj  dbus.BusObject
+
+	// sigconn/sigobj are only used to receive dbus signals
+	sigconn *dbus.Conn
+	sigobj  dbus.BusObject
+
+	jobListener struct {
+		jobs map[dbus.ObjectPath][]chan<- string
+		sync.Mutex
+	}
+	subStateSubscriber struct {
+		updateCh chan<- *SubStateUpdate
+		errCh    chan<- error
+		sync.Mutex
+		ignore      map[dbus.ObjectPath]int64
+		cleanIgnore int64
+	}
+	propertiesSubscriber struct {
+		updateCh chan<- *PropertiesUpdate
+		errCh    chan<- error
+		sync.Mutex
+	}
+}
+
+// Deprecated: use NewWithContext instead.
+func New() (*Conn, error) {
+	return NewWithContext(context.Background())
+}
+
+// NewWithContext establishes a connection to any available bus and authenticates.
+// Callers should call Close() when done with the connection.
+func NewWithContext(ctx context.Context) (*Conn, error) {
+	conn, err := NewSystemConnectionContext(ctx)
+	if err != nil && os.Geteuid() == 0 {
+		return NewSystemdConnectionContext(ctx)
+	}
+	return conn, err
+}
+
+// Deprecated: use NewSystemConnectionContext instead.
+func NewSystemConnection() (*Conn, error) {
+	return NewSystemConnectionContext(context.Background())
+}
+
+// NewSystemConnectionContext establishes a connection to the system bus and authenticates.
+// Callers should call Close() when done with the connection.
+func NewSystemConnectionContext(ctx context.Context) (*Conn, error) {
+	return NewConnection(func() (*dbus.Conn, error) {
+		return dbusAuthHelloConnection(ctx, dbus.SystemBusPrivate)
+	})
+}
+
+// Deprecated: use NewUserConnectionContext instead.
+func NewUserConnection() (*Conn, error) {
+	return NewUserConnectionContext(context.Background())
+}
+
+// NewUserConnectionContext establishes a connection to the session bus and
+// authenticates. This can be used to connect to systemd user instances.
+// Callers should call Close() when done with the connection.
+func NewUserConnectionContext(ctx context.Context) (*Conn, error) {
+	return NewConnection(func() (*dbus.Conn, error) {
+		return dbusAuthHelloConnection(ctx, dbus.SessionBusPrivate)
+	})
+}
+
+// Deprecated: use NewSystemdConnectionContext instead.
+func NewSystemdConnection() (*Conn, error) {
+	return NewSystemdConnectionContext(context.Background())
+}
+
+// NewSystemdConnectionContext establishes a private, direct connection to systemd.
+// This can be used for communicating with systemd without a dbus daemon.
+// Callers should call Close() when done with the connection.
+func NewSystemdConnectionContext(ctx context.Context) (*Conn, error) {
+	return NewConnection(func() (*dbus.Conn, error) {
+		// We skip Hello when talking directly to systemd.
+		return dbusAuthConnection(ctx, func(opts ...dbus.ConnOption) (*dbus.Conn, error) {
+			return dbus.Dial("unix:path=/run/systemd/private", opts...)
+		})
+	})
+}
+
+// Close closes an established connection.
+func (c *Conn) Close() {
+	c.sysconn.Close()
+	c.sigconn.Close()
+}
+
+// Connected returns whether conn is connected
+func (c *Conn) Connected() bool {
+	return c.sysconn.Connected() && c.sigconn.Connected()
+}
+
+// NewConnection establishes a connection to a bus using a caller-supplied function.
+// This allows connecting to remote buses through a user-supplied mechanism.
+// The supplied function may be called multiple times, and should return independent connections.
+// The returned connection must be fully initialised: the org.freedesktop.DBus.Hello call must have succeeded,
+// and any authentication should be handled by the function.
+func NewConnection(dialBus func() (*dbus.Conn, error)) (*Conn, error) {
+	sysconn, err := dialBus()
+	if err != nil {
+		return nil, err
+	}
+
+	sigconn, err := dialBus()
+	if err != nil {
+		sysconn.Close()
+		return nil, err
+	}
+
+	c := &Conn{
+		sysconn: sysconn,
+		sysobj:  systemdObject(sysconn),
+		sigconn: sigconn,
+		sigobj:  systemdObject(sigconn),
+	}
+
+	c.subStateSubscriber.ignore = make(map[dbus.ObjectPath]int64)
+	c.jobListener.jobs = make(map[dbus.ObjectPath][]chan<- string)
+
+	// Setup the listeners on jobs so that we can get completions
+	c.sigconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal', interface='org.freedesktop.systemd1.Manager', member='JobRemoved'")
+
+	c.dispatch()
+	return c, nil
+}
+
+// GetManagerProperty returns the value of a property on the org.freedesktop.systemd1.Manager
+// interface. The value is returned in its string representation, as defined at
+// https://developer.gnome.org/glib/unstable/gvariant-text.html.
+func (c *Conn) GetManagerProperty(prop string) (string, error) {
+	variant, err := c.sysobj.GetProperty("org.freedesktop.systemd1.Manager." + prop)
+	if err != nil {
+		return "", err
+	}
+	return variant.String(), nil
+}
+
+func dbusAuthConnection(ctx context.Context, createBus func(opts ...dbus.ConnOption) (*dbus.Conn, error)) (*dbus.Conn, error) {
+	conn, err := createBus(dbus.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	// Only use EXTERNAL method, and hardcode the uid (not username)
+	// to avoid a username lookup (which requires a dynamically linked
+	// libc)
+	methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(os.Getuid()))}
+
+	err = conn.Auth(methods)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func dbusAuthHelloConnection(ctx context.Context, createBus func(opts ...dbus.ConnOption) (*dbus.Conn, error)) (*dbus.Conn, error) {
+	conn, err := dbusAuthConnection(ctx, createBus)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = conn.Hello(); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func systemdObject(conn *dbus.Conn) dbus.BusObject {
+	return conn.Object("org.freedesktop.systemd1", dbus.ObjectPath("/org/freedesktop/systemd1"))
+}

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/methods.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/methods.go
@@ -1,0 +1,735 @@
+// Copyright 2015, 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// Who specifies which process to send a signal to via the [Conn.KillUnitWithTarget].
+type Who string
+
+const (
+	// All sends the signal to all processes in the unit.
+	All Who = "all"
+	// Main sends the signal to the main process of the unit.
+	Main Who = "main"
+	// Control sends the signal to the control process of the unit.
+	Control Who = "control"
+)
+
+func (c *Conn) jobComplete(signal *dbus.Signal) {
+	var id uint32
+	var job dbus.ObjectPath
+	var unit string
+	var result string
+
+	_ = dbus.Store(signal.Body, &id, &job, &unit, &result)
+	c.jobListener.Lock()
+	for _, out := range c.jobListener.jobs[job] {
+		out <- result
+	}
+	delete(c.jobListener.jobs, job)
+	c.jobListener.Unlock()
+}
+
+func (c *Conn) startJob(ctx context.Context, ch chan<- string, job string, args ...any) (int, error) {
+	if ch != nil {
+		c.jobListener.Lock()
+		defer c.jobListener.Unlock()
+	}
+
+	var p dbus.ObjectPath
+	err := c.sysobj.CallWithContext(ctx, job, 0, args...).Store(&p)
+	if err != nil {
+		return 0, err
+	}
+
+	if ch != nil {
+		c.jobListener.jobs[p] = append(c.jobListener.jobs[p], ch)
+	}
+
+	// ignore error since 0 is fine if conversion fails
+	jobID, _ := strconv.Atoi(path.Base(string(p)))
+
+	return jobID, nil
+}
+
+// Deprecated: use StartUnitContext instead.
+func (c *Conn) StartUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.StartUnitContext(context.Background(), name, mode, ch)
+}
+
+// StartUnitContext enqueues a start job and depending jobs, if any (unless otherwise
+// specified by the mode string).
+//
+// Takes the unit to activate, plus a mode string. The mode needs to be one of
+// replace, fail, isolate, ignore-dependencies, ignore-requirements. If
+// "replace" the call will start the unit and its dependencies, possibly
+// replacing already queued jobs that conflict with this. If "fail" the call
+// will start the unit and its dependencies, but will fail if this would change
+// an already queued job. If "isolate" the call will start the unit in question
+// and terminate all units that aren't dependencies of it. If
+// "ignore-dependencies" it will start a unit but ignore all its dependencies.
+// If "ignore-requirements" it will start a unit but only ignore the
+// requirement dependencies. It is not recommended to make use of the latter
+// two options.
+//
+// If the provided channel is non-nil, a result string will be sent to it upon
+// job completion: one of done, canceled, timeout, failed, dependency, skipped.
+// done indicates successful execution of a job. canceled indicates that a job
+// has been canceled  before it finished execution. timeout indicates that the
+// job timeout was reached. failed indicates that the job failed. dependency
+// indicates that a job this job has been depending on failed and the job hence
+// has been removed too. skipped indicates that a job was skipped because it
+// didn't apply to the units current state.
+//
+// Important: It is the caller's responsibility to unblock the provided channel write,
+// either by reading from the channel or by using a buffered channel. Until the write
+// is unblocked, the Conn object cannot handle other jobs.
+//
+// If no error occurs, the ID of the underlying systemd job will be returned. There
+// does exist the possibility for no error to be returned, but for the returned job
+// ID to be 0. In this case, the actual underlying ID is not 0 and this datapoint
+// should not be considered authoritative.
+//
+// If an error does occur, it will be returned to the user alongside a job ID of 0.
+func (c *Conn) StartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.StartUnit", name, mode)
+}
+
+// Deprecated: use StopUnitContext instead.
+func (c *Conn) StopUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.StopUnitContext(context.Background(), name, mode, ch)
+}
+
+// StopUnitContext is similar to StartUnitContext, but stops the specified unit
+// rather than starting it.
+func (c *Conn) StopUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.StopUnit", name, mode)
+}
+
+// Deprecated: use ReloadUnitContext instead.
+func (c *Conn) ReloadUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.ReloadUnitContext(context.Background(), name, mode, ch)
+}
+
+// ReloadUnitContext reloads a unit. Reloading is done only if the unit
+// is already running, and fails otherwise.
+func (c *Conn) ReloadUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.ReloadUnit", name, mode)
+}
+
+// Deprecated: use RestartUnitContext instead.
+func (c *Conn) RestartUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.RestartUnitContext(context.Background(), name, mode, ch)
+}
+
+// RestartUnitContext restarts a service. If a service is restarted that isn't
+// running it will be started.
+func (c *Conn) RestartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.RestartUnit", name, mode)
+}
+
+// Deprecated: use TryRestartUnitContext instead.
+func (c *Conn) TryRestartUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.TryRestartUnitContext(context.Background(), name, mode, ch)
+}
+
+// TryRestartUnitContext is like RestartUnitContext, except that a service that
+// isn't running is not affected by the restart.
+func (c *Conn) TryRestartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.TryRestartUnit", name, mode)
+}
+
+// Deprecated: use ReloadOrRestartUnitContext instead.
+func (c *Conn) ReloadOrRestartUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.ReloadOrRestartUnitContext(context.Background(), name, mode, ch)
+}
+
+// ReloadOrRestartUnitContext attempts a reload if the unit supports it and use
+// a restart otherwise.
+func (c *Conn) ReloadOrRestartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.ReloadOrRestartUnit", name, mode)
+}
+
+// Deprecated: use ReloadOrTryRestartUnitContext instead.
+func (c *Conn) ReloadOrTryRestartUnit(name string, mode string, ch chan<- string) (int, error) {
+	return c.ReloadOrTryRestartUnitContext(context.Background(), name, mode, ch)
+}
+
+// ReloadOrTryRestartUnitContext attempts a reload if the unit supports it,
+// and use a "Try" flavored restart otherwise.
+func (c *Conn) ReloadOrTryRestartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.ReloadOrTryRestartUnit", name, mode)
+}
+
+// Deprecated: use StartTransientUnitContext instead.
+func (c *Conn) StartTransientUnit(name string, mode string, properties []Property, ch chan<- string) (int, error) {
+	return c.StartTransientUnitContext(context.Background(), name, mode, properties, ch)
+}
+
+// StartTransientUnitContext may be used to create and start a transient unit, which
+// will be released as soon as it is not running or referenced anymore or the
+// system is rebooted. name is the unit name including suffix, and must be
+// unique. mode is the same as in StartUnitContext, properties contains properties
+// of the unit.
+func (c *Conn) StartTransientUnitContext(ctx context.Context, name string, mode string, properties []Property, ch chan<- string) (int, error) {
+	return c.StartTransientUnitAux(ctx, name, mode, properties, make([]PropertyCollection, 0), ch)
+}
+
+// StartTransientUnitAux is the same as StartTransientUnitContext but allows passing
+// auxiliary units in the aux parameter.
+func (c *Conn) StartTransientUnitAux(ctx context.Context, name string, mode string, properties []Property, aux []PropertyCollection, ch chan<- string) (int, error) {
+	return c.startJob(ctx, ch, "org.freedesktop.systemd1.Manager.StartTransientUnit", name, mode, properties, aux)
+}
+
+// Deprecated: use [Conn.KillUnitWithTarget] instead.
+func (c *Conn) KillUnit(name string, signal int32) {
+	c.KillUnitContext(context.Background(), name, signal)
+}
+
+// KillUnitContext takes the unit name and a UNIX signal number to send.
+// All of the unit's processes are killed.
+//
+// Deprecated: use [Conn.KillUnitWithTarget] instead, with target argument set to [All].
+func (c *Conn) KillUnitContext(ctx context.Context, name string, signal int32) {
+	_ = c.KillUnitWithTarget(ctx, name, All, signal)
+}
+
+// KillUnitWithTarget sends a signal to the specified unit.
+// The target argument can be one of [All], [Main], or [Control].
+func (c *Conn) KillUnitWithTarget(ctx context.Context, name string, target Who, signal int32) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.KillUnit", 0, name, string(target), signal).Store()
+}
+
+// Deprecated: use ResetFailedUnitContext instead.
+func (c *Conn) ResetFailedUnit(name string) error {
+	return c.ResetFailedUnitContext(context.Background(), name)
+}
+
+// ResetFailedUnitContext resets the "failed" state of a specific unit.
+func (c *Conn) ResetFailedUnitContext(ctx context.Context, name string) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ResetFailedUnit", 0, name).Store()
+}
+
+// Deprecated: use SystemStateContext instead.
+func (c *Conn) SystemState() (*Property, error) {
+	return c.SystemStateContext(context.Background())
+}
+
+// SystemStateContext returns the systemd state. Equivalent to
+// systemctl is-system-running.
+func (c *Conn) SystemStateContext(ctx context.Context) (*Property, error) {
+	var err error
+	var prop dbus.Variant
+
+	obj := c.sysconn.Object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+	err = obj.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0, "org.freedesktop.systemd1.Manager", "SystemState").Store(&prop)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Property{Name: "SystemState", Value: prop}, nil
+}
+
+// getProperties takes the unit path and returns all of its dbus object properties, for the given dbus interface.
+func (c *Conn) getProperties(ctx context.Context, path dbus.ObjectPath, dbusInterface string) (map[string]any, error) {
+	var err error
+	var props map[string]dbus.Variant
+
+	if !path.IsValid() {
+		return nil, fmt.Errorf("invalid unit name: %v", path)
+	}
+
+	obj := c.sysconn.Object("org.freedesktop.systemd1", path)
+	err = obj.CallWithContext(ctx, "org.freedesktop.DBus.Properties.GetAll", 0, dbusInterface).Store(&props)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		out[k] = v.Value()
+	}
+
+	return out, nil
+}
+
+// Deprecated: use GetUnitPropertiesContext instead.
+func (c *Conn) GetUnitProperties(unit string) (map[string]any, error) {
+	return c.GetUnitPropertiesContext(context.Background(), unit)
+}
+
+// GetUnitPropertiesContext takes the (unescaped) unit name and returns all of
+// its dbus object properties.
+func (c *Conn) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]any, error) {
+	path := unitPath(unit)
+	return c.getProperties(ctx, path, "org.freedesktop.systemd1.Unit")
+}
+
+// Deprecated: use GetUnitPathPropertiesContext instead.
+func (c *Conn) GetUnitPathProperties(path dbus.ObjectPath) (map[string]any, error) {
+	return c.GetUnitPathPropertiesContext(context.Background(), path)
+}
+
+// GetUnitPathPropertiesContext takes the (escaped) unit path and returns all
+// of its dbus object properties.
+func (c *Conn) GetUnitPathPropertiesContext(ctx context.Context, path dbus.ObjectPath) (map[string]any, error) {
+	return c.getProperties(ctx, path, "org.freedesktop.systemd1.Unit")
+}
+
+// Deprecated: use GetAllPropertiesContext instead.
+func (c *Conn) GetAllProperties(unit string) (map[string]any, error) {
+	return c.GetAllPropertiesContext(context.Background(), unit)
+}
+
+// GetAllPropertiesContext takes the (unescaped) unit name and returns all of
+// its dbus object properties.
+func (c *Conn) GetAllPropertiesContext(ctx context.Context, unit string) (map[string]any, error) {
+	path := unitPath(unit)
+	return c.getProperties(ctx, path, "")
+}
+
+func (c *Conn) getProperty(ctx context.Context, unit string, dbusInterface string, propertyName string) (*Property, error) {
+	var err error
+	var prop dbus.Variant
+
+	path := unitPath(unit)
+	if !path.IsValid() {
+		return nil, errors.New("invalid unit name: " + unit)
+	}
+
+	obj := c.sysconn.Object("org.freedesktop.systemd1", path)
+	err = obj.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0, dbusInterface, propertyName).Store(&prop)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Property{Name: propertyName, Value: prop}, nil
+}
+
+// Deprecated: use GetUnitPropertyContext instead.
+func (c *Conn) GetUnitProperty(unit string, propertyName string) (*Property, error) {
+	return c.GetUnitPropertyContext(context.Background(), unit, propertyName)
+}
+
+// GetUnitPropertyContext takes an (unescaped) unit name, and a property name,
+// and returns the property value.
+func (c *Conn) GetUnitPropertyContext(ctx context.Context, unit string, propertyName string) (*Property, error) {
+	return c.getProperty(ctx, unit, "org.freedesktop.systemd1.Unit", propertyName)
+}
+
+// Deprecated: use GetServicePropertyContext instead.
+func (c *Conn) GetServiceProperty(service string, propertyName string) (*Property, error) {
+	return c.GetServicePropertyContext(context.Background(), service, propertyName)
+}
+
+// GetServicePropertyContext returns property for given service name and property name.
+func (c *Conn) GetServicePropertyContext(ctx context.Context, service string, propertyName string) (*Property, error) {
+	return c.getProperty(ctx, service, "org.freedesktop.systemd1.Service", propertyName)
+}
+
+// Deprecated: use GetUnitTypePropertiesContext instead.
+func (c *Conn) GetUnitTypeProperties(unit string, unitType string) (map[string]any, error) {
+	return c.GetUnitTypePropertiesContext(context.Background(), unit, unitType)
+}
+
+// GetUnitTypePropertiesContext returns the extra properties for a unit, specific to the unit type.
+// Valid values for unitType: Service, Socket, Target, Device, Mount, Automount, Snapshot, Timer, Swap, Path, Slice, Scope.
+// Returns "dbus.Error: Unknown interface" error if the unitType is not the correct type of the unit.
+func (c *Conn) GetUnitTypePropertiesContext(ctx context.Context, unit string, unitType string) (map[string]any, error) {
+	path := unitPath(unit)
+	return c.getProperties(ctx, path, "org.freedesktop.systemd1."+unitType)
+}
+
+// Deprecated: use SetUnitPropertiesContext instead.
+func (c *Conn) SetUnitProperties(name string, runtime bool, properties ...Property) error {
+	return c.SetUnitPropertiesContext(context.Background(), name, runtime, properties...)
+}
+
+// SetUnitPropertiesContext may be used to modify certain unit properties at runtime.
+// Not all properties may be changed at runtime, but many resource management
+// settings (primarily those in systemd.cgroup(5)) may. The changes are applied
+// instantly, and stored on disk for future boots, unless runtime is true, in which
+// case the settings only apply until the next reboot. name is the name of the unit
+// to modify. properties are the settings to set, encoded as an array of property
+// name and value pairs.
+func (c *Conn) SetUnitPropertiesContext(ctx context.Context, name string, runtime bool, properties ...Property) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.SetUnitProperties", 0, name, runtime, properties).Store()
+}
+
+// Deprecated: use GetUnitTypePropertyContext instead.
+func (c *Conn) GetUnitTypeProperty(unit string, unitType string, propertyName string) (*Property, error) {
+	return c.GetUnitTypePropertyContext(context.Background(), unit, unitType, propertyName)
+}
+
+// GetUnitTypePropertyContext takes a property name, a unit name, and a unit type,
+// and returns a property value. For valid values of unitType, see GetUnitTypePropertiesContext.
+func (c *Conn) GetUnitTypePropertyContext(ctx context.Context, unit string, unitType string, propertyName string) (*Property, error) {
+	return c.getProperty(ctx, unit, "org.freedesktop.systemd1."+unitType, propertyName)
+}
+
+type UnitStatus struct {
+	Name        string          // The primary unit name as string
+	Description string          // The human readable description string
+	LoadState   string          // The load state (i.e. whether the unit file has been loaded successfully)
+	ActiveState string          // The active state (i.e. whether the unit is currently started or not)
+	SubState    string          // The sub state (a more fine-grained version of the active state that is specific to the unit type, which the active state is not)
+	Followed    string          // A unit that is being followed in its state by this unit, if there is any, otherwise the empty string.
+	Path        dbus.ObjectPath // The unit object path
+	JobId       uint32          // If there is a job queued for the job unit the numeric job id, 0 otherwise
+	JobType     string          // The job type as string
+	JobPath     dbus.ObjectPath // The job object path
+}
+
+type storeFunc func(retvalues ...any) error
+
+// convertSlice converts a []any result into a slice of the target type T
+// using dbus.Store to handle the type conversion.
+func convertSlice[T any](result []any) ([]T, error) {
+	converted := make([]T, len(result))
+	convertedInterface := make([]any, len(converted))
+	for i := range converted {
+		convertedInterface[i] = &converted[i]
+	}
+
+	err := dbus.Store(result, convertedInterface...)
+	if err != nil {
+		return nil, err
+	}
+
+	return converted, nil
+}
+
+// storeSlice fetches D-Bus array results via the provided storeFunc
+// and converts them into a slice of the target type T.
+func storeSlice[T any](f storeFunc) ([]T, error) {
+	var result []any
+	err := f(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertSlice[T](result)
+}
+
+// GetUnitByPID returns the unit object path of the unit a process ID
+// belongs to. It takes a UNIX PID and returns the object path. The PID must
+// refer to an existing system process
+func (c *Conn) GetUnitByPID(ctx context.Context, pid uint32) (dbus.ObjectPath, error) {
+	var result dbus.ObjectPath
+
+	err := c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.GetUnitByPID", 0, pid).Store(&result)
+
+	return result, err
+}
+
+// GetUnitNameByPID returns the name of the unit a process ID belongs to. It
+// takes a UNIX PID and returns the object path. The PID must refer to an
+// existing system process
+func (c *Conn) GetUnitNameByPID(ctx context.Context, pid uint32) (string, error) {
+	path, err := c.GetUnitByPID(ctx, pid)
+	if err != nil {
+		return "", err
+	}
+
+	return unitName(path), nil
+}
+
+// Deprecated: use ListUnitsContext instead.
+func (c *Conn) ListUnits() ([]UnitStatus, error) {
+	return c.ListUnitsContext(context.Background())
+}
+
+// ListUnitsContext returns an array with all currently loaded units. Note that
+// units may be known by multiple names at the same time, and hence there might
+// be more unit names loaded than actual units behind them.
+// Also note that a unit is only loaded if it is active and/or enabled.
+// Units that are both disabled and inactive will thus not be returned.
+func (c *Conn) ListUnitsContext(ctx context.Context) ([]UnitStatus, error) {
+	return storeSlice[UnitStatus](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListUnits", 0).Store)
+}
+
+// Deprecated: use ListUnitsFilteredContext instead.
+func (c *Conn) ListUnitsFiltered(states []string) ([]UnitStatus, error) {
+	return c.ListUnitsFilteredContext(context.Background(), states)
+}
+
+// ListUnitsFilteredContext returns an array with units filtered by state.
+// It takes a list of units' statuses to filter.
+func (c *Conn) ListUnitsFilteredContext(ctx context.Context, states []string) ([]UnitStatus, error) {
+	return storeSlice[UnitStatus](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListUnitsFiltered", 0, states).Store)
+}
+
+// Deprecated: use ListUnitsByPatternsContext instead.
+func (c *Conn) ListUnitsByPatterns(states []string, patterns []string) ([]UnitStatus, error) {
+	return c.ListUnitsByPatternsContext(context.Background(), states, patterns)
+}
+
+// ListUnitsByPatternsContext returns an array with units.
+// It takes a list of units' statuses and names to filter.
+// Note that units may be known by multiple names at the same time,
+// and hence there might be more unit names loaded than actual units behind them.
+func (c *Conn) ListUnitsByPatternsContext(ctx context.Context, states []string, patterns []string) ([]UnitStatus, error) {
+	return storeSlice[UnitStatus](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListUnitsByPatterns", 0, states, patterns).Store)
+}
+
+// Deprecated: use ListUnitsByNamesContext instead.
+func (c *Conn) ListUnitsByNames(units []string) ([]UnitStatus, error) {
+	return c.ListUnitsByNamesContext(context.Background(), units)
+}
+
+// ListUnitsByNamesContext returns an array with units. It takes a list of units'
+// names and returns an UnitStatus array. Comparing to ListUnitsByPatternsContext
+// method, this method returns statuses even for inactive or non-existing
+// units. Input array should contain exact unit names, but not patterns.
+//
+// Requires systemd v230 or higher.
+func (c *Conn) ListUnitsByNamesContext(ctx context.Context, units []string) ([]UnitStatus, error) {
+	return storeSlice[UnitStatus](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListUnitsByNames", 0, units).Store)
+}
+
+type UnitFile struct {
+	Path string
+	Type string
+}
+
+// Deprecated: use ListUnitFilesContext instead.
+func (c *Conn) ListUnitFiles() ([]UnitFile, error) {
+	return c.ListUnitFilesContext(context.Background())
+}
+
+// ListUnitFilesContext returns an array of all available units on disk.
+func (c *Conn) ListUnitFilesContext(ctx context.Context) ([]UnitFile, error) {
+	return storeSlice[UnitFile](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListUnitFiles", 0).Store)
+}
+
+// Deprecated: use ListUnitFilesByPatternsContext instead.
+func (c *Conn) ListUnitFilesByPatterns(states []string, patterns []string) ([]UnitFile, error) {
+	return c.ListUnitFilesByPatternsContext(context.Background(), states, patterns)
+}
+
+// ListUnitFilesByPatternsContext returns an array of all available units on disk matched the patterns.
+func (c *Conn) ListUnitFilesByPatternsContext(ctx context.Context, states []string, patterns []string) ([]UnitFile, error) {
+	return storeSlice[UnitFile](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListUnitFilesByPatterns", 0, states, patterns).Store)
+}
+
+type LinkUnitFileChange EnableUnitFileChange
+
+// Deprecated: use LinkUnitFilesContext instead.
+func (c *Conn) LinkUnitFiles(files []string, runtime bool, force bool) ([]LinkUnitFileChange, error) {
+	return c.LinkUnitFilesContext(context.Background(), files, runtime, force)
+}
+
+// LinkUnitFilesContext links unit files (that are located outside of the
+// usual unit search paths) into the unit search path.
+//
+// It takes a list of absolute paths to unit files to link and two
+// booleans.
+//
+// The first boolean controls whether the unit shall be
+// enabled for runtime only (true, /run), or persistently (false,
+// /etc).
+//
+// The second controls whether symlinks pointing to other units shall
+// be replaced if necessary.
+//
+// This call returns a list of the changes made. The list consists of
+// structures with three strings: the type of the change (one of symlink
+// or unlink), the file name of the symlink and the destination of the
+// symlink.
+func (c *Conn) LinkUnitFilesContext(ctx context.Context, files []string, runtime bool, force bool) ([]LinkUnitFileChange, error) {
+	return storeSlice[LinkUnitFileChange](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.LinkUnitFiles", 0, files, runtime, force).Store)
+}
+
+// Deprecated: use EnableUnitFilesContext instead.
+func (c *Conn) EnableUnitFiles(files []string, runtime bool, force bool) (bool, []EnableUnitFileChange, error) {
+	return c.EnableUnitFilesContext(context.Background(), files, runtime, force)
+}
+
+// EnableUnitFilesContext may be used to enable one or more units in the system
+// (by creating symlinks to them in /etc or /run).
+//
+// It takes a list of unit files to enable (either just file names or full
+// absolute paths if the unit files are residing outside the usual unit
+// search paths), and two booleans: the first controls whether the unit shall
+// be enabled for runtime only (true, /run), or persistently (false, /etc).
+// The second one controls whether symlinks pointing to other units shall
+// be replaced if necessary.
+//
+// This call returns one boolean and an array with the changes made. The
+// boolean signals whether the unit files contained any enablement
+// information (i.e. an [Install]) section. The changes list consists of
+// structures with three strings: the type of the change (one of symlink
+// or unlink), the file name of the symlink and the destination of the
+// symlink.
+func (c *Conn) EnableUnitFilesContext(ctx context.Context, files []string, runtime bool, force bool) (bool, []EnableUnitFileChange, error) {
+	var carries_install_info bool
+	var result []any
+
+	err := c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.EnableUnitFiles", 0, files, runtime, force).Store(&carries_install_info, &result)
+	if err != nil {
+		return false, nil, err
+	}
+
+	changes, err := convertSlice[EnableUnitFileChange](result)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return carries_install_info, changes, nil
+}
+
+type EnableUnitFileChange struct {
+	Type        string // Type of the change (one of symlink or unlink)
+	Filename    string // File name of the symlink
+	Destination string // Destination of the symlink
+}
+
+// Deprecated: use DisableUnitFilesContext instead.
+func (c *Conn) DisableUnitFiles(files []string, runtime bool) ([]DisableUnitFileChange, error) {
+	return c.DisableUnitFilesContext(context.Background(), files, runtime)
+}
+
+// DisableUnitFilesContext may be used to disable one or more units in the
+// system (by removing symlinks to them from /etc or /run).
+//
+// It takes a list of unit files to disable (either just file names or full
+// absolute paths if the unit files are residing outside the usual unit
+// search paths), and one boolean: whether the unit was enabled for runtime
+// only (true, /run), or persistently (false, /etc).
+//
+// This call returns an array with the changes made. The changes list
+// consists of structures with three strings: the type of the change (one of
+// symlink or unlink), the file name of the symlink and the destination of the
+// symlink.
+func (c *Conn) DisableUnitFilesContext(ctx context.Context, files []string, runtime bool) ([]DisableUnitFileChange, error) {
+	return storeSlice[DisableUnitFileChange](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.DisableUnitFiles", 0, files, runtime).Store)
+}
+
+type DisableUnitFileChange struct {
+	Type        string // Type of the change (one of symlink or unlink)
+	Filename    string // File name of the symlink
+	Destination string // Destination of the symlink
+}
+
+// Deprecated: use MaskUnitFilesContext instead.
+func (c *Conn) MaskUnitFiles(files []string, runtime bool, force bool) ([]MaskUnitFileChange, error) {
+	return c.MaskUnitFilesContext(context.Background(), files, runtime, force)
+}
+
+// MaskUnitFilesContext masks one or more units in the system.
+//
+// The files argument contains a  list of units to mask (either just file names
+// or full absolute paths if the unit files are residing outside the usual unit
+// search paths).
+//
+// The runtime argument is used to specify whether the unit was enabled for
+// runtime only (true, /run/systemd/..), or persistently (false,
+// /etc/systemd/..).
+func (c *Conn) MaskUnitFilesContext(ctx context.Context, files []string, runtime bool, force bool) ([]MaskUnitFileChange, error) {
+	return storeSlice[MaskUnitFileChange](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.MaskUnitFiles", 0, files, runtime, force).Store)
+}
+
+type MaskUnitFileChange struct {
+	Type        string // Type of the change (one of symlink or unlink)
+	Filename    string // File name of the symlink
+	Destination string // Destination of the symlink
+}
+
+// Deprecated: use UnmaskUnitFilesContext instead.
+func (c *Conn) UnmaskUnitFiles(files []string, runtime bool) ([]UnmaskUnitFileChange, error) {
+	return c.UnmaskUnitFilesContext(context.Background(), files, runtime)
+}
+
+// UnmaskUnitFilesContext unmasks one or more units in the system.
+//
+// It takes the list of unit files to mask (either just file names or full
+// absolute paths if the unit files are residing outside the usual unit search
+// paths), and a boolean runtime flag to specify whether the unit was enabled
+// for runtime only (true, /run/systemd/..), or persistently (false,
+// /etc/systemd/..).
+func (c *Conn) UnmaskUnitFilesContext(ctx context.Context, files []string, runtime bool) ([]UnmaskUnitFileChange, error) {
+	return storeSlice[UnmaskUnitFileChange](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.UnmaskUnitFiles", 0, files, runtime).Store)
+}
+
+type UnmaskUnitFileChange struct {
+	Type        string // Type of the change (one of symlink or unlink)
+	Filename    string // File name of the symlink
+	Destination string // Destination of the symlink
+}
+
+// Deprecated: use ReloadContext instead.
+func (c *Conn) Reload() error {
+	return c.ReloadContext(context.Background())
+}
+
+// ReloadContext instructs systemd to scan for and reload unit files. This is
+// an equivalent to systemctl daemon-reload.
+func (c *Conn) ReloadContext(ctx context.Context) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.Reload", 0).Store()
+}
+
+func unitPath(name string) dbus.ObjectPath {
+	return dbus.ObjectPath("/org/freedesktop/systemd1/unit/" + PathBusEscape(name))
+}
+
+// unitName returns the unescaped base element of the supplied escaped path.
+func unitName(dpath dbus.ObjectPath) string {
+	return pathBusUnescape(path.Base(string(dpath)))
+}
+
+// JobStatus holds a currently queued job definition.
+type JobStatus struct {
+	Id       uint32          // The numeric job id
+	Unit     string          // The primary unit name for this job
+	JobType  string          // The job type as string
+	Status   string          // The job state as string
+	JobPath  dbus.ObjectPath // The job object path
+	UnitPath dbus.ObjectPath // The unit object path
+}
+
+// Deprecated: use ListJobsContext instead.
+func (c *Conn) ListJobs() ([]JobStatus, error) {
+	return c.ListJobsContext(context.Background())
+}
+
+// ListJobsContext returns an array with all currently queued jobs.
+func (c *Conn) ListJobsContext(ctx context.Context) ([]JobStatus, error) {
+	return storeSlice[JobStatus](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListJobs", 0).Store)
+}
+
+// FreezeUnit freezes the cgroup associated with the unit.
+// Note that FreezeUnit and [Conn.ThawUnit] are only supported on systems running with cgroup v2.
+func (c *Conn) FreezeUnit(ctx context.Context, unit string) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.FreezeUnit", 0, unit).Store()
+}
+
+// ThawUnit unfreezes the cgroup associated with the unit.
+func (c *Conn) ThawUnit(ctx context.Context, unit string) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ThawUnit", 0, unit).Store()
+}
+
+// AttachProcessesToUnit moves existing processes, identified by pids, into an existing systemd unit.
+func (c *Conn) AttachProcessesToUnit(ctx context.Context, unit, subcgroup string, pids []uint32) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.AttachProcessesToUnit", 0, unit, subcgroup, pids).Store()
+}

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/properties.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/properties.go
@@ -1,0 +1,237 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbus
+
+import (
+	"github.com/godbus/dbus/v5"
+)
+
+// From the systemd docs:
+//
+// The properties array of StartTransientUnit() may take many of the settings
+// that may also be configured in unit files. Not all parameters are currently
+// accepted though, but we plan to cover more properties with future release.
+// Currently you may set the Description, Slice and all dependency types of
+// units, as well as RemainAfterExit, ExecStart for service units,
+// TimeoutStopUSec and PIDs for scope units, and CPUAccounting, CPUShares,
+// BlockIOAccounting, BlockIOWeight, BlockIOReadBandwidth,
+// BlockIOWriteBandwidth, BlockIODeviceWeight, MemoryAccounting, MemoryLimit,
+// DevicePolicy, DeviceAllow for services/scopes/slices. These fields map
+// directly to their counterparts in unit files and as normal D-Bus object
+// properties. The exception here is the PIDs field of scope units which is
+// used for construction of the scope only and specifies the initial PIDs to
+// add to the scope object.
+
+type Property struct {
+	Name  string
+	Value dbus.Variant
+}
+
+type PropertyCollection struct {
+	Name       string
+	Properties []Property
+}
+
+type execStart struct {
+	Path             string   // the binary path to execute
+	Args             []string // an array with all arguments to pass to the executed command, starting with argument 0
+	UncleanIsFailure bool     // a boolean whether it should be considered a failure if the process exits uncleanly
+}
+
+// PropExecStart sets the ExecStart service property.  The first argument is a
+// slice with the binary path to execute followed by the arguments to pass to
+// the executed command. See
+// http://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=
+func PropExecStart(command []string, uncleanIsFailure bool) Property {
+	execStarts := []execStart{
+		{
+			Path:             command[0],
+			Args:             command,
+			UncleanIsFailure: uncleanIsFailure,
+		},
+	}
+
+	return Property{
+		Name:  "ExecStart",
+		Value: dbus.MakeVariant(execStarts),
+	}
+}
+
+// PropRemainAfterExit sets the RemainAfterExit service property. See
+// http://www.freedesktop.org/software/systemd/man/systemd.service.html#RemainAfterExit=
+func PropRemainAfterExit(b bool) Property {
+	return Property{
+		Name:  "RemainAfterExit",
+		Value: dbus.MakeVariant(b),
+	}
+}
+
+// PropType sets the Type service property. See
+// http://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=
+func PropType(t string) Property {
+	return Property{
+		Name:  "Type",
+		Value: dbus.MakeVariant(t),
+	}
+}
+
+// PropDescription sets the Description unit property. See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit#Description=
+func PropDescription(desc string) Property {
+	return Property{
+		Name:  "Description",
+		Value: dbus.MakeVariant(desc),
+	}
+}
+
+func propDependency(name string, units []string) Property {
+	return Property{
+		Name:  name,
+		Value: dbus.MakeVariant(units),
+	}
+}
+
+// PropRequires sets the Requires unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=
+func PropRequires(units ...string) Property {
+	return propDependency("Requires", units)
+}
+
+// PropRequiresOverridable sets the RequiresOverridable unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiresOverridable=
+func PropRequiresOverridable(units ...string) Property {
+	return propDependency("RequiresOverridable", units)
+}
+
+// PropRequisite sets the Requisite unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requisite=
+func PropRequisite(units ...string) Property {
+	return propDependency("Requisite", units)
+}
+
+// PropRequisiteOverridable sets the RequisiteOverridable unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequisiteOverridable=
+func PropRequisiteOverridable(units ...string) Property {
+	return propDependency("RequisiteOverridable", units)
+}
+
+// PropWants sets the Wants unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=
+func PropWants(units ...string) Property {
+	return propDependency("Wants", units)
+}
+
+// PropBindsTo sets the BindsTo unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#BindsTo=
+func PropBindsTo(units ...string) Property {
+	return propDependency("BindsTo", units)
+}
+
+// PropRequiredBy sets the RequiredBy unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiredBy=
+func PropRequiredBy(units ...string) Property {
+	return propDependency("RequiredBy", units)
+}
+
+// PropRequiredByOverridable sets the RequiredByOverridable unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiredByOverridable=
+func PropRequiredByOverridable(units ...string) Property {
+	return propDependency("RequiredByOverridable", units)
+}
+
+// PropWantedBy sets the WantedBy unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#WantedBy=
+func PropWantedBy(units ...string) Property {
+	return propDependency("WantedBy", units)
+}
+
+// PropBoundBy sets the BoundBy unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#BoundBy=
+func PropBoundBy(units ...string) Property {
+	return propDependency("BoundBy", units)
+}
+
+// PropConflicts sets the Conflicts unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Conflicts=
+func PropConflicts(units ...string) Property {
+	return propDependency("Conflicts", units)
+}
+
+// PropConflictedBy sets the ConflictedBy unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConflictedBy=
+func PropConflictedBy(units ...string) Property {
+	return propDependency("ConflictedBy", units)
+}
+
+// PropBefore sets the Before unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
+func PropBefore(units ...string) Property {
+	return propDependency("Before", units)
+}
+
+// PropAfter sets the After unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#After=
+func PropAfter(units ...string) Property {
+	return propDependency("After", units)
+}
+
+// PropOnFailure sets the OnFailure unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#OnFailure=
+func PropOnFailure(units ...string) Property {
+	return propDependency("OnFailure", units)
+}
+
+// PropTriggers sets the Triggers unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Triggers=
+func PropTriggers(units ...string) Property {
+	return propDependency("Triggers", units)
+}
+
+// PropTriggeredBy sets the TriggeredBy unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#TriggeredBy=
+func PropTriggeredBy(units ...string) Property {
+	return propDependency("TriggeredBy", units)
+}
+
+// PropPropagatesReloadTo sets the PropagatesReloadTo unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#PropagatesReloadTo=
+func PropPropagatesReloadTo(units ...string) Property {
+	return propDependency("PropagatesReloadTo", units)
+}
+
+// PropRequiresMountsFor sets the RequiresMountsFor unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiresMountsFor=
+func PropRequiresMountsFor(units ...string) Property {
+	return propDependency("RequiresMountsFor", units)
+}
+
+// PropSlice sets the Slice unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#Slice=
+func PropSlice(slice string) Property {
+	return Property{
+		Name:  "Slice",
+		Value: dbus.MakeVariant(slice),
+	}
+}
+
+// PropPids sets the PIDs field of scope units used in the initial construction
+// of the scope only and specifies the initial PIDs to add to the scope object.
+// See https://www.freedesktop.org/wiki/Software/systemd/ControlGroupInterface/#properties
+func PropPids(pids ...uint32) Property {
+	return Property{
+		Name:  "PIDs",
+		Value: dbus.MakeVariant(pids),
+	}
+}

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/set.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/set.go
@@ -1,0 +1,62 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbus
+
+import (
+	"sync"
+)
+
+type set struct {
+	data map[string]bool
+	mu   sync.Mutex
+}
+
+func (s *set) Add(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[value] = true
+}
+
+func (s *set) Remove(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, value)
+}
+
+func (s *set) Contains(value string) (exists bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, exists = s.data[value]
+	return
+}
+
+func (s *set) Length() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.data)
+}
+
+func (s *set) Values() (values []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for val := range s.data {
+		values = append(values, val)
+	}
+	return
+}
+
+func newSet() *set {
+	return &set{data: make(map[string]bool)}
+}

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/subscription.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/subscription.go
@@ -1,0 +1,351 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbus
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	cleanIgnoreInterval = int64(10 * time.Second)
+	ignoreInterval      = int64(30 * time.Millisecond)
+)
+
+// Subscribe sets up this connection to subscribe to all systemd dbus events.
+// This is required before calling SubscribeUnits. When the connection closes
+// systemd will automatically stop sending signals so there is no need to
+// explicitly call Unsubscribe().
+func (c *Conn) Subscribe() error {
+	c.sigconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.systemd1.Manager',member='UnitNew'")
+	c.sigconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'")
+
+	return c.sigobj.Call("org.freedesktop.systemd1.Manager.Subscribe", 0).Store()
+}
+
+// Unsubscribe this connection from systemd dbus events.
+func (c *Conn) Unsubscribe() error {
+	return c.sigobj.Call("org.freedesktop.systemd1.Manager.Unsubscribe", 0).Store()
+}
+
+func (c *Conn) dispatch() {
+	ch := make(chan *dbus.Signal, signalBuffer)
+
+	c.sigconn.Signal(ch)
+
+	go func() {
+		for {
+			signal, ok := <-ch
+			if !ok {
+				return
+			}
+
+			if signal.Name == "org.freedesktop.systemd1.Manager.JobRemoved" {
+				c.jobComplete(signal)
+			}
+
+			if c.subStateSubscriber.updateCh == nil &&
+				c.propertiesSubscriber.updateCh == nil {
+				continue
+			}
+
+			var unitPath dbus.ObjectPath
+			switch signal.Name {
+			case "org.freedesktop.systemd1.Manager.JobRemoved":
+				unitName := signal.Body[2].(string)
+				_ = c.sysobj.Call("org.freedesktop.systemd1.Manager.GetUnit", 0, unitName).Store(&unitPath)
+			case "org.freedesktop.systemd1.Manager.UnitNew":
+				unitPath = signal.Body[1].(dbus.ObjectPath)
+			case "org.freedesktop.DBus.Properties.PropertiesChanged":
+				if signal.Body[0].(string) == "org.freedesktop.systemd1.Unit" {
+					unitPath = signal.Path
+
+					if len(signal.Body) >= 2 {
+						if changed, ok := signal.Body[1].(map[string]dbus.Variant); ok {
+							c.sendPropertiesUpdate(unitPath, changed)
+						}
+					}
+				}
+			}
+
+			if unitPath == dbus.ObjectPath("") {
+				continue
+			}
+
+			c.sendSubStateUpdate(unitPath)
+		}
+	}()
+}
+
+// Deprecated: use SubscribeUnitsContext instead.
+func (c *Conn) SubscribeUnits(interval time.Duration) (<-chan map[string]*UnitStatus, <-chan error) {
+	return c.SubscribeUnitsContext(context.Background(), interval)
+}
+
+// SubscribeUnitsContext returns two unbuffered channels which will receive all changed units every
+// interval.  Deleted units are sent as nil.
+func (c *Conn) SubscribeUnitsContext(ctx context.Context, interval time.Duration) (<-chan map[string]*UnitStatus, <-chan error) {
+	return c.SubscribeUnitsCustomContext(ctx, interval, 0, func(u1, u2 *UnitStatus) bool { return *u1 != *u2 }, nil)
+}
+
+// Deprecated: use SubscribeUnitsCustomContext instead.
+func (c *Conn) SubscribeUnitsCustom(interval time.Duration, buffer int, isChanged func(*UnitStatus, *UnitStatus) bool, filterUnit func(string) bool) (<-chan map[string]*UnitStatus, <-chan error) {
+	return c.SubscribeUnitsCustomContext(context.Background(), interval, buffer, isChanged, filterUnit)
+}
+
+// SubscribeUnitsCustomContext is like [Conn.SubscribeUnitsContext] but lets you specify the buffer
+// size of the channels, the comparison function for detecting changes and a filter
+// function for cutting down on the noise that your channel receives.
+func (c *Conn) SubscribeUnitsCustomContext(ctx context.Context, interval time.Duration, buffer int, isChanged func(*UnitStatus, *UnitStatus) bool, filterUnit func(string) bool) (<-chan map[string]*UnitStatus, <-chan error) {
+	old := make(map[string]*UnitStatus)
+	statusChan := make(chan map[string]*UnitStatus, buffer)
+	errChan := make(chan error, buffer)
+
+	go func() {
+		for {
+			timerChan := time.After(interval)
+
+			units, err := c.ListUnitsContext(ctx)
+			if err == nil {
+				cur := make(map[string]*UnitStatus)
+				for i := range units {
+					if filterUnit != nil && filterUnit(units[i].Name) {
+						continue
+					}
+					cur[units[i].Name] = &units[i]
+				}
+
+				// add all new or changed units
+				changed := make(map[string]*UnitStatus)
+				for n, u := range cur {
+					if oldU, ok := old[n]; !ok || isChanged(oldU, u) {
+						changed[n] = u
+					}
+					delete(old, n)
+				}
+
+				// add all deleted units
+				for oldN := range old {
+					changed[oldN] = nil
+				}
+
+				old = cur
+
+				if len(changed) != 0 {
+					statusChan <- changed
+				}
+			} else {
+				errChan <- err
+			}
+
+			select {
+			case <-timerChan:
+				continue
+			case <-ctx.Done():
+				close(statusChan)
+				close(errChan)
+				return
+			}
+		}
+	}()
+
+	return statusChan, errChan
+}
+
+type SubStateUpdate struct {
+	UnitName string
+	SubState string
+}
+
+// SetSubStateSubscriber writes to updateCh when any unit's substate changes.
+// Although this writes to updateCh on every state change, the reported state
+// may be more recent than the change that generated it (due to an unavoidable
+// race in the systemd dbus interface).  That is, this method provides a good
+// way to keep a current view of all units' states, but is not guaranteed to
+// show every state transition they go through.  Furthermore, state changes
+// will only be written to the channel with non-blocking writes.  If updateCh
+// is full, it attempts to write an error to errCh; if errCh is full, the error
+// passes silently.
+func (c *Conn) SetSubStateSubscriber(updateCh chan<- *SubStateUpdate, errCh chan<- error) {
+	if c == nil {
+		msg := "nil receiver"
+		select {
+		case errCh <- errors.New(msg):
+		default:
+			log.Printf("full error channel while reporting: %s\n", msg)
+		}
+		return
+	}
+
+	c.subStateSubscriber.Lock()
+	defer c.subStateSubscriber.Unlock()
+	c.subStateSubscriber.updateCh = updateCh
+	c.subStateSubscriber.errCh = errCh
+}
+
+func (c *Conn) sendSubStateUpdate(unitPath dbus.ObjectPath) {
+	c.subStateSubscriber.Lock()
+	defer c.subStateSubscriber.Unlock()
+
+	if c.subStateSubscriber.updateCh == nil {
+		return
+	}
+
+	isIgnored := c.shouldIgnore(unitPath)
+	defer c.cleanIgnore()
+	if isIgnored {
+		return
+	}
+
+	info, err := c.GetUnitPathProperties(unitPath)
+	if err != nil {
+		select {
+		case c.subStateSubscriber.errCh <- err:
+		default:
+			log.Printf("full error channel while reporting: %s\n", err)
+		}
+		return
+	}
+	defer c.updateIgnore(unitPath, info)
+
+	name, ok := info["Id"].(string)
+	if !ok {
+		msg := "failed to cast info.Id"
+		select {
+		case c.subStateSubscriber.errCh <- errors.New(msg):
+		default:
+			log.Printf("full error channel while reporting: %s\n", err)
+		}
+		return
+	}
+	substate, ok := info["SubState"].(string)
+	if !ok {
+		msg := "failed to cast info.SubState"
+		select {
+		case c.subStateSubscriber.errCh <- errors.New(msg):
+		default:
+			log.Printf("full error channel while reporting: %s\n", msg)
+		}
+		return
+	}
+
+	update := &SubStateUpdate{name, substate}
+	select {
+	case c.subStateSubscriber.updateCh <- update:
+	default:
+		msg := "update channel is full"
+		select {
+		case c.subStateSubscriber.errCh <- errors.New(msg):
+		default:
+			log.Printf("full error channel while reporting: %s\n", msg)
+		}
+		return
+	}
+}
+
+// The ignore functions work around a wart in the systemd dbus interface.
+// Requesting the properties of an unloaded unit will cause systemd to send a
+// pair of UnitNew/UnitRemoved signals.  Because we need to get a unit's
+// properties on UnitNew (as that's the only indication of a new unit coming up
+// for the first time), we would enter an infinite loop if we did not attempt
+// to detect and ignore these spurious signals.  The signal themselves are
+// indistinguishable from relevant ones, so we (somewhat hackishly) ignore an
+// unloaded unit's signals for a short time after requesting its properties.
+// This means that we will miss e.g. a transient unit being restarted
+// *immediately* upon failure and also a transient unit being started
+// immediately after requesting its status (with systemctl status, for example,
+// because this causes a UnitNew signal to be sent which then causes us to fetch
+// the properties).
+
+func (c *Conn) shouldIgnore(path dbus.ObjectPath) bool {
+	t, ok := c.subStateSubscriber.ignore[path]
+	return ok && t >= time.Now().UnixNano()
+}
+
+func (c *Conn) updateIgnore(path dbus.ObjectPath, info map[string]any) {
+	loadState, ok := info["LoadState"].(string)
+	if !ok {
+		return
+	}
+
+	// unit is unloaded - it will trigger bad systemd dbus behavior
+	if loadState == "not-found" {
+		c.subStateSubscriber.ignore[path] = time.Now().UnixNano() + ignoreInterval
+	}
+}
+
+// without this, ignore would grow unboundedly over time
+func (c *Conn) cleanIgnore() {
+	now := time.Now().UnixNano()
+	if c.subStateSubscriber.cleanIgnore < now {
+		c.subStateSubscriber.cleanIgnore = now + cleanIgnoreInterval
+
+		for p, t := range c.subStateSubscriber.ignore {
+			if t < now {
+				delete(c.subStateSubscriber.ignore, p)
+			}
+		}
+	}
+}
+
+// PropertiesUpdate holds a map of a unit's changed properties
+type PropertiesUpdate struct {
+	UnitName string
+	Changed  map[string]dbus.Variant
+}
+
+// SetPropertiesSubscriber writes to updateCh when any unit's properties
+// change. Every property change reported by systemd will be sent; that is, no
+// transitions will be "missed" (as they might be with SetSubStateSubscriber).
+// However, state changes will only be written to the channel with non-blocking
+// writes.  If updateCh is full, it attempts to write an error to errCh; if
+// errCh is full, the error passes silently.
+func (c *Conn) SetPropertiesSubscriber(updateCh chan<- *PropertiesUpdate, errCh chan<- error) {
+	c.propertiesSubscriber.Lock()
+	defer c.propertiesSubscriber.Unlock()
+	c.propertiesSubscriber.updateCh = updateCh
+	c.propertiesSubscriber.errCh = errCh
+}
+
+// we don't need to worry about shouldIgnore() here because
+// sendPropertiesUpdate doesn't call GetProperties()
+func (c *Conn) sendPropertiesUpdate(unitPath dbus.ObjectPath, changedProps map[string]dbus.Variant) {
+	c.propertiesSubscriber.Lock()
+	defer c.propertiesSubscriber.Unlock()
+
+	if c.propertiesSubscriber.updateCh == nil {
+		return
+	}
+
+	update := &PropertiesUpdate{unitName(unitPath), changedProps}
+
+	select {
+	case c.propertiesSubscriber.updateCh <- update:
+	default:
+		msg := "update channel is full"
+		select {
+		case c.propertiesSubscriber.errCh <- errors.New(msg):
+		default:
+			log.Printf("full error channel while reporting: %s\n", msg)
+		}
+		return
+	}
+}

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/subscription_set.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/subscription_set.go
@@ -1,0 +1,63 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbus
+
+import (
+	"context"
+	"time"
+)
+
+// SubscriptionSet returns a subscription set which is like conn.Subscribe but
+// can filter to only return events for a set of units.
+type SubscriptionSet struct {
+	*set
+	conn *Conn
+}
+
+func (s *SubscriptionSet) filter(unit string) bool {
+	return !s.Contains(unit)
+}
+
+// SubscribeContext starts listening for dbus events for all of the units in the set.
+// Returns channels identical to conn.SubscribeUnits.
+func (s *SubscriptionSet) SubscribeContext(ctx context.Context) (<-chan map[string]*UnitStatus, <-chan error) {
+	// TODO: Make fully evented by using systemd 209 with properties changed values
+	return s.conn.SubscribeUnitsCustomContext(ctx, time.Second, 0,
+		mismatchUnitStatus,
+		func(unit string) bool { return s.filter(unit) },
+	)
+}
+
+// Deprecated: use SubscribeContext instead.
+func (s *SubscriptionSet) Subscribe() (<-chan map[string]*UnitStatus, <-chan error) {
+	return s.SubscribeContext(context.Background())
+}
+
+// NewSubscriptionSet returns a new subscription set.
+func (c *Conn) NewSubscriptionSet() *SubscriptionSet {
+	return &SubscriptionSet{newSet(), c}
+}
+
+// mismatchUnitStatus returns true if the provided UnitStatus objects
+// are not equivalent. false is returned if the objects are equivalent.
+// Only the Name, Description and state-related fields are used in
+// the comparison.
+func mismatchUnitStatus(u1, u2 *UnitStatus) bool {
+	return u1.Name != u2.Name ||
+		u1.Description != u2.Description ||
+		u1.LoadState != u2.LoadState ||
+		u1.ActiveState != u2.ActiveState ||
+		u1.SubState != u2.SubState
+}

--- a/vendor/github.com/godbus/dbus/v5/CONTRIBUTING.md
+++ b/vendor/github.com/godbus/dbus/v5/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# How to Contribute
+
+## Getting Started
+
+- Fork the repository on GitHub
+- Read the [README](README.markdown) for build and test instructions
+- Play with the project, submit bugs, submit patches!
+
+## Contribution Flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+- Create a topic branch from where you want to base your work (usually master).
+- Make commits of logical units.
+- Make sure your commit messages are in the proper format (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Make sure the tests pass, and add any new tests as appropriate.
+- Submit a pull request to the original repository.
+
+Thanks for your contributions!
+
+### Format of the Commit Message
+
+We follow a rough convention for commit messages that is designed to answer two
+questions: what changed and why. The subject line should feature the what and
+the body of the commit should describe the why.
+
+```
+scripts: add the test-cluster command
+
+this uses tmux to setup a test cluster that you can easily kill and
+start for debugging.
+
+Fixes #38
+```
+
+The format can be described more formally as follows:
+
+```
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+The first line is the subject and should be no longer than 70 characters, the
+second line is always blank, and other lines should be wrapped at 80 characters.
+This allows the message to be easier to read on GitHub as well as in various
+git tools.

--- a/vendor/github.com/godbus/dbus/v5/LICENSE
+++ b/vendor/github.com/godbus/dbus/v5/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/godbus/dbus/v5/MAINTAINERS
+++ b/vendor/github.com/godbus/dbus/v5/MAINTAINERS
@@ -1,0 +1,3 @@
+Brandon Philips <brandon@ifup.org> (@philips)
+Brian Waldon <brian@waldon.cc> (@bcwaldon)
+John Southworth <jsouthwo@brocade.com> (@jsouthworth)

--- a/vendor/github.com/godbus/dbus/v5/README.md
+++ b/vendor/github.com/godbus/dbus/v5/README.md
@@ -1,0 +1,46 @@
+![Build Status](https://github.com/godbus/dbus/workflows/Go/badge.svg)
+
+dbus
+----
+
+dbus is a simple library that implements native Go client bindings for the
+D-Bus message bus system.
+
+### Features
+
+* Complete native implementation of the D-Bus message protocol
+* Go-like API (channels for signals / asynchronous method calls, Goroutine-safe connections)
+* Subpackages that help with the introspection / property interfaces
+
+### Installation
+
+This packages requires Go 1.12 or later. It can be installed by running the command below:
+
+```
+go get github.com/godbus/dbus/v5
+```
+
+### Usage
+
+The complete package documentation and some simple examples are available at
+[godoc.org](http://godoc.org/github.com/godbus/dbus). Also, the
+[_examples](https://github.com/godbus/dbus/tree/master/_examples) directory
+gives a short overview over the basic usage. 
+
+#### Projects using godbus
+- [fyne](https://github.com/fyne-io/fyne) a cross platform GUI in Go inspired by Material Design.
+- [fynedesk](https://github.com/fyne-io/fynedesk) a full desktop environment for Linux/Unix using Fyne.
+- [go-bluetooth](https://github.com/muka/go-bluetooth) provides a bluetooth client over bluez dbus API.
+- [iwd](https://github.com/shibumi/iwd) go bindings for the internet wireless daemon "iwd".
+- [notify](https://github.com/esiqveland/notify) provides desktop notifications over dbus into a library.
+- [playerbm](https://github.com/altdesktop/playerbm) a bookmark utility for media players.
+
+Please note that the API is considered unstable for now and may change without
+further notice.
+
+### License
+
+go.dbus is available under the Simplified BSD License; see LICENSE for the full
+text.
+
+Nearly all of the credit for this library goes to github.com/guelfey/go.dbus.

--- a/vendor/github.com/godbus/dbus/v5/auth.go
+++ b/vendor/github.com/godbus/dbus/v5/auth.go
@@ -1,0 +1,257 @@
+package dbus
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+)
+
+// AuthStatus represents the Status of an authentication mechanism.
+type AuthStatus byte
+
+const (
+	// AuthOk signals that authentication is finished; the next command
+	// from the server should be an OK.
+	AuthOk AuthStatus = iota
+
+	// AuthContinue signals that additional data is needed; the next command
+	// from the server should be a DATA.
+	AuthContinue
+
+	// AuthError signals an error; the server sent invalid data or some
+	// other unexpected thing happened and the current authentication
+	// process should be aborted.
+	AuthError
+)
+
+type authState byte
+
+const (
+	waitingForData authState = iota
+	waitingForOk
+	waitingForReject
+)
+
+// Auth defines the behaviour of an authentication mechanism.
+type Auth interface {
+	// Return the name of the mechanism, the argument to the first AUTH command
+	// and the next status.
+	FirstData() (name, resp []byte, status AuthStatus)
+
+	// Process the given DATA command, and return the argument to the DATA
+	// command and the next status. If len(resp) == 0, no DATA command is sent.
+	HandleData(data []byte) (resp []byte, status AuthStatus)
+}
+
+// Auth authenticates the connection, trying the given list of authentication
+// mechanisms (in that order). If nil is passed, the EXTERNAL and
+// DBUS_COOKIE_SHA1 mechanisms are tried for the current user. For private
+// connections, this method must be called before sending any messages to the
+// bus. Auth must not be called on shared connections.
+func (conn *Conn) Auth(methods []Auth) error {
+	if methods == nil {
+		uid := strconv.Itoa(os.Geteuid())
+		methods = []Auth{AuthExternal(uid), AuthCookieSha1(uid, getHomeDir())}
+	}
+	in := bufio.NewReader(conn.transport)
+	err := conn.transport.SendNullByte()
+	if err != nil {
+		return err
+	}
+	err = authWriteLine(conn.transport, []byte("AUTH"))
+	if err != nil {
+		return err
+	}
+	s, err := authReadLine(in)
+	if err != nil {
+		return err
+	}
+	if len(s) < 2 || !bytes.Equal(s[0], []byte("REJECTED")) {
+		return errors.New("dbus: authentication protocol error")
+	}
+	s = s[1:]
+	for _, v := range s {
+		for _, m := range methods {
+			if name, _, status := m.FirstData(); bytes.Equal(v, name) {
+				var ok bool
+				err = authWriteLine(conn.transport, []byte("AUTH"), v)
+				if err != nil {
+					return err
+				}
+				switch status {
+				case AuthOk:
+					err, ok = conn.tryAuth(m, waitingForOk, in)
+				case AuthContinue:
+					err, ok = conn.tryAuth(m, waitingForData, in)
+				default:
+					panic("dbus: invalid authentication status")
+				}
+				if err != nil {
+					return err
+				}
+				if ok {
+					if conn.transport.SupportsUnixFDs() {
+						err = authWriteLine(conn, []byte("NEGOTIATE_UNIX_FD"))
+						if err != nil {
+							return err
+						}
+						line, err := authReadLine(in)
+						if err != nil {
+							return err
+						}
+						switch {
+						case bytes.Equal(line[0], []byte("AGREE_UNIX_FD")):
+							conn.EnableUnixFDs()
+							conn.unixFD = true
+						case bytes.Equal(line[0], []byte("ERROR")):
+						default:
+							return errors.New("dbus: authentication protocol error")
+						}
+					}
+					err = authWriteLine(conn.transport, []byte("BEGIN"))
+					if err != nil {
+						return err
+					}
+					go conn.inWorker()
+					return nil
+				}
+			}
+		}
+	}
+	return errors.New("dbus: authentication failed")
+}
+
+// tryAuth tries to authenticate with m as the mechanism, using state as the
+// initial authState and in for reading input. It returns (nil, true) on
+// success, (nil, false) on a REJECTED and (someErr, false) if some other
+// error occurred.
+func (conn *Conn) tryAuth(m Auth, state authState, in *bufio.Reader) (error, bool) {
+	for {
+		s, err := authReadLine(in)
+		if err != nil {
+			return err, false
+		}
+		switch {
+		case state == waitingForData && string(s[0]) == "DATA":
+			if len(s) != 2 {
+				err = authWriteLine(conn.transport, []byte("ERROR"))
+				if err != nil {
+					return err, false
+				}
+				continue
+			}
+			data, status := m.HandleData(s[1])
+			switch status {
+			case AuthOk, AuthContinue:
+				if len(data) != 0 {
+					err = authWriteLine(conn.transport, []byte("DATA"), data)
+					if err != nil {
+						return err, false
+					}
+				}
+				if status == AuthOk {
+					state = waitingForOk
+				}
+			case AuthError:
+				err = authWriteLine(conn.transport, []byte("ERROR"))
+				if err != nil {
+					return err, false
+				}
+			}
+		case state == waitingForData && string(s[0]) == "REJECTED":
+			return nil, false
+		case state == waitingForData && string(s[0]) == "ERROR":
+			err = authWriteLine(conn.transport, []byte("CANCEL"))
+			if err != nil {
+				return err, false
+			}
+			state = waitingForReject
+		case state == waitingForData && string(s[0]) == "OK":
+			if len(s) != 2 {
+				err = authWriteLine(conn.transport, []byte("CANCEL"))
+				if err != nil {
+					return err, false
+				}
+				state = waitingForReject
+			} else {
+				conn.uuid = string(s[1])
+				return nil, true
+			}
+		case state == waitingForData:
+			err = authWriteLine(conn.transport, []byte("ERROR"))
+			if err != nil {
+				return err, false
+			}
+		case state == waitingForOk && string(s[0]) == "OK":
+			if len(s) != 2 {
+				err = authWriteLine(conn.transport, []byte("CANCEL"))
+				if err != nil {
+					return err, false
+				}
+				state = waitingForReject
+			} else {
+				conn.uuid = string(s[1])
+				return nil, true
+			}
+		case state == waitingForOk && string(s[0]) == "DATA":
+			err = authWriteLine(conn.transport, []byte("DATA"))
+			if err != nil {
+				return err, false
+			}
+		case state == waitingForOk && string(s[0]) == "REJECTED":
+			return nil, false
+		case state == waitingForOk && string(s[0]) == "ERROR":
+			err = authWriteLine(conn.transport, []byte("CANCEL"))
+			if err != nil {
+				return err, false
+			}
+			state = waitingForReject
+		case state == waitingForOk:
+			err = authWriteLine(conn.transport, []byte("ERROR"))
+			if err != nil {
+				return err, false
+			}
+		case state == waitingForReject && string(s[0]) == "REJECTED":
+			return nil, false
+		case state == waitingForReject:
+			return errors.New("dbus: authentication protocol error"), false
+		default:
+			panic("dbus: invalid auth state")
+		}
+	}
+}
+
+// authReadLine reads a line and separates it into its fields.
+func authReadLine(in *bufio.Reader) ([][]byte, error) {
+	data, err := in.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	data = bytes.TrimSuffix(data, []byte("\r\n"))
+	return bytes.Split(data, []byte{' '}), nil
+}
+
+// authWriteLine writes the given line in the authentication protocol format
+// (elements of data separated by a " " and terminated by "\r\n").
+func authWriteLine(out io.Writer, data ...[]byte) error {
+	buf := make([]byte, 0)
+	for i, v := range data {
+		buf = append(buf, v...)
+		if i != len(data)-1 {
+			buf = append(buf, ' ')
+		}
+	}
+	buf = append(buf, '\r')
+	buf = append(buf, '\n')
+	n, err := out.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_anonymous.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_anonymous.go
@@ -1,0 +1,16 @@
+package dbus
+
+// AuthAnonymous returns an Auth that uses the ANONYMOUS mechanism.
+func AuthAnonymous() Auth {
+	return &authAnonymous{}
+}
+
+type authAnonymous struct{}
+
+func (a *authAnonymous) FirstData() (name, resp []byte, status AuthStatus) {
+	return []byte("ANONYMOUS"), nil, AuthOk
+}
+
+func (a *authAnonymous) HandleData(data []byte) (resp []byte, status AuthStatus) {
+	return nil, AuthError
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_external.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_external.go
@@ -1,0 +1,26 @@
+package dbus
+
+import (
+	"encoding/hex"
+)
+
+// AuthExternal returns an Auth that authenticates as the given user with the
+// EXTERNAL mechanism.
+func AuthExternal(user string) Auth {
+	return authExternal{user}
+}
+
+// AuthExternal implements the EXTERNAL authentication mechanism.
+type authExternal struct {
+	user string
+}
+
+func (a authExternal) FirstData() ([]byte, []byte, AuthStatus) {
+	b := make([]byte, 2*len(a.user))
+	hex.Encode(b, []byte(a.user))
+	return []byte("EXTERNAL"), b, AuthOk
+}
+
+func (a authExternal) HandleData(b []byte) ([]byte, AuthStatus) {
+	return nil, AuthError
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_sha1.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_sha1.go
@@ -1,0 +1,102 @@
+package dbus
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"os"
+)
+
+// AuthCookieSha1 returns an Auth that authenticates as the given user with the
+// DBUS_COOKIE_SHA1 mechanism. The home parameter should specify the home
+// directory of the user.
+func AuthCookieSha1(user, home string) Auth {
+	return authCookieSha1{user, home}
+}
+
+type authCookieSha1 struct {
+	user, home string
+}
+
+func (a authCookieSha1) FirstData() ([]byte, []byte, AuthStatus) {
+	b := make([]byte, 2*len(a.user))
+	hex.Encode(b, []byte(a.user))
+	return []byte("DBUS_COOKIE_SHA1"), b, AuthContinue
+}
+
+func (a authCookieSha1) HandleData(data []byte) ([]byte, AuthStatus) {
+	challenge := make([]byte, len(data)/2)
+	_, err := hex.Decode(challenge, data)
+	if err != nil {
+		return nil, AuthError
+	}
+	b := bytes.Split(challenge, []byte{' '})
+	if len(b) != 3 {
+		return nil, AuthError
+	}
+	context := b[0]
+	id := b[1]
+	svchallenge := b[2]
+	cookie := a.getCookie(context, id)
+	if cookie == nil {
+		return nil, AuthError
+	}
+	clchallenge := a.generateChallenge()
+	if clchallenge == nil {
+		return nil, AuthError
+	}
+	hash := sha1.New()
+	hash.Write(bytes.Join([][]byte{svchallenge, clchallenge, cookie}, []byte{':'}))
+	hexhash := make([]byte, 2*hash.Size())
+	hex.Encode(hexhash, hash.Sum(nil))
+	data = append(clchallenge, ' ')
+	data = append(data, hexhash...)
+	resp := make([]byte, 2*len(data))
+	hex.Encode(resp, data)
+	return resp, AuthOk
+}
+
+// getCookie searches for the cookie identified by id in context and returns
+// the cookie content or nil. (Since HandleData can't return a specific error,
+// but only whether an error occurred, this function also doesn't bother to
+// return an error.)
+func (a authCookieSha1) getCookie(context, id []byte) []byte {
+	file, err := os.Open(a.home + "/.dbus-keyrings/" + string(context))
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	rd := bufio.NewReader(file)
+	for {
+		line, err := rd.ReadBytes('\n')
+		if err != nil {
+			return nil
+		}
+		line = line[:len(line)-1]
+		b := bytes.Split(line, []byte{' '})
+		if len(b) != 3 {
+			return nil
+		}
+		if bytes.Equal(b[0], id) {
+			return b[2]
+		}
+	}
+}
+
+// generateChallenge returns a random, hex-encoded challenge, or nil on error
+// (see above).
+func (a authCookieSha1) generateChallenge() []byte {
+	b := make([]byte, 16)
+	n, err := rand.Read(b)
+	if err != nil {
+		return nil
+	}
+	if n != 16 {
+		return nil
+	}
+	enc := make([]byte, 32)
+	hex.Encode(enc, b)
+	return enc
+}

--- a/vendor/github.com/godbus/dbus/v5/call.go
+++ b/vendor/github.com/godbus/dbus/v5/call.go
@@ -1,0 +1,69 @@
+package dbus
+
+import (
+	"context"
+	"errors"
+)
+
+var errSignature = errors.New("dbus: mismatched signature")
+
+// Call represents a pending or completed method call.
+type Call struct {
+	Destination string
+	Path        ObjectPath
+	Method      string
+	Args        []interface{}
+
+	// Strobes when the call is complete.
+	Done chan *Call
+
+	// After completion, the error status. If this is non-nil, it may be an
+	// error message from the peer (with Error as its type) or some other error.
+	Err error
+
+	// Holds the response once the call is done.
+	Body []interface{}
+
+	// ResponseSequence stores the sequence number of the DBus message containing
+	// the call response (or error). This can be compared to the sequence number
+	// of other call responses and signals on this connection to determine their
+	// relative ordering on the underlying DBus connection.
+	// For errors, ResponseSequence is populated only if the error came from a
+	// DBusMessage that was received or if there was an error receiving. In case of
+	// failure to make the call, ResponseSequence will be NoSequence.
+	ResponseSequence Sequence
+
+	// tracks context and canceler
+	ctx         context.Context
+	ctxCanceler context.CancelFunc
+}
+
+func (c *Call) Context() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+
+	return c.ctx
+}
+
+func (c *Call) ContextCancel() {
+	if c.ctxCanceler != nil {
+		c.ctxCanceler()
+	}
+}
+
+// Store stores the body of the reply into the provided pointers. It returns
+// an error if the signatures of the body and retvalues don't match, or if
+// the error status is not nil.
+func (c *Call) Store(retvalues ...interface{}) error {
+	if c.Err != nil {
+		return c.Err
+	}
+
+	return Store(c.Body, retvalues...)
+}
+
+func (c *Call) done() {
+	c.Done <- c
+	c.ContextCancel()
+}

--- a/vendor/github.com/godbus/dbus/v5/conn.go
+++ b/vendor/github.com/godbus/dbus/v5/conn.go
@@ -1,0 +1,996 @@
+package dbus
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	systemBus     *Conn
+	systemBusLck  sync.Mutex
+	sessionBus    *Conn
+	sessionBusLck sync.Mutex
+)
+
+// ErrClosed is the error returned by calls on a closed connection.
+var ErrClosed = errors.New("dbus: connection closed by user")
+
+// Conn represents a connection to a message bus (usually, the system or
+// session bus).
+//
+// Connections are either shared or private. Shared connections
+// are shared between calls to the functions that return them. As a result,
+// the methods Close, Auth and Hello must not be called on them.
+//
+// Multiple goroutines may invoke methods on a connection simultaneously.
+type Conn struct {
+	transport
+
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+
+	closeOnce sync.Once
+	closeErr  error
+
+	busObj BusObject
+	unixFD bool
+	uuid   string
+
+	handler       Handler
+	signalHandler SignalHandler
+	serialGen     SerialGenerator
+	inInt         Interceptor
+	outInt        Interceptor
+	auth          []Auth
+
+	names      *nameTracker
+	calls      *callTracker
+	outHandler *outputHandler
+
+	eavesdropped    chan<- *Message
+	eavesdroppedLck sync.Mutex
+}
+
+// SessionBus returns a shared connection to the session bus, connecting to it
+// if not already done.
+func SessionBus() (conn *Conn, err error) {
+	sessionBusLck.Lock()
+	defer sessionBusLck.Unlock()
+	if sessionBus != nil &&
+		sessionBus.Connected() {
+		return sessionBus, nil
+	}
+	defer func() {
+		if conn != nil {
+			sessionBus = conn
+		}
+	}()
+	conn, err = ConnectSessionBus()
+	return
+}
+
+func getSessionBusAddress(autolaunch bool) (string, error) {
+	if address := os.Getenv("DBUS_SESSION_BUS_ADDRESS"); address != "" && address != "autolaunch:" {
+		return address, nil
+
+	} else if address := tryDiscoverDbusSessionBusAddress(); address != "" {
+		os.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+		return address, nil
+	}
+	if !autolaunch {
+		return "", errors.New("dbus: couldn't determine address of session bus")
+	}
+	return getSessionBusPlatformAddress()
+}
+
+// SessionBusPrivate returns a new private connection to the session bus.
+func SessionBusPrivate(opts ...ConnOption) (*Conn, error) {
+	address, err := getSessionBusAddress(true)
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial(address, opts...)
+}
+
+// SessionBusPrivate returns a new private connection to the session bus.  If
+// the session bus is not already open, do not attempt to launch it.
+func SessionBusPrivateNoAutoStartup(opts ...ConnOption) (*Conn, error) {
+	address, err := getSessionBusAddress(false)
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial(address, opts...)
+}
+
+// SessionBusPrivate returns a new private connection to the session bus.
+//
+// Deprecated: use SessionBusPrivate with options instead.
+func SessionBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return SessionBusPrivate(WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// SystemBus returns a shared connection to the system bus, connecting to it if
+// not already done.
+func SystemBus() (conn *Conn, err error) {
+	systemBusLck.Lock()
+	defer systemBusLck.Unlock()
+	if systemBus != nil &&
+		systemBus.Connected() {
+		return systemBus, nil
+	}
+	defer func() {
+		if conn != nil {
+			systemBus = conn
+		}
+	}()
+	conn, err = ConnectSystemBus()
+	return
+}
+
+// ConnectSessionBus connects to the session bus.
+func ConnectSessionBus(opts ...ConnOption) (*Conn, error) {
+	address, err := getSessionBusAddress(true)
+	if err != nil {
+		return nil, err
+	}
+	return Connect(address, opts...)
+}
+
+// ConnectSystemBus connects to the system bus.
+func ConnectSystemBus(opts ...ConnOption) (*Conn, error) {
+	return Connect(getSystemBusPlatformAddress(), opts...)
+}
+
+// Connect connects to the given address.
+//
+// Returned connection is ready to use and doesn't require calling
+// Auth and Hello methods to make it usable.
+func Connect(address string, opts ...ConnOption) (*Conn, error) {
+	conn, err := Dial(address, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err = conn.Auth(conn.auth); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// SystemBusPrivate returns a new private connection to the system bus.
+// Note: this connection is not ready to use. One must perform Auth and Hello
+// on the connection before it is usable.
+func SystemBusPrivate(opts ...ConnOption) (*Conn, error) {
+	return Dial(getSystemBusPlatformAddress(), opts...)
+}
+
+// SystemBusPrivateHandler returns a new private connection to the system bus, using the provided handlers.
+//
+// Deprecated: use SystemBusPrivate with options instead.
+func SystemBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return SystemBusPrivate(WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// Dial establishes a new private connection to the message bus specified by address.
+func Dial(address string, opts ...ConnOption) (*Conn, error) {
+	tr, err := getTransport(address)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(tr, opts...)
+}
+
+// DialHandler establishes a new private connection to the message bus specified by address, using the supplied handlers.
+//
+// Deprecated: use Dial with options instead.
+func DialHandler(address string, handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return Dial(address, WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// ConnOption is a connection option.
+type ConnOption func(conn *Conn) error
+
+// WithHandler overrides the default handler.
+func WithHandler(handler Handler) ConnOption {
+	return func(conn *Conn) error {
+		conn.handler = handler
+		return nil
+	}
+}
+
+// WithSignalHandler overrides the default signal handler.
+func WithSignalHandler(handler SignalHandler) ConnOption {
+	return func(conn *Conn) error {
+		conn.signalHandler = handler
+		return nil
+	}
+}
+
+// WithSerialGenerator overrides the default signals generator.
+func WithSerialGenerator(gen SerialGenerator) ConnOption {
+	return func(conn *Conn) error {
+		conn.serialGen = gen
+		return nil
+	}
+}
+
+// WithAuth sets authentication methods for the auth conversation.
+func WithAuth(methods ...Auth) ConnOption {
+	return func(conn *Conn) error {
+		conn.auth = methods
+		return nil
+	}
+}
+
+// Interceptor intercepts incoming and outgoing messages.
+type Interceptor func(msg *Message)
+
+// WithIncomingInterceptor sets the given interceptor for incoming messages.
+func WithIncomingInterceptor(interceptor Interceptor) ConnOption {
+	return func(conn *Conn) error {
+		conn.inInt = interceptor
+		return nil
+	}
+}
+
+// WithOutgoingInterceptor sets the given interceptor for outgoing messages.
+func WithOutgoingInterceptor(interceptor Interceptor) ConnOption {
+	return func(conn *Conn) error {
+		conn.outInt = interceptor
+		return nil
+	}
+}
+
+// WithContext overrides  the default context for the connection.
+func WithContext(ctx context.Context) ConnOption {
+	return func(conn *Conn) error {
+		conn.ctx = ctx
+		return nil
+	}
+}
+
+// NewConn creates a new private *Conn from an already established connection.
+func NewConn(conn io.ReadWriteCloser, opts ...ConnOption) (*Conn, error) {
+	return newConn(genericTransport{conn}, opts...)
+}
+
+// NewConnHandler creates a new private *Conn from an already established connection, using the supplied handlers.
+//
+// Deprecated: use NewConn with options instead.
+func NewConnHandler(conn io.ReadWriteCloser, handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return NewConn(genericTransport{conn}, WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// newConn creates a new *Conn from a transport.
+func newConn(tr transport, opts ...ConnOption) (*Conn, error) {
+	conn := new(Conn)
+	conn.transport = tr
+	for _, opt := range opts {
+		if err := opt(conn); err != nil {
+			return nil, err
+		}
+	}
+	if conn.ctx == nil {
+		conn.ctx = context.Background()
+	}
+	conn.ctx, conn.cancelCtx = context.WithCancel(conn.ctx)
+
+	conn.calls = newCallTracker()
+	if conn.handler == nil {
+		conn.handler = NewDefaultHandler()
+	}
+	if conn.signalHandler == nil {
+		conn.signalHandler = NewDefaultSignalHandler()
+	}
+	if conn.serialGen == nil {
+		conn.serialGen = newSerialGenerator()
+	}
+	conn.outHandler = &outputHandler{conn: conn}
+	conn.names = newNameTracker()
+	conn.busObj = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+
+	go func() {
+		<-conn.ctx.Done()
+		conn.Close()
+	}()
+	return conn, nil
+}
+
+// BusObject returns the object owned by the bus daemon which handles
+// administrative requests.
+func (conn *Conn) BusObject() BusObject {
+	return conn.busObj
+}
+
+// Close closes the connection. Any blocked operations will return with errors
+// and the channels passed to Eavesdrop and Signal are closed. This method must
+// not be called on shared connections.
+func (conn *Conn) Close() error {
+	conn.closeOnce.Do(func() {
+		conn.outHandler.close()
+		if term, ok := conn.signalHandler.(Terminator); ok {
+			term.Terminate()
+		}
+
+		if term, ok := conn.handler.(Terminator); ok {
+			term.Terminate()
+		}
+
+		conn.eavesdroppedLck.Lock()
+		if conn.eavesdropped != nil {
+			close(conn.eavesdropped)
+		}
+		conn.eavesdroppedLck.Unlock()
+
+		conn.cancelCtx()
+
+		conn.closeErr = conn.transport.Close()
+	})
+	return conn.closeErr
+}
+
+// Context returns the context associated with the connection.  The
+// context will be cancelled when the connection is closed.
+func (conn *Conn) Context() context.Context {
+	return conn.ctx
+}
+
+// Connected returns whether conn is connected
+func (conn *Conn) Connected() bool {
+	return conn.ctx.Err() == nil
+}
+
+// Eavesdrop causes conn to send all incoming messages to the given channel
+// without further processing. Method replies, errors and signals will not be
+// sent to the appropriate channels and method calls will not be handled. If nil
+// is passed, the normal behaviour is restored.
+//
+// The caller has to make sure that ch is sufficiently buffered;
+// if a message arrives when a write to ch is not possible, the message is
+// discarded.
+func (conn *Conn) Eavesdrop(ch chan<- *Message) {
+	conn.eavesdroppedLck.Lock()
+	conn.eavesdropped = ch
+	conn.eavesdroppedLck.Unlock()
+}
+
+// getSerial returns an unused serial.
+func (conn *Conn) getSerial() uint32 {
+	return conn.serialGen.GetSerial()
+}
+
+// Hello sends the initial org.freedesktop.DBus.Hello call. This method must be
+// called after authentication, but before sending any other messages to the
+// bus. Hello must not be called for shared connections.
+func (conn *Conn) Hello() error {
+	var s string
+	err := conn.busObj.Call("org.freedesktop.DBus.Hello", 0).Store(&s)
+	if err != nil {
+		return err
+	}
+	conn.names.acquireUniqueConnectionName(s)
+	return nil
+}
+
+// inWorker runs in an own goroutine, reading incoming messages from the
+// transport and dispatching them appropriately.
+func (conn *Conn) inWorker() {
+	sequenceGen := newSequenceGenerator()
+	for {
+		msg, err := conn.ReadMessage()
+		if err != nil {
+			if _, ok := err.(InvalidMessageError); !ok {
+				// Some read error occurred (usually EOF); we can't really do
+				// anything but to shut down all stuff and returns errors to all
+				// pending replies.
+				conn.Close()
+				conn.calls.finalizeAllWithError(sequenceGen, err)
+				return
+			}
+			// invalid messages are ignored
+			continue
+		}
+		conn.eavesdroppedLck.Lock()
+		if conn.eavesdropped != nil {
+			select {
+			case conn.eavesdropped <- msg:
+			default:
+			}
+			conn.eavesdroppedLck.Unlock()
+			continue
+		}
+		conn.eavesdroppedLck.Unlock()
+		dest, _ := msg.Headers[FieldDestination].value.(string)
+		found := dest == "" ||
+			!conn.names.uniqueNameIsKnown() ||
+			conn.names.isKnownName(dest)
+		if !found {
+			// Eavesdropped a message, but no channel for it is registered.
+			// Ignore it.
+			continue
+		}
+
+		if conn.inInt != nil {
+			conn.inInt(msg)
+		}
+		sequence := sequenceGen.next()
+		switch msg.Type {
+		case TypeError:
+			conn.serialGen.RetireSerial(conn.calls.handleDBusError(sequence, msg))
+		case TypeMethodReply:
+			conn.serialGen.RetireSerial(conn.calls.handleReply(sequence, msg))
+		case TypeSignal:
+			conn.handleSignal(sequence, msg)
+		case TypeMethodCall:
+			go conn.handleCall(msg)
+		}
+
+	}
+}
+
+func (conn *Conn) handleSignal(sequence Sequence, msg *Message) {
+	iface := msg.Headers[FieldInterface].value.(string)
+	member := msg.Headers[FieldMember].value.(string)
+	// as per http://dbus.freedesktop.org/doc/dbus-specification.html ,
+	// sender is optional for signals.
+	sender, _ := msg.Headers[FieldSender].value.(string)
+	if iface == "org.freedesktop.DBus" && sender == "org.freedesktop.DBus" {
+		if member == "NameLost" {
+			// If we lost the name on the bus, remove it from our
+			// tracking list.
+			name, ok := msg.Body[0].(string)
+			if !ok {
+				panic("Unable to read the lost name")
+			}
+			conn.names.loseName(name)
+		} else if member == "NameAcquired" {
+			// If we acquired the name on the bus, add it to our
+			// tracking list.
+			name, ok := msg.Body[0].(string)
+			if !ok {
+				panic("Unable to read the acquired name")
+			}
+			conn.names.acquireName(name)
+		}
+	}
+	signal := &Signal{
+		Sender:   sender,
+		Path:     msg.Headers[FieldPath].value.(ObjectPath),
+		Name:     iface + "." + member,
+		Body:     msg.Body,
+		Sequence: sequence,
+	}
+	conn.signalHandler.DeliverSignal(iface, member, signal)
+}
+
+// Names returns the list of all names that are currently owned by this
+// connection. The slice is always at least one element long, the first element
+// being the unique name of the connection.
+func (conn *Conn) Names() []string {
+	return conn.names.listKnownNames()
+}
+
+// Object returns the object identified by the given destination name and path.
+func (conn *Conn) Object(dest string, path ObjectPath) BusObject {
+	return &Object{conn, dest, path}
+}
+
+func (conn *Conn) sendMessageAndIfClosed(msg *Message, ifClosed func()) {
+	if msg.serial == 0 {
+		msg.serial = conn.getSerial()
+	}
+	if conn.outInt != nil {
+		conn.outInt(msg)
+	}
+	err := conn.outHandler.sendAndIfClosed(msg, ifClosed)
+	if err != nil {
+		conn.handleSendError(msg, err)
+	} else if msg.Type != TypeMethodCall {
+		conn.serialGen.RetireSerial(msg.serial)
+	}
+}
+
+func (conn *Conn) handleSendError(msg *Message, err error) {
+	if msg.Type == TypeMethodCall {
+		conn.calls.handleSendError(msg, err)
+	} else if msg.Type == TypeMethodReply {
+		if _, ok := err.(FormatError); ok {
+			conn.sendError(err, msg.Headers[FieldDestination].value.(string), msg.Headers[FieldReplySerial].value.(uint32))
+		}
+	}
+	conn.serialGen.RetireSerial(msg.serial)
+}
+
+// Send sends the given message to the message bus. You usually don't need to
+// use this; use the higher-level equivalents (Call / Go, Emit and Export)
+// instead. If msg is a method call and NoReplyExpected is not set, a non-nil
+// call is returned and the same value is sent to ch (which must be buffered)
+// once the call is complete. Otherwise, ch is ignored and a Call structure is
+// returned of which only the Err member is valid.
+func (conn *Conn) Send(msg *Message, ch chan *Call) *Call {
+	return conn.send(context.Background(), msg, ch)
+}
+
+// SendWithContext acts like Send but takes a context
+func (conn *Conn) SendWithContext(ctx context.Context, msg *Message, ch chan *Call) *Call {
+	return conn.send(ctx, msg, ch)
+}
+
+func (conn *Conn) send(ctx context.Context, msg *Message, ch chan *Call) *Call {
+	if ctx == nil {
+		panic("nil context")
+	}
+	if ch == nil {
+		ch = make(chan *Call, 1)
+	} else if cap(ch) == 0 {
+		panic("dbus: unbuffered channel passed to (*Conn).Send")
+	}
+
+	var call *Call
+	ctx, canceler := context.WithCancel(ctx)
+	msg.serial = conn.getSerial()
+	if msg.Type == TypeMethodCall && msg.Flags&FlagNoReplyExpected == 0 {
+		call = new(Call)
+		call.Destination, _ = msg.Headers[FieldDestination].value.(string)
+		call.Path, _ = msg.Headers[FieldPath].value.(ObjectPath)
+		iface, _ := msg.Headers[FieldInterface].value.(string)
+		member, _ := msg.Headers[FieldMember].value.(string)
+		call.Method = iface + "." + member
+		call.Args = msg.Body
+		call.Done = ch
+		call.ctx = ctx
+		call.ctxCanceler = canceler
+		conn.calls.track(msg.serial, call)
+		if ctx.Err() != nil {
+			// short path: don't even send the message if context already cancelled
+			conn.calls.handleSendError(msg, ctx.Err())
+			return call
+		}
+		go func() {
+			<-ctx.Done()
+			conn.calls.handleSendError(msg, ctx.Err())
+		}()
+		conn.sendMessageAndIfClosed(msg, func() {
+			conn.calls.handleSendError(msg, ErrClosed)
+			canceler()
+		})
+	} else {
+		canceler()
+		call = &Call{Err: nil, Done: ch}
+		ch <- call
+		conn.sendMessageAndIfClosed(msg, func() {
+			call = &Call{Err: ErrClosed}
+		})
+	}
+	return call
+}
+
+// sendError creates an error message corresponding to the parameters and sends
+// it to conn.out.
+func (conn *Conn) sendError(err error, dest string, serial uint32) {
+	var e *Error
+	switch em := err.(type) {
+	case Error:
+		e = &em
+	case *Error:
+		e = em
+	case DBusError:
+		name, body := em.DBusError()
+		e = NewError(name, body)
+	default:
+		e = MakeFailedError(err)
+	}
+	msg := new(Message)
+	msg.Type = TypeError
+	msg.Headers = make(map[HeaderField]Variant)
+	if dest != "" {
+		msg.Headers[FieldDestination] = MakeVariant(dest)
+	}
+	msg.Headers[FieldErrorName] = MakeVariant(e.Name)
+	msg.Headers[FieldReplySerial] = MakeVariant(serial)
+	msg.Body = e.Body
+	if len(e.Body) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(e.Body...))
+	}
+	conn.sendMessageAndIfClosed(msg, nil)
+}
+
+// sendReply creates a method reply message corresponding to the parameters and
+// sends it to conn.out.
+func (conn *Conn) sendReply(dest string, serial uint32, values ...interface{}) {
+	msg := new(Message)
+	msg.Type = TypeMethodReply
+	msg.Headers = make(map[HeaderField]Variant)
+	if dest != "" {
+		msg.Headers[FieldDestination] = MakeVariant(dest)
+	}
+	msg.Headers[FieldReplySerial] = MakeVariant(serial)
+	msg.Body = values
+	if len(values) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(values...))
+	}
+	conn.sendMessageAndIfClosed(msg, nil)
+}
+
+// AddMatchSignal registers the given match rule to receive broadcast
+// signals based on their contents.
+func (conn *Conn) AddMatchSignal(options ...MatchOption) error {
+	return conn.AddMatchSignalContext(context.Background(), options...)
+}
+
+// AddMatchSignalContext acts like AddMatchSignal but takes a context.
+func (conn *Conn) AddMatchSignalContext(ctx context.Context, options ...MatchOption) error {
+	options = append([]MatchOption{withMatchType("signal")}, options...)
+	return conn.busObj.CallWithContext(
+		ctx,
+		"org.freedesktop.DBus.AddMatch", 0,
+		formatMatchOptions(options),
+	).Store()
+}
+
+// RemoveMatchSignal removes the first rule that matches previously registered with AddMatchSignal.
+func (conn *Conn) RemoveMatchSignal(options ...MatchOption) error {
+	return conn.RemoveMatchSignalContext(context.Background(), options...)
+}
+
+// RemoveMatchSignalContext acts like RemoveMatchSignal but takes a context.
+func (conn *Conn) RemoveMatchSignalContext(ctx context.Context, options ...MatchOption) error {
+	options = append([]MatchOption{withMatchType("signal")}, options...)
+	return conn.busObj.CallWithContext(
+		ctx,
+		"org.freedesktop.DBus.RemoveMatch", 0,
+		formatMatchOptions(options),
+	).Store()
+}
+
+// Signal registers the given channel to be passed all received signal messages.
+//
+// Multiple of these channels can be registered at the same time. The channel is
+// closed if the Conn is closed; it should not be closed by the caller before
+// RemoveSignal was called on it.
+//
+// These channels are "overwritten" by Eavesdrop; i.e., if there currently is a
+// channel for eavesdropped messages, this channel receives all signals, and
+// none of the channels passed to Signal will receive any signals.
+//
+// Panics if the signal handler is not a `SignalRegistrar`.
+func (conn *Conn) Signal(ch chan<- *Signal) {
+	handler, ok := conn.signalHandler.(SignalRegistrar)
+	if !ok {
+		panic("cannot use this method with a non SignalRegistrar handler")
+	}
+	handler.AddSignal(ch)
+}
+
+// RemoveSignal removes the given channel from the list of the registered channels.
+//
+// Panics if the signal handler is not a `SignalRegistrar`.
+func (conn *Conn) RemoveSignal(ch chan<- *Signal) {
+	handler, ok := conn.signalHandler.(SignalRegistrar)
+	if !ok {
+		panic("cannot use this method with a non SignalRegistrar handler")
+	}
+	handler.RemoveSignal(ch)
+}
+
+// SupportsUnixFDs returns whether the underlying transport supports passing of
+// unix file descriptors. If this is false, method calls containing unix file
+// descriptors will return an error and emitted signals containing them will
+// not be sent.
+func (conn *Conn) SupportsUnixFDs() bool {
+	return conn.unixFD
+}
+
+// Error represents a D-Bus message of type Error.
+type Error struct {
+	Name string
+	Body []interface{}
+}
+
+func NewError(name string, body []interface{}) *Error {
+	return &Error{name, body}
+}
+
+func (e Error) Error() string {
+	if len(e.Body) >= 1 {
+		s, ok := e.Body[0].(string)
+		if ok {
+			return s
+		}
+	}
+	return e.Name
+}
+
+// Signal represents a D-Bus message of type Signal. The name member is given in
+// "interface.member" notation, e.g. org.freedesktop.D-Bus.NameLost.
+type Signal struct {
+	Sender   string
+	Path     ObjectPath
+	Name     string
+	Body     []interface{}
+	Sequence Sequence
+}
+
+// transport is a D-Bus transport.
+type transport interface {
+	// Read and Write raw data (for example, for the authentication protocol).
+	io.ReadWriteCloser
+
+	// Send the initial null byte used for the EXTERNAL mechanism.
+	SendNullByte() error
+
+	// Returns whether this transport supports passing Unix FDs.
+	SupportsUnixFDs() bool
+
+	// Signal the transport that Unix FD passing is enabled for this connection.
+	EnableUnixFDs()
+
+	// Read / send a message, handling things like Unix FDs.
+	ReadMessage() (*Message, error)
+	SendMessage(*Message) error
+}
+
+var (
+	transports = make(map[string]func(string) (transport, error))
+)
+
+func getTransport(address string) (transport, error) {
+	var err error
+	var t transport
+
+	addresses := strings.Split(address, ";")
+	for _, v := range addresses {
+		i := strings.IndexRune(v, ':')
+		if i == -1 {
+			err = errors.New("dbus: invalid bus address (no transport)")
+			continue
+		}
+		f := transports[v[:i]]
+		if f == nil {
+			err = errors.New("dbus: invalid bus address (invalid or unsupported transport)")
+			continue
+		}
+		t, err = f(v[i+1:])
+		if err == nil {
+			return t, nil
+		}
+	}
+	return nil, err
+}
+
+// getKey gets a key from a the list of keys. Returns "" on error / not found...
+func getKey(s, key string) string {
+	for _, keyEqualsValue := range strings.Split(s, ",") {
+		keyValue := strings.SplitN(keyEqualsValue, "=", 2)
+		if len(keyValue) == 2 && keyValue[0] == key {
+			val, err := UnescapeBusAddressValue(keyValue[1])
+			if err != nil {
+				// No way to return an error.
+				return ""
+			}
+			return val
+		}
+	}
+	return ""
+}
+
+type outputHandler struct {
+	conn    *Conn
+	sendLck sync.Mutex
+	closed  struct {
+		isClosed bool
+		lck      sync.RWMutex
+	}
+}
+
+func (h *outputHandler) sendAndIfClosed(msg *Message, ifClosed func()) error {
+	h.closed.lck.RLock()
+	defer h.closed.lck.RUnlock()
+	if h.closed.isClosed {
+		if ifClosed != nil {
+			ifClosed()
+		}
+		return nil
+	}
+	h.sendLck.Lock()
+	defer h.sendLck.Unlock()
+	return h.conn.SendMessage(msg)
+}
+
+func (h *outputHandler) close() {
+	h.closed.lck.Lock()
+	defer h.closed.lck.Unlock()
+	h.closed.isClosed = true
+}
+
+type serialGenerator struct {
+	lck        sync.Mutex
+	nextSerial uint32
+	serialUsed map[uint32]bool
+}
+
+func newSerialGenerator() *serialGenerator {
+	return &serialGenerator{
+		serialUsed: map[uint32]bool{0: true},
+		nextSerial: 1,
+	}
+}
+
+func (gen *serialGenerator) GetSerial() uint32 {
+	gen.lck.Lock()
+	defer gen.lck.Unlock()
+	n := gen.nextSerial
+	for gen.serialUsed[n] {
+		n++
+	}
+	gen.serialUsed[n] = true
+	gen.nextSerial = n + 1
+	return n
+}
+
+func (gen *serialGenerator) RetireSerial(serial uint32) {
+	gen.lck.Lock()
+	defer gen.lck.Unlock()
+	delete(gen.serialUsed, serial)
+}
+
+type nameTracker struct {
+	lck    sync.RWMutex
+	unique string
+	names  map[string]struct{}
+}
+
+func newNameTracker() *nameTracker {
+	return &nameTracker{names: map[string]struct{}{}}
+}
+func (tracker *nameTracker) acquireUniqueConnectionName(name string) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	tracker.unique = name
+}
+func (tracker *nameTracker) acquireName(name string) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	tracker.names[name] = struct{}{}
+}
+func (tracker *nameTracker) loseName(name string) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	delete(tracker.names, name)
+}
+
+func (tracker *nameTracker) uniqueNameIsKnown() bool {
+	tracker.lck.RLock()
+	defer tracker.lck.RUnlock()
+	return tracker.unique != ""
+}
+func (tracker *nameTracker) isKnownName(name string) bool {
+	tracker.lck.RLock()
+	defer tracker.lck.RUnlock()
+	_, ok := tracker.names[name]
+	return ok || name == tracker.unique
+}
+func (tracker *nameTracker) listKnownNames() []string {
+	tracker.lck.RLock()
+	defer tracker.lck.RUnlock()
+	out := make([]string, 0, len(tracker.names)+1)
+	out = append(out, tracker.unique)
+	for k := range tracker.names {
+		out = append(out, k)
+	}
+	return out
+}
+
+type callTracker struct {
+	calls map[uint32]*Call
+	lck   sync.RWMutex
+}
+
+func newCallTracker() *callTracker {
+	return &callTracker{calls: map[uint32]*Call{}}
+}
+
+func (tracker *callTracker) track(sn uint32, call *Call) {
+	tracker.lck.Lock()
+	tracker.calls[sn] = call
+	tracker.lck.Unlock()
+}
+
+func (tracker *callTracker) handleReply(sequence Sequence, msg *Message) uint32 {
+	serial := msg.Headers[FieldReplySerial].value.(uint32)
+	tracker.lck.RLock()
+	_, ok := tracker.calls[serial]
+	tracker.lck.RUnlock()
+	if ok {
+		tracker.finalizeWithBody(serial, sequence, msg.Body)
+	}
+	return serial
+}
+
+func (tracker *callTracker) handleDBusError(sequence Sequence, msg *Message) uint32 {
+	serial := msg.Headers[FieldReplySerial].value.(uint32)
+	tracker.lck.RLock()
+	_, ok := tracker.calls[serial]
+	tracker.lck.RUnlock()
+	if ok {
+		name, _ := msg.Headers[FieldErrorName].value.(string)
+		tracker.finalizeWithError(serial, sequence, Error{name, msg.Body})
+	}
+	return serial
+}
+
+func (tracker *callTracker) handleSendError(msg *Message, err error) {
+	if err == nil {
+		return
+	}
+	tracker.lck.RLock()
+	_, ok := tracker.calls[msg.serial]
+	tracker.lck.RUnlock()
+	if ok {
+		tracker.finalizeWithError(msg.serial, NoSequence, err)
+	}
+}
+
+// finalize was the only func that did not strobe Done
+func (tracker *callTracker) finalize(sn uint32) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+		c.ContextCancel()
+	}
+}
+
+func (tracker *callTracker) finalizeWithBody(sn uint32, sequence Sequence, body []interface{}) {
+	tracker.lck.Lock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+	}
+	tracker.lck.Unlock()
+	if ok {
+		c.Body = body
+		c.ResponseSequence = sequence
+		c.done()
+	}
+}
+
+func (tracker *callTracker) finalizeWithError(sn uint32, sequence Sequence, err error) {
+	tracker.lck.Lock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+	}
+	tracker.lck.Unlock()
+	if ok {
+		c.Err = err
+		c.ResponseSequence = sequence
+		c.done()
+	}
+}
+
+func (tracker *callTracker) finalizeAllWithError(sequenceGen *sequenceGenerator, err error) {
+	tracker.lck.Lock()
+	closedCalls := make([]*Call, 0, len(tracker.calls))
+	for sn := range tracker.calls {
+		closedCalls = append(closedCalls, tracker.calls[sn])
+	}
+	tracker.calls = map[uint32]*Call{}
+	tracker.lck.Unlock()
+	for _, call := range closedCalls {
+		call.Err = err
+		call.ResponseSequence = sequenceGen.next()
+		call.done()
+	}
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_darwin.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_darwin.go
@@ -1,0 +1,37 @@
+package dbus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const defaultSystemBusAddress = "unix:path=/opt/local/var/run/dbus/system_bus_socket"
+
+func getSessionBusPlatformAddress() (string, error) {
+	cmd := exec.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+	b, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(b) == 0 {
+		return "", errors.New("dbus: couldn't determine address of session bus")
+	}
+
+	return "unix:path=" + string(b[:len(b)-1]), nil
+}
+
+func getSystemBusPlatformAddress() string {
+	address := os.Getenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+	if address != "" {
+		return fmt.Sprintf("unix:path=%s", address)
+	}
+	return defaultSystemBusAddress
+}
+
+func tryDiscoverDbusSessionBusAddress() string {
+	return ""
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_other.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_other.go
@@ -1,0 +1,90 @@
+// +build !darwin
+
+package dbus
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"strings"
+)
+
+var execCommand = exec.Command
+
+func getSessionBusPlatformAddress() (string, error) {
+	cmd := execCommand("dbus-launch")
+	b, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", err
+	}
+
+	i := bytes.IndexByte(b, '=')
+	j := bytes.IndexByte(b, '\n')
+
+	if i == -1 || j == -1 || i > j {
+		return "", errors.New("dbus: couldn't determine address of session bus")
+	}
+
+	env, addr := string(b[0:i]), string(b[i+1:j])
+	os.Setenv(env, addr)
+
+	return addr, nil
+}
+
+// tryDiscoverDbusSessionBusAddress tries to discover an existing dbus session
+// and return the value of its DBUS_SESSION_BUS_ADDRESS.
+// It tries different techniques employed by different operating systems,
+// returning the first valid address it finds, or an empty string.
+//
+// * /run/user/<uid>/bus           if this exists, it *is* the bus socket. present on
+//                                 Ubuntu 18.04
+// * /run/user/<uid>/dbus-session: if this exists, it can be parsed for the bus
+//                                 address. present on Ubuntu 16.04
+//
+// See https://dbus.freedesktop.org/doc/dbus-launch.1.html
+func tryDiscoverDbusSessionBusAddress() string {
+	if runtimeDirectory, err := getRuntimeDirectory(); err == nil {
+
+		if runUserBusFile := path.Join(runtimeDirectory, "bus"); fileExists(runUserBusFile) {
+			// if /run/user/<uid>/bus exists, that file itself
+			// *is* the unix socket, so return its path
+			return fmt.Sprintf("unix:path=%s", EscapeBusAddressValue(runUserBusFile))
+		}
+		if runUserSessionDbusFile := path.Join(runtimeDirectory, "dbus-session"); fileExists(runUserSessionDbusFile) {
+			// if /run/user/<uid>/dbus-session exists, it's a
+			// text file // containing the address of the socket, e.g.:
+			// DBUS_SESSION_BUS_ADDRESS=unix:abstract=/tmp/dbus-E1c73yNqrG
+
+			if f, err := ioutil.ReadFile(runUserSessionDbusFile); err == nil {
+				fileContent := string(f)
+
+				prefix := "DBUS_SESSION_BUS_ADDRESS="
+
+				if strings.HasPrefix(fileContent, prefix) {
+					address := strings.TrimRight(strings.TrimPrefix(fileContent, prefix), "\n\r")
+					return address
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func getRuntimeDirectory() (string, error) {
+	if currentUser, err := user.Current(); err != nil {
+		return "", err
+	} else {
+		return fmt.Sprintf("/run/user/%s", currentUser.Uid), nil
+	}
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_unix.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_unix.go
@@ -1,0 +1,17 @@
+//+build !windows,!solaris,!darwin
+
+package dbus
+
+import (
+	"os"
+)
+
+const defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"
+
+func getSystemBusPlatformAddress() string {
+	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
+	if address != "" {
+		return address
+	}
+	return defaultSystemBusAddress
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_windows.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_windows.go
@@ -1,0 +1,15 @@
+//+build windows
+
+package dbus
+
+import "os"
+
+const defaultSystemBusAddress = "tcp:host=127.0.0.1,port=12434"
+
+func getSystemBusPlatformAddress() string {
+	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
+	if address != "" {
+		return address
+	}
+	return defaultSystemBusAddress
+}

--- a/vendor/github.com/godbus/dbus/v5/dbus.go
+++ b/vendor/github.com/godbus/dbus/v5/dbus.go
@@ -1,0 +1,430 @@
+package dbus
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var (
+	byteType        = reflect.TypeOf(byte(0))
+	boolType        = reflect.TypeOf(false)
+	uint8Type       = reflect.TypeOf(uint8(0))
+	int16Type       = reflect.TypeOf(int16(0))
+	uint16Type      = reflect.TypeOf(uint16(0))
+	intType         = reflect.TypeOf(int(0))
+	uintType        = reflect.TypeOf(uint(0))
+	int32Type       = reflect.TypeOf(int32(0))
+	uint32Type      = reflect.TypeOf(uint32(0))
+	int64Type       = reflect.TypeOf(int64(0))
+	uint64Type      = reflect.TypeOf(uint64(0))
+	float64Type     = reflect.TypeOf(float64(0))
+	stringType      = reflect.TypeOf("")
+	signatureType   = reflect.TypeOf(Signature{""})
+	objectPathType  = reflect.TypeOf(ObjectPath(""))
+	variantType     = reflect.TypeOf(Variant{Signature{""}, nil})
+	interfacesType  = reflect.TypeOf([]interface{}{})
+	interfaceType   = reflect.TypeOf((*interface{})(nil)).Elem()
+	unixFDType      = reflect.TypeOf(UnixFD(0))
+	unixFDIndexType = reflect.TypeOf(UnixFDIndex(0))
+	errType         = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+// An InvalidTypeError signals that a value which cannot be represented in the
+// D-Bus wire format was passed to a function.
+type InvalidTypeError struct {
+	Type reflect.Type
+}
+
+func (e InvalidTypeError) Error() string {
+	return "dbus: invalid type " + e.Type.String()
+}
+
+// Store copies the values contained in src to dest, which must be a slice of
+// pointers. It converts slices of interfaces from src to corresponding structs
+// in dest. An error is returned if the lengths of src and dest or the types of
+// their elements don't match.
+func Store(src []interface{}, dest ...interface{}) error {
+	if len(src) != len(dest) {
+		return errors.New("dbus.Store: length mismatch")
+	}
+
+	for i := range src {
+		if err := storeInterfaces(src[i], dest[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func storeInterfaces(src, dest interface{}) error {
+	return store(reflect.ValueOf(dest), reflect.ValueOf(src))
+}
+
+func store(dest, src reflect.Value) error {
+	if dest.Kind() == reflect.Ptr {
+		if dest.IsNil() {
+			dest.Set(reflect.New(dest.Type().Elem()))
+		}
+		return store(dest.Elem(), src)
+	}
+	switch src.Kind() {
+	case reflect.Slice:
+		return storeSlice(dest, src)
+	case reflect.Map:
+		return storeMap(dest, src)
+	default:
+		return storeBase(dest, src)
+	}
+}
+
+func storeBase(dest, src reflect.Value) error {
+	return setDest(dest, src)
+}
+
+func setDest(dest, src reflect.Value) error {
+	if !isVariant(src.Type()) && isVariant(dest.Type()) {
+		//special conversion for dbus.Variant
+		dest.Set(reflect.ValueOf(MakeVariant(src.Interface())))
+		return nil
+	}
+	if isVariant(src.Type()) && !isVariant(dest.Type()) {
+		src = getVariantValue(src)
+		return store(dest, src)
+	}
+	if !src.Type().ConvertibleTo(dest.Type()) {
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: cannot convert %s to %s",
+			src.Type(), dest.Type())
+	}
+	dest.Set(src.Convert(dest.Type()))
+	return nil
+}
+
+func kindsAreCompatible(dest, src reflect.Type) bool {
+	switch {
+	case isVariant(dest):
+		return true
+	case dest.Kind() == reflect.Interface:
+		return true
+	default:
+		return dest.Kind() == src.Kind()
+	}
+}
+
+func isConvertibleTo(dest, src reflect.Type) bool {
+	switch {
+	case isVariant(dest):
+		return true
+	case dest.Kind() == reflect.Interface:
+		return true
+	case dest.Kind() == reflect.Slice:
+		return src.Kind() == reflect.Slice &&
+			isConvertibleTo(dest.Elem(), src.Elem())
+	case dest.Kind() == reflect.Ptr:
+		dest = dest.Elem()
+		return isConvertibleTo(dest, src)
+	case dest.Kind() == reflect.Struct:
+		return src == interfacesType || dest.Kind() == src.Kind()
+	default:
+		return src.ConvertibleTo(dest)
+	}
+}
+
+func storeMap(dest, src reflect.Value) error {
+	switch {
+	case !kindsAreCompatible(dest.Type(), src.Type()):
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"map: cannot store a value of %s into %s",
+			src.Type(), dest.Type())
+	case isVariant(dest.Type()):
+		return storeMapIntoVariant(dest, src)
+	case dest.Kind() == reflect.Interface:
+		return storeMapIntoInterface(dest, src)
+	case isConvertibleTo(dest.Type().Key(), src.Type().Key()) &&
+		isConvertibleTo(dest.Type().Elem(), src.Type().Elem()):
+		return storeMapIntoMap(dest, src)
+	default:
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"map: cannot convert a value of %s into %s",
+			src.Type(), dest.Type())
+	}
+}
+
+func storeMapIntoVariant(dest, src reflect.Value) error {
+	dv := reflect.MakeMap(src.Type())
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeMapIntoInterface(dest, src reflect.Value) error {
+	var dv reflect.Value
+	if isVariant(src.Type().Elem()) {
+		//Convert variants to interface{} recursively when converting
+		//to interface{}
+		dv = reflect.MakeMap(
+			reflect.MapOf(src.Type().Key(), interfaceType))
+	} else {
+		dv = reflect.MakeMap(src.Type())
+	}
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeMapIntoMap(dest, src reflect.Value) error {
+	if dest.IsNil() {
+		dest.Set(reflect.MakeMap(dest.Type()))
+	}
+	keys := src.MapKeys()
+	for _, key := range keys {
+		dkey := key.Convert(dest.Type().Key())
+		dval := reflect.New(dest.Type().Elem()).Elem()
+		err := store(dval, getVariantValue(src.MapIndex(key)))
+		if err != nil {
+			return err
+		}
+		dest.SetMapIndex(dkey, dval)
+	}
+	return nil
+}
+
+func storeSlice(dest, src reflect.Value) error {
+	switch {
+	case src.Type() == interfacesType && dest.Kind() == reflect.Struct:
+		//The decoder always decodes structs as slices of interface{}
+		return storeStruct(dest, src)
+	case !kindsAreCompatible(dest.Type(), src.Type()):
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"slice: cannot store a value of %s into %s",
+			src.Type(), dest.Type())
+	case isVariant(dest.Type()):
+		return storeSliceIntoVariant(dest, src)
+	case dest.Kind() == reflect.Interface:
+		return storeSliceIntoInterface(dest, src)
+	case isConvertibleTo(dest.Type().Elem(), src.Type().Elem()):
+		return storeSliceIntoSlice(dest, src)
+	default:
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"slice: cannot convert a value of %s into %s",
+			src.Type(), dest.Type())
+	}
+}
+
+func storeStruct(dest, src reflect.Value) error {
+	if isVariant(dest.Type()) {
+		return storeBase(dest, src)
+	}
+	dval := make([]interface{}, 0, dest.NumField())
+	dtype := dest.Type()
+	for i := 0; i < dest.NumField(); i++ {
+		field := dest.Field(i)
+		ftype := dtype.Field(i)
+		if ftype.PkgPath != "" {
+			continue
+		}
+		if ftype.Tag.Get("dbus") == "-" {
+			continue
+		}
+		dval = append(dval, field.Addr().Interface())
+	}
+	if src.Len() != len(dval) {
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"destination struct does not have "+
+				"enough fields need: %d have: %d",
+			src.Len(), len(dval))
+	}
+	return Store(src.Interface().([]interface{}), dval...)
+}
+
+func storeSliceIntoVariant(dest, src reflect.Value) error {
+	dv := reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeSliceIntoInterface(dest, src reflect.Value) error {
+	var dv reflect.Value
+	if isVariant(src.Type().Elem()) {
+		//Convert variants to interface{} recursively when converting
+		//to interface{}
+		dv = reflect.MakeSlice(reflect.SliceOf(interfaceType),
+			src.Len(), src.Cap())
+	} else {
+		dv = reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+	}
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeSliceIntoSlice(dest, src reflect.Value) error {
+	if dest.IsNil() || dest.Len() < src.Len() {
+		dest.Set(reflect.MakeSlice(dest.Type(), src.Len(), src.Cap()))
+	} else if dest.Len() > src.Len() {
+		dest.Set(dest.Slice(0, src.Len()))
+	}
+	for i := 0; i < src.Len(); i++ {
+		err := store(dest.Index(i), getVariantValue(src.Index(i)))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getVariantValue(in reflect.Value) reflect.Value {
+	if isVariant(in.Type()) {
+		return reflect.ValueOf(in.Interface().(Variant).Value())
+	}
+	return in
+}
+
+func isVariant(t reflect.Type) bool {
+	return t == variantType
+}
+
+// An ObjectPath is an object path as defined by the D-Bus spec.
+type ObjectPath string
+
+// IsValid returns whether the object path is valid.
+func (o ObjectPath) IsValid() bool {
+	s := string(o)
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] != '/' {
+		return false
+	}
+	if s[len(s)-1] == '/' && len(s) != 1 {
+		return false
+	}
+	// probably not used, but technically possible
+	if s == "/" {
+		return true
+	}
+	split := strings.Split(s[1:], "/")
+	for _, v := range split {
+		if len(v) == 0 {
+			return false
+		}
+		for _, c := range v {
+			if !isMemberChar(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// A UnixFD is a Unix file descriptor sent over the wire. See the package-level
+// documentation for more information about Unix file descriptor passsing.
+type UnixFD int32
+
+// A UnixFDIndex is the representation of a Unix file descriptor in a message.
+type UnixFDIndex uint32
+
+// alignment returns the alignment of values of type t.
+func alignment(t reflect.Type) int {
+	switch t {
+	case variantType:
+		return 1
+	case objectPathType:
+		return 4
+	case signatureType:
+		return 1
+	case interfacesType:
+		return 4
+	}
+	switch t.Kind() {
+	case reflect.Uint8:
+		return 1
+	case reflect.Uint16, reflect.Int16:
+		return 2
+	case reflect.Uint, reflect.Int, reflect.Uint32, reflect.Int32, reflect.String, reflect.Array, reflect.Slice, reflect.Map:
+		return 4
+	case reflect.Uint64, reflect.Int64, reflect.Float64, reflect.Struct:
+		return 8
+	case reflect.Ptr:
+		return alignment(t.Elem())
+	}
+	return 1
+}
+
+// isKeyType returns whether t is a valid type for a D-Bus dict.
+func isKeyType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Int16, reflect.Int32, reflect.Int64, reflect.Float64,
+		reflect.String, reflect.Uint, reflect.Int:
+
+		return true
+	}
+	return false
+}
+
+// isValidInterface returns whether s is a valid name for an interface.
+func isValidInterface(s string) bool {
+	if len(s) == 0 || len(s) > 255 || s[0] == '.' {
+		return false
+	}
+	elem := strings.Split(s, ".")
+	if len(elem) < 2 {
+		return false
+	}
+	for _, v := range elem {
+		if len(v) == 0 {
+			return false
+		}
+		if v[0] >= '0' && v[0] <= '9' {
+			return false
+		}
+		for _, c := range v {
+			if !isMemberChar(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isValidMember returns whether s is a valid name for a member.
+func isValidMember(s string) bool {
+	if len(s) == 0 || len(s) > 255 {
+		return false
+	}
+	i := strings.Index(s, ".")
+	if i != -1 {
+		return false
+	}
+	if s[0] >= '0' && s[0] <= '9' {
+		return false
+	}
+	for _, c := range s {
+		if !isMemberChar(c) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMemberChar(c rune) bool {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') || c == '_'
+}

--- a/vendor/github.com/godbus/dbus/v5/decoder.go
+++ b/vendor/github.com/godbus/dbus/v5/decoder.go
@@ -1,0 +1,292 @@
+package dbus
+
+import (
+	"encoding/binary"
+	"io"
+	"reflect"
+)
+
+type decoder struct {
+	in    io.Reader
+	order binary.ByteOrder
+	pos   int
+	fds   []int
+}
+
+// newDecoder returns a new decoder that reads values from in. The input is
+// expected to be in the given byte order.
+func newDecoder(in io.Reader, order binary.ByteOrder, fds []int) *decoder {
+	dec := new(decoder)
+	dec.in = in
+	dec.order = order
+	dec.fds = fds
+	return dec
+}
+
+// align aligns the input to the given boundary and panics on error.
+func (dec *decoder) align(n int) {
+	if dec.pos%n != 0 {
+		newpos := (dec.pos + n - 1) & ^(n - 1)
+		empty := make([]byte, newpos-dec.pos)
+		if _, err := io.ReadFull(dec.in, empty); err != nil {
+			panic(err)
+		}
+		dec.pos = newpos
+	}
+}
+
+// Calls binary.Read(dec.in, dec.order, v) and panics on read errors.
+func (dec *decoder) binread(v interface{}) {
+	if err := binary.Read(dec.in, dec.order, v); err != nil {
+		panic(err)
+	}
+}
+
+func (dec *decoder) Decode(sig Signature) (vs []interface{}, err error) {
+	defer func() {
+		var ok bool
+		v := recover()
+		if err, ok = v.(error); ok {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				err = FormatError("unexpected EOF")
+			}
+		}
+	}()
+	vs = make([]interface{}, 0)
+	s := sig.str
+	for s != "" {
+		err, rem := validSingle(s, &depthCounter{})
+		if err != nil {
+			return nil, err
+		}
+		v := dec.decode(s[:len(s)-len(rem)], 0)
+		vs = append(vs, v)
+		s = rem
+	}
+	return vs, nil
+}
+
+func (dec *decoder) decode(s string, depth int) interface{} {
+	dec.align(alignment(typeFor(s)))
+	switch s[0] {
+	case 'y':
+		var b [1]byte
+		if _, err := dec.in.Read(b[:]); err != nil {
+			panic(err)
+		}
+		dec.pos++
+		return b[0]
+	case 'b':
+		i := dec.decode("u", depth).(uint32)
+		switch {
+		case i == 0:
+			return false
+		case i == 1:
+			return true
+		default:
+			panic(FormatError("invalid value for boolean"))
+		}
+	case 'n':
+		var i int16
+		dec.binread(&i)
+		dec.pos += 2
+		return i
+	case 'i':
+		var i int32
+		dec.binread(&i)
+		dec.pos += 4
+		return i
+	case 'x':
+		var i int64
+		dec.binread(&i)
+		dec.pos += 8
+		return i
+	case 'q':
+		var i uint16
+		dec.binread(&i)
+		dec.pos += 2
+		return i
+	case 'u':
+		var i uint32
+		dec.binread(&i)
+		dec.pos += 4
+		return i
+	case 't':
+		var i uint64
+		dec.binread(&i)
+		dec.pos += 8
+		return i
+	case 'd':
+		var f float64
+		dec.binread(&f)
+		dec.pos += 8
+		return f
+	case 's':
+		length := dec.decode("u", depth).(uint32)
+		b := make([]byte, int(length)+1)
+		if _, err := io.ReadFull(dec.in, b); err != nil {
+			panic(err)
+		}
+		dec.pos += int(length) + 1
+		return string(b[:len(b)-1])
+	case 'o':
+		return ObjectPath(dec.decode("s", depth).(string))
+	case 'g':
+		length := dec.decode("y", depth).(byte)
+		b := make([]byte, int(length)+1)
+		if _, err := io.ReadFull(dec.in, b); err != nil {
+			panic(err)
+		}
+		dec.pos += int(length) + 1
+		sig, err := ParseSignature(string(b[:len(b)-1]))
+		if err != nil {
+			panic(err)
+		}
+		return sig
+	case 'v':
+		if depth >= 64 {
+			panic(FormatError("input exceeds container depth limit"))
+		}
+		var variant Variant
+		sig := dec.decode("g", depth).(Signature)
+		if len(sig.str) == 0 {
+			panic(FormatError("variant signature is empty"))
+		}
+		err, rem := validSingle(sig.str, &depthCounter{})
+		if err != nil {
+			panic(err)
+		}
+		if rem != "" {
+			panic(FormatError("variant signature has multiple types"))
+		}
+		variant.sig = sig
+		variant.value = dec.decode(sig.str, depth+1)
+		return variant
+	case 'h':
+		idx := dec.decode("u", depth).(uint32)
+		if int(idx) < len(dec.fds) {
+			return UnixFD(dec.fds[idx])
+		}
+		return UnixFDIndex(idx)
+	case 'a':
+		if len(s) > 1 && s[1] == '{' {
+			ksig := s[2:3]
+			vsig := s[3 : len(s)-1]
+			v := reflect.MakeMap(reflect.MapOf(typeFor(ksig), typeFor(vsig)))
+			if depth >= 63 {
+				panic(FormatError("input exceeds container depth limit"))
+			}
+			length := dec.decode("u", depth).(uint32)
+			// Even for empty maps, the correct padding must be included
+			dec.align(8)
+			spos := dec.pos
+			for dec.pos < spos+int(length) {
+				dec.align(8)
+				if !isKeyType(v.Type().Key()) {
+					panic(InvalidTypeError{v.Type()})
+				}
+				kv := dec.decode(ksig, depth+2)
+				vv := dec.decode(vsig, depth+2)
+				v.SetMapIndex(reflect.ValueOf(kv), reflect.ValueOf(vv))
+			}
+			return v.Interface()
+		}
+		if depth >= 64 {
+			panic(FormatError("input exceeds container depth limit"))
+		}
+		sig := s[1:]
+		length := dec.decode("u", depth).(uint32)
+		// capacity can be determined only for fixed-size element types
+		var capacity int
+		if s := sigByteSize(sig); s != 0 {
+			capacity = int(length) / s
+		}
+		v := reflect.MakeSlice(reflect.SliceOf(typeFor(sig)), 0, capacity)
+		// Even for empty arrays, the correct padding must be included
+		align := alignment(typeFor(s[1:]))
+		if len(s) > 1 && s[1] == '(' {
+			//Special case for arrays of structs
+			//structs decode as a slice of interface{} values
+			//but the dbus alignment does not match this
+			align = 8
+		}
+		dec.align(align)
+		spos := dec.pos
+		for dec.pos < spos+int(length) {
+			ev := dec.decode(s[1:], depth+1)
+			v = reflect.Append(v, reflect.ValueOf(ev))
+		}
+		return v.Interface()
+	case '(':
+		if depth >= 64 {
+			panic(FormatError("input exceeds container depth limit"))
+		}
+		dec.align(8)
+		v := make([]interface{}, 0)
+		s = s[1 : len(s)-1]
+		for s != "" {
+			err, rem := validSingle(s, &depthCounter{})
+			if err != nil {
+				panic(err)
+			}
+			ev := dec.decode(s[:len(s)-len(rem)], depth+1)
+			v = append(v, ev)
+			s = rem
+		}
+		return v
+	default:
+		panic(SignatureError{Sig: s})
+	}
+}
+
+// sigByteSize tries to calculates size of the given signature in bytes.
+//
+// It returns zero when it can't, for example when it contains non-fixed size
+// types such as strings, maps and arrays that require reading of the transmitted
+// data, for that we would need to implement the unread method for Decoder first.
+func sigByteSize(sig string) int {
+	var total int
+	for offset := 0; offset < len(sig); {
+		switch sig[offset] {
+		case 'y':
+			total += 1
+			offset += 1
+		case 'n', 'q':
+			total += 2
+			offset += 1
+		case 'b', 'i', 'u', 'h':
+			total += 4
+			offset += 1
+		case 'x', 't', 'd':
+			total += 8
+			offset += 1
+		case '(':
+			i := 1
+			depth := 1
+			for i < len(sig[offset:]) && depth != 0 {
+				if sig[offset+i] == '(' {
+					depth++
+				} else if sig[offset+i] == ')' {
+					depth--
+				}
+				i++
+			}
+			s := sigByteSize(sig[offset+1 : offset+i-1])
+			if s == 0 {
+				return 0
+			}
+			total += s
+			offset += i
+		default:
+			return 0
+		}
+	}
+	return total
+}
+
+// A FormatError is an error in the wire format.
+type FormatError string
+
+func (e FormatError) Error() string {
+	return "dbus: wire format error: " + string(e)
+}

--- a/vendor/github.com/godbus/dbus/v5/default_handler.go
+++ b/vendor/github.com/godbus/dbus/v5/default_handler.go
@@ -1,0 +1,342 @@
+package dbus
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+func newIntrospectIntf(h *defaultHandler) *exportedIntf {
+	methods := make(map[string]Method)
+	methods["Introspect"] = exportedMethod{
+		reflect.ValueOf(func(msg Message) (string, *Error) {
+			path := msg.Headers[FieldPath].value.(ObjectPath)
+			return h.introspectPath(path), nil
+		}),
+	}
+	return newExportedIntf(methods, true)
+}
+
+//NewDefaultHandler returns an instance of the default
+//call handler. This is useful if you want to implement only
+//one of the two handlers but not both.
+//
+// Deprecated: this is the default value, don't use it, it will be unexported.
+func NewDefaultHandler() *defaultHandler {
+	h := &defaultHandler{
+		objects:     make(map[ObjectPath]*exportedObj),
+		defaultIntf: make(map[string]*exportedIntf),
+	}
+	h.defaultIntf["org.freedesktop.DBus.Introspectable"] = newIntrospectIntf(h)
+	return h
+}
+
+type defaultHandler struct {
+	sync.RWMutex
+	objects     map[ObjectPath]*exportedObj
+	defaultIntf map[string]*exportedIntf
+}
+
+func (h *defaultHandler) PathExists(path ObjectPath) bool {
+	_, ok := h.objects[path]
+	return ok
+}
+
+func (h *defaultHandler) introspectPath(path ObjectPath) string {
+	subpath := make(map[string]struct{})
+	var xml bytes.Buffer
+	xml.WriteString("<node>")
+	for obj := range h.objects {
+		p := string(path)
+		if p != "/" {
+			p += "/"
+		}
+		if strings.HasPrefix(string(obj), p) {
+			node_name := strings.Split(string(obj[len(p):]), "/")[0]
+			subpath[node_name] = struct{}{}
+		}
+	}
+	for s := range subpath {
+		xml.WriteString("\n\t<node name=\"" + s + "\"/>")
+	}
+	xml.WriteString("\n</node>")
+	return xml.String()
+}
+
+func (h *defaultHandler) LookupObject(path ObjectPath) (ServerObject, bool) {
+	h.RLock()
+	defer h.RUnlock()
+	object, ok := h.objects[path]
+	if ok {
+		return object, ok
+	}
+
+	// If an object wasn't found for this exact path,
+	// look for a matching subtree registration
+	subtreeObject := newExportedObject()
+	path = path[:strings.LastIndex(string(path), "/")]
+	for len(path) > 0 {
+		object, ok = h.objects[path]
+		if ok {
+			for name, iface := range object.interfaces {
+				// Only include this handler if it registered for the subtree
+				if iface.isFallbackInterface() {
+					subtreeObject.interfaces[name] = iface
+				}
+			}
+			break
+		}
+
+		path = path[:strings.LastIndex(string(path), "/")]
+	}
+
+	for name, intf := range h.defaultIntf {
+		if _, exists := subtreeObject.interfaces[name]; exists {
+			continue
+		}
+		subtreeObject.interfaces[name] = intf
+	}
+
+	return subtreeObject, true
+}
+
+func (h *defaultHandler) AddObject(path ObjectPath, object *exportedObj) {
+	h.Lock()
+	h.objects[path] = object
+	h.Unlock()
+}
+
+func (h *defaultHandler) DeleteObject(path ObjectPath) {
+	h.Lock()
+	delete(h.objects, path)
+	h.Unlock()
+}
+
+type exportedMethod struct {
+	reflect.Value
+}
+
+func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
+	t := m.Type()
+
+	params := make([]reflect.Value, len(args))
+	for i := 0; i < len(args); i++ {
+		params[i] = reflect.ValueOf(args[i]).Elem()
+	}
+
+	ret := m.Value.Call(params)
+	var err error
+	nilErr := false // The reflection will find almost-nils, let's only pass back clean ones!
+	if t.NumOut() > 0 {
+		if e, ok := ret[t.NumOut()-1].Interface().(*Error); ok { // godbus *Error
+			nilErr = ret[t.NumOut()-1].IsNil()
+			ret = ret[:t.NumOut()-1]
+			err = e
+		} else if ret[t.NumOut()-1].Type().Implements(errType) { // Go error
+			i := ret[t.NumOut()-1].Interface()
+			if i == nil {
+				nilErr = ret[t.NumOut()-1].IsNil()
+			} else {
+				err = i.(error)
+			}
+			ret = ret[:t.NumOut()-1]
+		}
+	}
+	out := make([]interface{}, len(ret))
+	for i, val := range ret {
+		out[i] = val.Interface()
+	}
+	if nilErr || err == nil {
+		//concrete type to interface nil is a special case
+		return out, nil
+	}
+	return out, err
+}
+
+func (m exportedMethod) NumArguments() int {
+	return m.Value.Type().NumIn()
+}
+
+func (m exportedMethod) ArgumentValue(i int) interface{} {
+	return reflect.Zero(m.Type().In(i)).Interface()
+}
+
+func (m exportedMethod) NumReturns() int {
+	return m.Value.Type().NumOut()
+}
+
+func (m exportedMethod) ReturnValue(i int) interface{} {
+	return reflect.Zero(m.Type().Out(i)).Interface()
+}
+
+func newExportedObject() *exportedObj {
+	return &exportedObj{
+		interfaces: make(map[string]*exportedIntf),
+	}
+}
+
+type exportedObj struct {
+	mu         sync.RWMutex
+	interfaces map[string]*exportedIntf
+}
+
+func (obj *exportedObj) LookupInterface(name string) (Interface, bool) {
+	if name == "" {
+		return obj, true
+	}
+	obj.mu.RLock()
+	defer obj.mu.RUnlock()
+	intf, exists := obj.interfaces[name]
+	return intf, exists
+}
+
+func (obj *exportedObj) AddInterface(name string, iface *exportedIntf) {
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+	obj.interfaces[name] = iface
+}
+
+func (obj *exportedObj) DeleteInterface(name string) {
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+	delete(obj.interfaces, name)
+}
+
+func (obj *exportedObj) LookupMethod(name string) (Method, bool) {
+	obj.mu.RLock()
+	defer obj.mu.RUnlock()
+	for _, intf := range obj.interfaces {
+		method, exists := intf.LookupMethod(name)
+		if exists {
+			return method, exists
+		}
+	}
+	return nil, false
+}
+
+func (obj *exportedObj) isFallbackInterface() bool {
+	return false
+}
+
+func newExportedIntf(methods map[string]Method, includeSubtree bool) *exportedIntf {
+	return &exportedIntf{
+		methods:        methods,
+		includeSubtree: includeSubtree,
+	}
+}
+
+type exportedIntf struct {
+	methods map[string]Method
+
+	// Whether or not this export is for the entire subtree
+	includeSubtree bool
+}
+
+func (obj *exportedIntf) LookupMethod(name string) (Method, bool) {
+	out, exists := obj.methods[name]
+	return out, exists
+}
+
+func (obj *exportedIntf) isFallbackInterface() bool {
+	return obj.includeSubtree
+}
+
+//NewDefaultSignalHandler returns an instance of the default
+//signal handler. This is useful if you want to implement only
+//one of the two handlers but not both.
+//
+// Deprecated: this is the default value, don't use it, it will be unexported.
+func NewDefaultSignalHandler() *defaultSignalHandler {
+	return &defaultSignalHandler{}
+}
+
+type defaultSignalHandler struct {
+	mu      sync.RWMutex
+	closed  bool
+	signals []*signalChannelData
+}
+
+func (sh *defaultSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	if sh.closed {
+		return
+	}
+	for _, scd := range sh.signals {
+		scd.deliver(signal)
+	}
+}
+
+func (sh *defaultSignalHandler) Terminate() {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+
+	for _, scd := range sh.signals {
+		scd.close()
+		close(scd.ch)
+	}
+	sh.closed = true
+	sh.signals = nil
+}
+
+func (sh *defaultSignalHandler) AddSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	sh.signals = append(sh.signals, &signalChannelData{
+		ch:   ch,
+		done: make(chan struct{}),
+	})
+}
+
+func (sh *defaultSignalHandler) RemoveSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	for i := len(sh.signals) - 1; i >= 0; i-- {
+		if ch == sh.signals[i].ch {
+			sh.signals[i].close()
+			copy(sh.signals[i:], sh.signals[i+1:])
+			sh.signals[len(sh.signals)-1] = nil
+			sh.signals = sh.signals[:len(sh.signals)-1]
+		}
+	}
+}
+
+type signalChannelData struct {
+	wg   sync.WaitGroup
+	ch   chan<- *Signal
+	done chan struct{}
+}
+
+func (scd *signalChannelData) deliver(signal *Signal) {
+	select {
+	case scd.ch <- signal:
+	case <-scd.done:
+		return
+	default:
+		scd.wg.Add(1)
+		go scd.deferredDeliver(signal)
+	}
+}
+
+func (scd *signalChannelData) deferredDeliver(signal *Signal) {
+	select {
+	case scd.ch <- signal:
+	case <-scd.done:
+	}
+	scd.wg.Done()
+}
+
+func (scd *signalChannelData) close() {
+	close(scd.done)
+	scd.wg.Wait() // wait until all spawned goroutines return
+}

--- a/vendor/github.com/godbus/dbus/v5/doc.go
+++ b/vendor/github.com/godbus/dbus/v5/doc.go
@@ -1,0 +1,71 @@
+/*
+Package dbus implements bindings to the D-Bus message bus system.
+
+To use the message bus API, you first need to connect to a bus (usually the
+session or system bus). The acquired connection then can be used to call methods
+on remote objects and emit or receive signals. Using the Export method, you can
+arrange D-Bus methods calls to be directly translated to method calls on a Go
+value.
+
+Conversion Rules
+
+For outgoing messages, Go types are automatically converted to the
+corresponding D-Bus types. See the official specification at
+https://dbus.freedesktop.org/doc/dbus-specification.html#type-system for more
+information on the D-Bus type system. The following types are directly encoded
+as their respective D-Bus equivalents:
+
+     Go type     | D-Bus type
+     ------------+-----------
+     byte        | BYTE
+     bool        | BOOLEAN
+     int16       | INT16
+     uint16      | UINT16
+     int         | INT32
+     uint        | UINT32
+     int32       | INT32
+     uint32      | UINT32
+     int64       | INT64
+     uint64      | UINT64
+     float64     | DOUBLE
+     string      | STRING
+     ObjectPath  | OBJECT_PATH
+     Signature   | SIGNATURE
+     Variant     | VARIANT
+     interface{} | VARIANT
+     UnixFDIndex | UNIX_FD
+
+Slices and arrays encode as ARRAYs of their element type.
+
+Maps encode as DICTs, provided that their key type can be used as a key for
+a DICT.
+
+Structs other than Variant and Signature encode as a STRUCT containing their
+exported fields in order. Fields whose tags contain `dbus:"-"` and unexported
+fields will be skipped.
+
+Pointers encode as the value they're pointed to.
+
+Types convertible to one of the base types above will be mapped as the
+base type.
+
+Trying to encode any other type or a slice, map or struct containing an
+unsupported type will result in an InvalidTypeError.
+
+For incoming messages, the inverse of these rules are used, with the exception
+of STRUCTs. Incoming STRUCTS are represented as a slice of empty interfaces
+containing the struct fields in the correct order. The Store function can be
+used to convert such values to Go structs.
+
+Unix FD passing
+
+Handling Unix file descriptors deserves special mention. To use them, you should
+first check that they are supported on a connection by calling SupportsUnixFDs.
+If it returns true, all method of Connection will translate messages containing
+UnixFD's to messages that are accompanied by the given file descriptors with the
+UnixFD values being substituted by the correct indices. Similarly, the indices
+of incoming messages are automatically resolved. It shouldn't be necessary to use
+UnixFDIndex.
+
+*/
+package dbus

--- a/vendor/github.com/godbus/dbus/v5/encoder.go
+++ b/vendor/github.com/godbus/dbus/v5/encoder.go
@@ -1,0 +1,235 @@
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+)
+
+// An encoder encodes values to the D-Bus wire format.
+type encoder struct {
+	out   io.Writer
+	fds   []int
+	order binary.ByteOrder
+	pos   int
+}
+
+// NewEncoder returns a new encoder that writes to out in the given byte order.
+func newEncoder(out io.Writer, order binary.ByteOrder, fds []int) *encoder {
+	enc := newEncoderAtOffset(out, 0, order, fds)
+	return enc
+}
+
+// newEncoderAtOffset returns a new encoder that writes to out in the given
+// byte order. Specify the offset to initialize pos for proper alignment
+// computation.
+func newEncoderAtOffset(out io.Writer, offset int, order binary.ByteOrder, fds []int) *encoder {
+	enc := new(encoder)
+	enc.out = out
+	enc.order = order
+	enc.pos = offset
+	enc.fds = fds
+	return enc
+}
+
+// Aligns the next output to be on a multiple of n. Panics on write errors.
+func (enc *encoder) align(n int) {
+	pad := enc.padding(0, n)
+	if pad > 0 {
+		empty := make([]byte, pad)
+		if _, err := enc.out.Write(empty); err != nil {
+			panic(err)
+		}
+		enc.pos += pad
+	}
+}
+
+// pad returns the number of bytes of padding, based on current position and additional offset.
+// and alignment.
+func (enc *encoder) padding(offset, algn int) int {
+	abs := enc.pos + offset
+	if abs%algn != 0 {
+		newabs := (abs + algn - 1) & ^(algn - 1)
+		return newabs - abs
+	}
+	return 0
+}
+
+// Calls binary.Write(enc.out, enc.order, v) and panics on write errors.
+func (enc *encoder) binwrite(v interface{}) {
+	if err := binary.Write(enc.out, enc.order, v); err != nil {
+		panic(err)
+	}
+}
+
+// Encode encodes the given values to the underlying reader. All written values
+// are aligned properly as required by the D-Bus spec.
+func (enc *encoder) Encode(vs ...interface{}) (err error) {
+	defer func() {
+		err, _ = recover().(error)
+	}()
+	for _, v := range vs {
+		enc.encode(reflect.ValueOf(v), 0)
+	}
+	return nil
+}
+
+// encode encodes the given value to the writer and panics on error. depth holds
+// the depth of the container nesting.
+func (enc *encoder) encode(v reflect.Value, depth int) {
+	if depth > 64 {
+		panic(FormatError("input exceeds depth limitation"))
+	}
+	enc.align(alignment(v.Type()))
+	switch v.Kind() {
+	case reflect.Uint8:
+		var b [1]byte
+		b[0] = byte(v.Uint())
+		if _, err := enc.out.Write(b[:]); err != nil {
+			panic(err)
+		}
+		enc.pos++
+	case reflect.Bool:
+		if v.Bool() {
+			enc.encode(reflect.ValueOf(uint32(1)), depth)
+		} else {
+			enc.encode(reflect.ValueOf(uint32(0)), depth)
+		}
+	case reflect.Int16:
+		enc.binwrite(int16(v.Int()))
+		enc.pos += 2
+	case reflect.Uint16:
+		enc.binwrite(uint16(v.Uint()))
+		enc.pos += 2
+	case reflect.Int, reflect.Int32:
+		if v.Type() == unixFDType {
+			fd := v.Int()
+			idx := len(enc.fds)
+			enc.fds = append(enc.fds, int(fd))
+			enc.binwrite(uint32(idx))
+		} else {
+			enc.binwrite(int32(v.Int()))
+		}
+		enc.pos += 4
+	case reflect.Uint, reflect.Uint32:
+		enc.binwrite(uint32(v.Uint()))
+		enc.pos += 4
+	case reflect.Int64:
+		enc.binwrite(v.Int())
+		enc.pos += 8
+	case reflect.Uint64:
+		enc.binwrite(v.Uint())
+		enc.pos += 8
+	case reflect.Float64:
+		enc.binwrite(v.Float())
+		enc.pos += 8
+	case reflect.String:
+		str := v.String()
+		if !utf8.ValidString(str) {
+			panic(FormatError("input has a not-utf8 char in string"))
+		}
+		if strings.IndexByte(str, byte(0)) != -1 {
+			panic(FormatError("input has a null char('\\000') in string"))
+		}
+		if v.Type() == objectPathType {
+			if !ObjectPath(str).IsValid() {
+				panic(FormatError("invalid object path"))
+			}
+		}
+		enc.encode(reflect.ValueOf(uint32(len(str))), depth)
+		b := make([]byte, v.Len()+1)
+		copy(b, str)
+		b[len(b)-1] = 0
+		n, err := enc.out.Write(b)
+		if err != nil {
+			panic(err)
+		}
+		enc.pos += n
+	case reflect.Ptr:
+		enc.encode(v.Elem(), depth)
+	case reflect.Slice, reflect.Array:
+		// Lookahead offset: 4 bytes for uint32 length (with alignment),
+		// plus alignment for elements.
+		n := enc.padding(0, 4) + 4
+		offset := enc.pos + n + enc.padding(n, alignment(v.Type().Elem()))
+
+		var buf bytes.Buffer
+		bufenc := newEncoderAtOffset(&buf, offset, enc.order, enc.fds)
+
+		for i := 0; i < v.Len(); i++ {
+			bufenc.encode(v.Index(i), depth+1)
+		}
+
+		if buf.Len() > 1<<26 {
+			panic(FormatError("input exceeds array size limitation"))
+		}
+
+		enc.fds = bufenc.fds
+		enc.encode(reflect.ValueOf(uint32(buf.Len())), depth)
+		length := buf.Len()
+		enc.align(alignment(v.Type().Elem()))
+		if _, err := buf.WriteTo(enc.out); err != nil {
+			panic(err)
+		}
+		enc.pos += length
+	case reflect.Struct:
+		switch t := v.Type(); t {
+		case signatureType:
+			str := v.Field(0)
+			enc.encode(reflect.ValueOf(byte(str.Len())), depth)
+			b := make([]byte, str.Len()+1)
+			copy(b, str.String())
+			b[len(b)-1] = 0
+			n, err := enc.out.Write(b)
+			if err != nil {
+				panic(err)
+			}
+			enc.pos += n
+		case variantType:
+			variant := v.Interface().(Variant)
+			enc.encode(reflect.ValueOf(variant.sig), depth+1)
+			enc.encode(reflect.ValueOf(variant.value), depth+1)
+		default:
+			for i := 0; i < v.Type().NumField(); i++ {
+				field := t.Field(i)
+				if field.PkgPath == "" && field.Tag.Get("dbus") != "-" {
+					enc.encode(v.Field(i), depth+1)
+				}
+			}
+		}
+	case reflect.Map:
+		// Maps are arrays of structures, so they actually increase the depth by
+		// 2.
+		if !isKeyType(v.Type().Key()) {
+			panic(InvalidTypeError{v.Type()})
+		}
+		keys := v.MapKeys()
+		// Lookahead offset: 4 bytes for uint32 length (with alignment),
+		// plus 8-byte alignment
+		n := enc.padding(0, 4) + 4
+		offset := enc.pos + n + enc.padding(n, 8)
+
+		var buf bytes.Buffer
+		bufenc := newEncoderAtOffset(&buf, offset, enc.order, enc.fds)
+		for _, k := range keys {
+			bufenc.align(8)
+			bufenc.encode(k, depth+2)
+			bufenc.encode(v.MapIndex(k), depth+2)
+		}
+		enc.fds = bufenc.fds
+		enc.encode(reflect.ValueOf(uint32(buf.Len())), depth)
+		length := buf.Len()
+		enc.align(8)
+		if _, err := buf.WriteTo(enc.out); err != nil {
+			panic(err)
+		}
+		enc.pos += length
+	case reflect.Interface:
+		enc.encode(reflect.ValueOf(MakeVariant(v.Interface())), depth)
+	default:
+		panic(InvalidTypeError{v.Type()})
+	}
+}

--- a/vendor/github.com/godbus/dbus/v5/escape.go
+++ b/vendor/github.com/godbus/dbus/v5/escape.go
@@ -1,0 +1,84 @@
+package dbus
+
+import "net/url"
+
+// EscapeBusAddressValue implements a requirement to escape the values
+// in D-Bus server addresses, as defined by the D-Bus specification at
+// https://dbus.freedesktop.org/doc/dbus-specification.html#addresses.
+func EscapeBusAddressValue(val string) string {
+	toEsc := strNeedsEscape(val)
+	if toEsc == 0 {
+		// Avoid unneeded allocation/copying.
+		return val
+	}
+
+	// Avoid allocation for short paths.
+	var buf [64]byte
+	var out []byte
+	// Every to-be-escaped byte needs 2 extra bytes.
+	required := len(val) + 2*toEsc
+	if required <= len(buf) {
+		out = buf[:required]
+	} else {
+		out = make([]byte, required)
+	}
+
+	j := 0
+	for i := 0; i < len(val); i++ {
+		if ch := val[i]; needsEscape(ch) {
+			// Convert ch to %xx, where xx is hex value.
+			out[j] = '%'
+			out[j+1] = hexchar(ch >> 4)
+			out[j+2] = hexchar(ch & 0x0F)
+			j += 3
+		} else {
+			out[j] = ch
+			j++
+		}
+	}
+
+	return string(out)
+}
+
+// UnescapeBusAddressValue unescapes values in D-Bus server addresses,
+// as defined by the D-Bus specification at
+// https://dbus.freedesktop.org/doc/dbus-specification.html#addresses.
+func UnescapeBusAddressValue(val string) (string, error) {
+	// Looks like url.PathUnescape does exactly what is required.
+	return url.PathUnescape(val)
+}
+
+// hexchar returns an octal representation of a n, where n < 16.
+// For invalid values of n, the function panics.
+func hexchar(n byte) byte {
+	const hex = "0123456789abcdef"
+
+	// For n >= len(hex), runtime will panic.
+	return hex[n]
+}
+
+// needsEscape tells if a byte is NOT one of optionally-escaped bytes.
+func needsEscape(c byte) bool {
+	if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' {
+		return false
+	}
+	switch c {
+	case '-', '_', '/', '\\', '.', '*':
+		return false
+	}
+
+	return true
+}
+
+// strNeedsEscape tells how many bytes in the string need escaping.
+func strNeedsEscape(val string) int {
+	count := 0
+
+	for i := 0; i < len(val); i++ {
+		if needsEscape(val[i]) {
+			count++
+		}
+	}
+
+	return count
+}

--- a/vendor/github.com/godbus/dbus/v5/export.go
+++ b/vendor/github.com/godbus/dbus/v5/export.go
@@ -1,0 +1,463 @@
+package dbus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+var (
+	ErrMsgInvalidArg = Error{
+		"org.freedesktop.DBus.Error.InvalidArgs",
+		[]interface{}{"Invalid type / number of args"},
+	}
+	ErrMsgNoObject = Error{
+		"org.freedesktop.DBus.Error.NoSuchObject",
+		[]interface{}{"No such object"},
+	}
+	ErrMsgUnknownMethod = Error{
+		"org.freedesktop.DBus.Error.UnknownMethod",
+		[]interface{}{"Unknown / invalid method"},
+	}
+	ErrMsgUnknownInterface = Error{
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		[]interface{}{"Object does not implement the interface"},
+	}
+)
+
+func MakeNoObjectError(path ObjectPath) Error {
+	return Error{
+		"org.freedesktop.DBus.Error.NoSuchObject",
+		[]interface{}{fmt.Sprintf("No such object '%s'", string(path))},
+	}
+}
+
+func MakeUnknownMethodError(methodName string) Error {
+	return Error{
+		"org.freedesktop.DBus.Error.UnknownMethod",
+		[]interface{}{fmt.Sprintf("Unknown / invalid method '%s'", methodName)},
+	}
+}
+
+func MakeUnknownInterfaceError(ifaceName string) Error {
+	return Error{
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		[]interface{}{fmt.Sprintf("Object does not implement the interface '%s'", ifaceName)},
+	}
+}
+
+func MakeFailedError(err error) *Error {
+	return &Error{
+		"org.freedesktop.DBus.Error.Failed",
+		[]interface{}{err.Error()},
+	}
+}
+
+// Sender is a type which can be used in exported methods to receive the message
+// sender.
+type Sender string
+
+func computeMethodName(name string, mapping map[string]string) string {
+	newname, ok := mapping[name]
+	if ok {
+		name = newname
+	}
+	return name
+}
+
+func getMethods(in interface{}, mapping map[string]string) map[string]reflect.Value {
+	if in == nil {
+		return nil
+	}
+	methods := make(map[string]reflect.Value)
+	val := reflect.ValueOf(in)
+	typ := val.Type()
+	for i := 0; i < typ.NumMethod(); i++ {
+		methtype := typ.Method(i)
+		method := val.Method(i)
+		t := method.Type()
+		// only track valid methods must return *Error as last arg
+		// and must be exported
+		if t.NumOut() == 0 ||
+			t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) ||
+			methtype.PkgPath != "" {
+			continue
+		}
+		// map names while building table
+		methods[computeMethodName(methtype.Name, mapping)] = method
+	}
+	return methods
+}
+
+func getAllMethods(in interface{}, mapping map[string]string) map[string]reflect.Value {
+	if in == nil {
+		return nil
+	}
+	methods := make(map[string]reflect.Value)
+	val := reflect.ValueOf(in)
+	typ := val.Type()
+	for i := 0; i < typ.NumMethod(); i++ {
+		methtype := typ.Method(i)
+		method := val.Method(i)
+		// map names while building table
+		methods[computeMethodName(methtype.Name, mapping)] = method
+	}
+	return methods
+}
+
+func standardMethodArgumentDecode(m Method, sender string, msg *Message, body []interface{}) ([]interface{}, error) {
+	pointers := make([]interface{}, m.NumArguments())
+	decode := make([]interface{}, 0, len(body))
+
+	for i := 0; i < m.NumArguments(); i++ {
+		tp := reflect.TypeOf(m.ArgumentValue(i))
+		val := reflect.New(tp)
+		pointers[i] = val.Interface()
+		if tp == reflect.TypeOf((*Sender)(nil)).Elem() {
+			val.Elem().SetString(sender)
+		} else if tp == reflect.TypeOf((*Message)(nil)).Elem() {
+			val.Elem().Set(reflect.ValueOf(*msg))
+		} else {
+			decode = append(decode, pointers[i])
+		}
+	}
+
+	if len(decode) != len(body) {
+		return nil, ErrMsgInvalidArg
+	}
+
+	if err := Store(body, decode...); err != nil {
+		return nil, ErrMsgInvalidArg
+	}
+
+	return pointers, nil
+}
+
+func (conn *Conn) decodeArguments(m Method, sender string, msg *Message) ([]interface{}, error) {
+	if decoder, ok := m.(ArgumentDecoder); ok {
+		return decoder.DecodeArguments(conn, sender, msg, msg.Body)
+	}
+	return standardMethodArgumentDecode(m, sender, msg, msg.Body)
+}
+
+// handleCall handles the given method call (i.e. looks if it's one of the
+// pre-implemented ones and searches for a corresponding handler if not).
+func (conn *Conn) handleCall(msg *Message) {
+	name := msg.Headers[FieldMember].value.(string)
+	path := msg.Headers[FieldPath].value.(ObjectPath)
+	ifaceName, _ := msg.Headers[FieldInterface].value.(string)
+	sender, hasSender := msg.Headers[FieldSender].value.(string)
+	serial := msg.serial
+
+	if len(name) == 0 {
+		conn.sendError(ErrMsgUnknownMethod, sender, serial)
+	}
+
+	if ifaceName == "org.freedesktop.DBus.Peer" {
+		switch name {
+		case "Ping":
+			conn.sendReply(sender, serial)
+		case "GetMachineId":
+			conn.sendReply(sender, serial, conn.uuid)
+		default:
+			conn.sendError(MakeUnknownMethodError(name), sender, serial)
+		}
+		return
+	}
+
+	object, ok := conn.handler.LookupObject(path)
+	if !ok {
+		conn.sendError(MakeNoObjectError(path), sender, serial)
+		return
+	}
+
+	iface, exists := object.LookupInterface(ifaceName)
+	if !exists {
+		conn.sendError(MakeUnknownInterfaceError(ifaceName), sender, serial)
+		return
+	}
+
+	m, exists := iface.LookupMethod(name)
+	if !exists {
+		conn.sendError(MakeUnknownMethodError(name), sender, serial)
+		return
+	}
+	args, err := conn.decodeArguments(m, sender, msg)
+	if err != nil {
+		conn.sendError(err, sender, serial)
+		return
+	}
+
+	ret, err := m.Call(args...)
+	if err != nil {
+		conn.sendError(err, sender, serial)
+		return
+	}
+
+	if msg.Flags&FlagNoReplyExpected == 0 {
+		reply := new(Message)
+		reply.Type = TypeMethodReply
+		reply.Headers = make(map[HeaderField]Variant)
+		if hasSender {
+			reply.Headers[FieldDestination] = msg.Headers[FieldSender]
+		}
+		reply.Headers[FieldReplySerial] = MakeVariant(msg.serial)
+		reply.Body = make([]interface{}, len(ret))
+		for i := 0; i < len(ret); i++ {
+			reply.Body[i] = ret[i]
+		}
+		reply.Headers[FieldSignature] = MakeVariant(SignatureOf(reply.Body...))
+
+		if err := reply.IsValid(); err != nil {
+			fmt.Fprintf(os.Stderr, "dbus: dropping invalid reply to %s.%s on obj %s: %s\n", ifaceName, name, path, err)
+		} else {
+			conn.sendMessageAndIfClosed(reply, nil)
+		}
+	}
+}
+
+// Emit emits the given signal on the message bus. The name parameter must be
+// formatted as "interface.member", e.g., "org.freedesktop.DBus.NameLost".
+func (conn *Conn) Emit(path ObjectPath, name string, values ...interface{}) error {
+	i := strings.LastIndex(name, ".")
+	if i == -1 {
+		return errors.New("dbus: invalid method name")
+	}
+	iface := name[:i]
+	member := name[i+1:]
+	msg := new(Message)
+	msg.Type = TypeSignal
+	msg.Headers = make(map[HeaderField]Variant)
+	msg.Headers[FieldInterface] = MakeVariant(iface)
+	msg.Headers[FieldMember] = MakeVariant(member)
+	msg.Headers[FieldPath] = MakeVariant(path)
+	msg.Body = values
+	if len(values) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(values...))
+	}
+	if err := msg.IsValid(); err != nil {
+		return err
+	}
+
+	var closed bool
+	conn.sendMessageAndIfClosed(msg, func() {
+		closed = true
+	})
+	if closed {
+		return ErrClosed
+	}
+	return nil
+}
+
+// Export registers the given value to be exported as an object on the
+// message bus.
+//
+// If a method call on the given path and interface is received, an exported
+// method with the same name is called with v as the receiver if the
+// parameters match and the last return value is of type *Error. If this
+// *Error is not nil, it is sent back to the caller as an error.
+// Otherwise, a method reply is sent with the other return values as its body.
+//
+// Any parameters with the special type Sender are set to the sender of the
+// dbus message when the method is called. Parameters of this type do not
+// contribute to the dbus signature of the method (i.e. the method is exposed
+// as if the parameters of type Sender were not there).
+//
+// Similarly, any parameters with the type Message are set to the raw message
+// received on the bus. Again, parameters of this type do not contribute to the
+// dbus signature of the method.
+//
+// Every method call is executed in a new goroutine, so the method may be called
+// in multiple goroutines at once.
+//
+// Method calls on the interface org.freedesktop.DBus.Peer will be automatically
+// handled for every object.
+//
+// Passing nil as the first parameter will cause conn to cease handling calls on
+// the given combination of path and interface.
+//
+// Export returns an error if path is not a valid path name.
+func (conn *Conn) Export(v interface{}, path ObjectPath, iface string) error {
+	return conn.ExportWithMap(v, nil, path, iface)
+}
+
+// ExportAll registers all exported methods defined by the given object on
+// the message bus.
+//
+// Unlike Export there is no requirement to have the last parameter as type
+// *Error. If you want to be able to return error then you can append an error
+// type parameter to your method signature. If the error returned is not nil,
+// it is sent back to the caller as an error. Otherwise, a method reply is
+// sent with the other return values as its body.
+func (conn *Conn) ExportAll(v interface{}, path ObjectPath, iface string) error {
+	return conn.export(getAllMethods(v, nil), path, iface, false)
+}
+
+// ExportWithMap works exactly like Export but provides the ability to remap
+// method names (e.g. export a lower-case method).
+//
+// The keys in the map are the real method names (exported on the struct), and
+// the values are the method names to be exported on DBus.
+func (conn *Conn) ExportWithMap(v interface{}, mapping map[string]string, path ObjectPath, iface string) error {
+	return conn.export(getMethods(v, mapping), path, iface, false)
+}
+
+// ExportSubtree works exactly like Export but registers the given value for
+// an entire subtree rather under the root path provided.
+//
+// In order to make this useful, one parameter in each of the value's exported
+// methods should be a Message, in which case it will contain the raw message
+// (allowing one to get access to the path that caused the method to be called).
+//
+// Note that more specific export paths take precedence over less specific. For
+// example, a method call using the ObjectPath /foo/bar/baz will call a method
+// exported on /foo/bar before a method exported on /foo.
+func (conn *Conn) ExportSubtree(v interface{}, path ObjectPath, iface string) error {
+	return conn.ExportSubtreeWithMap(v, nil, path, iface)
+}
+
+// ExportSubtreeWithMap works exactly like ExportSubtree but provides the
+// ability to remap method names (e.g. export a lower-case method).
+//
+// The keys in the map are the real method names (exported on the struct), and
+// the values are the method names to be exported on DBus.
+func (conn *Conn) ExportSubtreeWithMap(v interface{}, mapping map[string]string, path ObjectPath, iface string) error {
+	return conn.export(getMethods(v, mapping), path, iface, true)
+}
+
+// ExportMethodTable like Export registers the given methods as an object
+// on the message bus. Unlike Export the it uses a method table to define
+// the object instead of a native go object.
+//
+// The method table is a map from method name to function closure
+// representing the method. This allows an object exported on the bus to not
+// necessarily be a native go object. It can be useful for generating exposed
+// methods on the fly.
+//
+// Any non-function objects in the method table are ignored.
+func (conn *Conn) ExportMethodTable(methods map[string]interface{}, path ObjectPath, iface string) error {
+	return conn.exportMethodTable(methods, path, iface, false)
+}
+
+// Like ExportSubtree, but with the same caveats as ExportMethodTable.
+func (conn *Conn) ExportSubtreeMethodTable(methods map[string]interface{}, path ObjectPath, iface string) error {
+	return conn.exportMethodTable(methods, path, iface, true)
+}
+
+func (conn *Conn) exportMethodTable(methods map[string]interface{}, path ObjectPath, iface string, includeSubtree bool) error {
+	var out map[string]reflect.Value
+	if methods != nil {
+		out = make(map[string]reflect.Value)
+		for name, method := range methods {
+			rval := reflect.ValueOf(method)
+			if rval.Kind() != reflect.Func {
+				continue
+			}
+			t := rval.Type()
+			// only track valid methods must return *Error as last arg
+			if t.NumOut() == 0 ||
+				t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) {
+				continue
+			}
+			out[name] = rval
+		}
+	}
+	return conn.export(out, path, iface, includeSubtree)
+}
+
+func (conn *Conn) unexport(h *defaultHandler, path ObjectPath, iface string) error {
+	if h.PathExists(path) {
+		obj := h.objects[path]
+		obj.DeleteInterface(iface)
+		if len(obj.interfaces) == 0 {
+			h.DeleteObject(path)
+		}
+	}
+	return nil
+}
+
+// export is the worker function for all exports/registrations.
+func (conn *Conn) export(methods map[string]reflect.Value, path ObjectPath, iface string, includeSubtree bool) error {
+	h, ok := conn.handler.(*defaultHandler)
+	if !ok {
+		return fmt.Errorf(
+			`dbus: export only allowed on the default handler. Received: %T"`,
+			conn.handler)
+	}
+
+	if !path.IsValid() {
+		return fmt.Errorf(`dbus: Invalid path name: "%s"`, path)
+	}
+
+	// Remove a previous export if the interface is nil
+	if methods == nil {
+		return conn.unexport(h, path, iface)
+	}
+
+	// If this is the first handler for this path, make a new map to hold all
+	// handlers for this path.
+	if !h.PathExists(path) {
+		h.AddObject(path, newExportedObject())
+	}
+
+	exportedMethods := make(map[string]Method)
+	for name, method := range methods {
+		exportedMethods[name] = exportedMethod{method}
+	}
+
+	// Finally, save this handler
+	obj := h.objects[path]
+	obj.AddInterface(iface, newExportedIntf(exportedMethods, includeSubtree))
+
+	return nil
+}
+
+// ReleaseName calls org.freedesktop.DBus.ReleaseName and awaits a response.
+func (conn *Conn) ReleaseName(name string) (ReleaseNameReply, error) {
+	var r uint32
+	err := conn.busObj.Call("org.freedesktop.DBus.ReleaseName", 0, name).Store(&r)
+	if err != nil {
+		return 0, err
+	}
+	return ReleaseNameReply(r), nil
+}
+
+// RequestName calls org.freedesktop.DBus.RequestName and awaits a response.
+func (conn *Conn) RequestName(name string, flags RequestNameFlags) (RequestNameReply, error) {
+	var r uint32
+	err := conn.busObj.Call("org.freedesktop.DBus.RequestName", 0, name, flags).Store(&r)
+	if err != nil {
+		return 0, err
+	}
+	return RequestNameReply(r), nil
+}
+
+// ReleaseNameReply is the reply to a ReleaseName call.
+type ReleaseNameReply uint32
+
+const (
+	ReleaseNameReplyReleased ReleaseNameReply = 1 + iota
+	ReleaseNameReplyNonExistent
+	ReleaseNameReplyNotOwner
+)
+
+// RequestNameFlags represents the possible flags for a RequestName call.
+type RequestNameFlags uint32
+
+const (
+	NameFlagAllowReplacement RequestNameFlags = 1 << iota
+	NameFlagReplaceExisting
+	NameFlagDoNotQueue
+)
+
+// RequestNameReply is the reply to a RequestName call.
+type RequestNameReply uint32
+
+const (
+	RequestNameReplyPrimaryOwner RequestNameReply = 1 + iota
+	RequestNameReplyInQueue
+	RequestNameReplyExists
+	RequestNameReplyAlreadyOwner
+)

--- a/vendor/github.com/godbus/dbus/v5/homedir.go
+++ b/vendor/github.com/godbus/dbus/v5/homedir.go
@@ -1,0 +1,25 @@
+package dbus
+
+import (
+	"os"
+	"os/user"
+)
+
+// Get returns the home directory of the current user, which is usually the
+// value of HOME environment variable. In case it is not set or empty, os/user
+// package is used.
+//
+// If linking statically with cgo enabled against glibc, make sure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
+func getHomeDir() string {
+	homeDir := os.Getenv("HOME")
+	if homeDir != "" {
+		return homeDir
+	}
+	if u, err := user.Current(); err == nil {
+		return u.HomeDir
+	}
+	return "/"
+}

--- a/vendor/github.com/godbus/dbus/v5/match.go
+++ b/vendor/github.com/godbus/dbus/v5/match.go
@@ -1,0 +1,89 @@
+package dbus
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MatchOption specifies option for dbus routing match rule. Options can be constructed with WithMatch* helpers.
+// For full list of available options consult
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-routing-match-rules
+type MatchOption struct {
+	key   string
+	value string
+}
+
+func formatMatchOptions(options []MatchOption) string {
+	items := make([]string, 0, len(options))
+	for _, option := range options {
+		items = append(items, option.key+"='"+option.value+"'")
+	}
+	return strings.Join(items, ",")
+}
+
+// WithMatchOption creates match option with given key and value
+func WithMatchOption(key, value string) MatchOption {
+	return MatchOption{key, value}
+}
+
+// doesn't make sense to export this option because clients can only
+// subscribe to messages with signal type.
+func withMatchType(typ string) MatchOption {
+	return WithMatchOption("type", typ)
+}
+
+// WithMatchSender sets sender match option.
+func WithMatchSender(sender string) MatchOption {
+	return WithMatchOption("sender", sender)
+}
+
+// WithMatchSender sets interface match option.
+func WithMatchInterface(iface string) MatchOption {
+	return WithMatchOption("interface", iface)
+}
+
+// WithMatchMember sets member match option.
+func WithMatchMember(member string) MatchOption {
+	return WithMatchOption("member", member)
+}
+
+// WithMatchObjectPath creates match option that filters events based on given path
+func WithMatchObjectPath(path ObjectPath) MatchOption {
+	return WithMatchOption("path", string(path))
+}
+
+// WithMatchPathNamespace sets path_namespace match option.
+func WithMatchPathNamespace(namespace ObjectPath) MatchOption {
+	return WithMatchOption("path_namespace", string(namespace))
+}
+
+// WithMatchDestination sets destination match option.
+func WithMatchDestination(destination string) MatchOption {
+	return WithMatchOption("destination", destination)
+}
+
+// WithMatchArg sets argN match option, range of N is 0 to 63.
+func WithMatchArg(argIdx int, value string) MatchOption {
+	if argIdx < 0 || argIdx > 63 {
+		panic("range of argument index is 0 to 63")
+	}
+	return WithMatchOption("arg"+strconv.Itoa(argIdx), value)
+}
+
+// WithMatchArgPath sets argN path match option, range of N is 0 to 63.
+func WithMatchArgPath(argIdx int, path string) MatchOption {
+	if argIdx < 0 || argIdx > 63 {
+		panic("range of argument index is 0 to 63")
+	}
+	return WithMatchOption("arg"+strconv.Itoa(argIdx)+"path", path)
+}
+
+// WithMatchArg0Namespace sets arg0namespace match option.
+func WithMatchArg0Namespace(arg0Namespace string) MatchOption {
+	return WithMatchOption("arg0namespace", arg0Namespace)
+}
+
+// WithMatchEavesdrop sets eavesdrop match option.
+func WithMatchEavesdrop(eavesdrop bool) MatchOption {
+	return WithMatchOption("eavesdrop", strconv.FormatBool(eavesdrop))
+}

--- a/vendor/github.com/godbus/dbus/v5/message.go
+++ b/vendor/github.com/godbus/dbus/v5/message.go
@@ -1,0 +1,390 @@
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+)
+
+const protoVersion byte = 1
+
+// Flags represents the possible flags of a D-Bus message.
+type Flags byte
+
+const (
+	// FlagNoReplyExpected signals that the message is not expected to generate
+	// a reply. If this flag is set on outgoing messages, any possible reply
+	// will be discarded.
+	FlagNoReplyExpected Flags = 1 << iota
+	// FlagNoAutoStart signals that the message bus should not automatically
+	// start an application when handling this message.
+	FlagNoAutoStart
+	// FlagAllowInteractiveAuthorization may be set on a method call
+	// message to inform the receiving side that the caller is prepared
+	// to wait for interactive authorization, which might take a
+	// considerable time to complete. For instance, if this flag is set,
+	// it would be appropriate to query the user for passwords or
+	// confirmation via Polkit or a similar framework.
+	FlagAllowInteractiveAuthorization
+)
+
+// Type represents the possible types of a D-Bus message.
+type Type byte
+
+const (
+	TypeMethodCall Type = 1 + iota
+	TypeMethodReply
+	TypeError
+	TypeSignal
+	typeMax
+)
+
+func (t Type) String() string {
+	switch t {
+	case TypeMethodCall:
+		return "method call"
+	case TypeMethodReply:
+		return "reply"
+	case TypeError:
+		return "error"
+	case TypeSignal:
+		return "signal"
+	}
+	return "invalid"
+}
+
+// HeaderField represents the possible byte codes for the headers
+// of a D-Bus message.
+type HeaderField byte
+
+const (
+	FieldPath HeaderField = 1 + iota
+	FieldInterface
+	FieldMember
+	FieldErrorName
+	FieldReplySerial
+	FieldDestination
+	FieldSender
+	FieldSignature
+	FieldUnixFDs
+	fieldMax
+)
+
+// An InvalidMessageError describes the reason why a D-Bus message is regarded as
+// invalid.
+type InvalidMessageError string
+
+func (e InvalidMessageError) Error() string {
+	return "dbus: invalid message: " + string(e)
+}
+
+// fieldType are the types of the various header fields.
+var fieldTypes = [fieldMax]reflect.Type{
+	FieldPath:        objectPathType,
+	FieldInterface:   stringType,
+	FieldMember:      stringType,
+	FieldErrorName:   stringType,
+	FieldReplySerial: uint32Type,
+	FieldDestination: stringType,
+	FieldSender:      stringType,
+	FieldSignature:   signatureType,
+	FieldUnixFDs:     uint32Type,
+}
+
+// requiredFields lists the header fields that are required by the different
+// message types.
+var requiredFields = [typeMax][]HeaderField{
+	TypeMethodCall:  {FieldPath, FieldMember},
+	TypeMethodReply: {FieldReplySerial},
+	TypeError:       {FieldErrorName, FieldReplySerial},
+	TypeSignal:      {FieldPath, FieldInterface, FieldMember},
+}
+
+// Message represents a single D-Bus message.
+type Message struct {
+	Type
+	Flags
+	Headers map[HeaderField]Variant
+	Body    []interface{}
+
+	serial uint32
+}
+
+type header struct {
+	Field byte
+	Variant
+}
+
+func DecodeMessageWithFDs(rd io.Reader, fds []int) (msg *Message, err error) {
+	var order binary.ByteOrder
+	var hlength, length uint32
+	var typ, flags, proto byte
+	var headers []header
+
+	b := make([]byte, 1)
+	_, err = rd.Read(b)
+	if err != nil {
+		return
+	}
+	switch b[0] {
+	case 'l':
+		order = binary.LittleEndian
+	case 'B':
+		order = binary.BigEndian
+	default:
+		return nil, InvalidMessageError("invalid byte order")
+	}
+
+	dec := newDecoder(rd, order, fds)
+	dec.pos = 1
+
+	msg = new(Message)
+	vs, err := dec.Decode(Signature{"yyyuu"})
+	if err != nil {
+		return nil, err
+	}
+	if err = Store(vs, &typ, &flags, &proto, &length, &msg.serial); err != nil {
+		return nil, err
+	}
+	msg.Type = Type(typ)
+	msg.Flags = Flags(flags)
+
+	// get the header length separately because we need it later
+	b = make([]byte, 4)
+	_, err = io.ReadFull(rd, b)
+	if err != nil {
+		return nil, err
+	}
+	binary.Read(bytes.NewBuffer(b), order, &hlength)
+	if hlength+length+16 > 1<<27 {
+		return nil, InvalidMessageError("message is too long")
+	}
+	dec = newDecoder(io.MultiReader(bytes.NewBuffer(b), rd), order, fds)
+	dec.pos = 12
+	vs, err = dec.Decode(Signature{"a(yv)"})
+	if err != nil {
+		return nil, err
+	}
+	if err = Store(vs, &headers); err != nil {
+		return nil, err
+	}
+
+	msg.Headers = make(map[HeaderField]Variant)
+	for _, v := range headers {
+		msg.Headers[HeaderField(v.Field)] = v.Variant
+	}
+
+	dec.align(8)
+	body := make([]byte, int(length))
+	if length != 0 {
+		_, err := io.ReadFull(rd, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err = msg.IsValid(); err != nil {
+		return nil, err
+	}
+	sig, _ := msg.Headers[FieldSignature].value.(Signature)
+	if sig.str != "" {
+		buf := bytes.NewBuffer(body)
+		dec = newDecoder(buf, order, fds)
+		vs, err := dec.Decode(sig)
+		if err != nil {
+			return nil, err
+		}
+		msg.Body = vs
+	}
+
+	return
+}
+
+// DecodeMessage tries to decode a single message in the D-Bus wire format
+// from the given reader. The byte order is figured out from the first byte.
+// The possibly returned error can be an error of the underlying reader, an
+// InvalidMessageError or a FormatError.
+func DecodeMessage(rd io.Reader) (msg *Message, err error) {
+	return DecodeMessageWithFDs(rd, make([]int, 0))
+}
+
+type nullwriter struct{}
+
+func (nullwriter) Write(p []byte) (cnt int, err error) {
+	return len(p), nil
+}
+
+func (msg *Message) CountFds() (int, error) {
+	if len(msg.Body) == 0 {
+		return 0, nil
+	}
+	enc := newEncoder(nullwriter{}, nativeEndian, make([]int, 0))
+	err := enc.Encode(msg.Body...)
+	return len(enc.fds), err
+}
+
+func (msg *Message) EncodeToWithFDs(out io.Writer, order binary.ByteOrder) (fds []int, err error) {
+	if err := msg.validateHeader(); err != nil {
+		return nil, err
+	}
+	var vs [7]interface{}
+	switch order {
+	case binary.LittleEndian:
+		vs[0] = byte('l')
+	case binary.BigEndian:
+		vs[0] = byte('B')
+	default:
+		return nil, errors.New("dbus: invalid byte order")
+	}
+	body := new(bytes.Buffer)
+	fds = make([]int, 0)
+	enc := newEncoder(body, order, fds)
+	if len(msg.Body) != 0 {
+		err = enc.Encode(msg.Body...)
+		if err != nil {
+			return
+		}
+	}
+	vs[1] = msg.Type
+	vs[2] = msg.Flags
+	vs[3] = protoVersion
+	vs[4] = uint32(len(body.Bytes()))
+	vs[5] = msg.serial
+	headers := make([]header, 0, len(msg.Headers))
+	for k, v := range msg.Headers {
+		headers = append(headers, header{byte(k), v})
+	}
+	vs[6] = headers
+	var buf bytes.Buffer
+	enc = newEncoder(&buf, order, enc.fds)
+	err = enc.Encode(vs[:]...)
+	if err != nil {
+		return
+	}
+	enc.align(8)
+	body.WriteTo(&buf)
+	if buf.Len() > 1<<27 {
+		return make([]int, 0), InvalidMessageError("message is too long")
+	}
+	if _, err := buf.WriteTo(out); err != nil {
+		return make([]int, 0), err
+	}
+	return enc.fds, nil
+}
+
+// EncodeTo encodes and sends a message to the given writer. The byte order must
+// be either binary.LittleEndian or binary.BigEndian. If the message is not
+// valid or an error occurs when writing, an error is returned.
+func (msg *Message) EncodeTo(out io.Writer, order binary.ByteOrder) (err error) {
+	_, err = msg.EncodeToWithFDs(out, order)
+	return err
+}
+
+// IsValid checks whether msg is a valid message and returns an
+// InvalidMessageError or FormatError if it is not.
+func (msg *Message) IsValid() error {
+	var b bytes.Buffer
+	return msg.EncodeTo(&b, nativeEndian)
+}
+
+func (msg *Message) validateHeader() error {
+	if msg.Flags & ^(FlagNoAutoStart|FlagNoReplyExpected|FlagAllowInteractiveAuthorization) != 0 {
+		return InvalidMessageError("invalid flags")
+	}
+	if msg.Type == 0 || msg.Type >= typeMax {
+		return InvalidMessageError("invalid message type")
+	}
+	for k, v := range msg.Headers {
+		if k == 0 || k >= fieldMax {
+			return InvalidMessageError("invalid header")
+		}
+		if reflect.TypeOf(v.value) != fieldTypes[k] {
+			return InvalidMessageError("invalid type of header field")
+		}
+	}
+	for _, v := range requiredFields[msg.Type] {
+		if _, ok := msg.Headers[v]; !ok {
+			return InvalidMessageError("missing required header")
+		}
+	}
+	if path, ok := msg.Headers[FieldPath]; ok {
+		if !path.value.(ObjectPath).IsValid() {
+			return InvalidMessageError("invalid path name")
+		}
+	}
+	if iface, ok := msg.Headers[FieldInterface]; ok {
+		if !isValidInterface(iface.value.(string)) {
+			return InvalidMessageError("invalid interface name")
+		}
+	}
+	if member, ok := msg.Headers[FieldMember]; ok {
+		if !isValidMember(member.value.(string)) {
+			return InvalidMessageError("invalid member name")
+		}
+	}
+	if errname, ok := msg.Headers[FieldErrorName]; ok {
+		if !isValidInterface(errname.value.(string)) {
+			return InvalidMessageError("invalid error name")
+		}
+	}
+	if len(msg.Body) != 0 {
+		if _, ok := msg.Headers[FieldSignature]; !ok {
+			return InvalidMessageError("missing signature")
+		}
+	}
+
+	return nil
+}
+
+// Serial returns the message's serial number. The returned value is only valid
+// for messages received by eavesdropping.
+func (msg *Message) Serial() uint32 {
+	return msg.serial
+}
+
+// String returns a string representation of a message similar to the format of
+// dbus-monitor.
+func (msg *Message) String() string {
+	if err := msg.IsValid(); err != nil {
+		return "<invalid>"
+	}
+	s := msg.Type.String()
+	if v, ok := msg.Headers[FieldSender]; ok {
+		s += " from " + v.value.(string)
+	}
+	if v, ok := msg.Headers[FieldDestination]; ok {
+		s += " to " + v.value.(string)
+	}
+	s += " serial " + strconv.FormatUint(uint64(msg.serial), 10)
+	if v, ok := msg.Headers[FieldReplySerial]; ok {
+		s += " reply_serial " + strconv.FormatUint(uint64(v.value.(uint32)), 10)
+	}
+	if v, ok := msg.Headers[FieldUnixFDs]; ok {
+		s += " unixfds " + strconv.FormatUint(uint64(v.value.(uint32)), 10)
+	}
+	if v, ok := msg.Headers[FieldPath]; ok {
+		s += " path " + string(v.value.(ObjectPath))
+	}
+	if v, ok := msg.Headers[FieldInterface]; ok {
+		s += " interface " + v.value.(string)
+	}
+	if v, ok := msg.Headers[FieldErrorName]; ok {
+		s += " error " + v.value.(string)
+	}
+	if v, ok := msg.Headers[FieldMember]; ok {
+		s += " member " + v.value.(string)
+	}
+	if len(msg.Body) != 0 {
+		s += "\n"
+	}
+	for i, v := range msg.Body {
+		s += "  " + MakeVariant(v).String()
+		if i != len(msg.Body)-1 {
+			s += "\n"
+		}
+	}
+	return s
+}

--- a/vendor/github.com/godbus/dbus/v5/object.go
+++ b/vendor/github.com/godbus/dbus/v5/object.go
@@ -1,0 +1,174 @@
+package dbus
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// BusObject is the interface of a remote object on which methods can be
+// invoked.
+type BusObject interface {
+	Call(method string, flags Flags, args ...interface{}) *Call
+	CallWithContext(ctx context.Context, method string, flags Flags, args ...interface{}) *Call
+	Go(method string, flags Flags, ch chan *Call, args ...interface{}) *Call
+	GoWithContext(ctx context.Context, method string, flags Flags, ch chan *Call, args ...interface{}) *Call
+	AddMatchSignal(iface, member string, options ...MatchOption) *Call
+	RemoveMatchSignal(iface, member string, options ...MatchOption) *Call
+	GetProperty(p string) (Variant, error)
+	StoreProperty(p string, value interface{}) error
+	SetProperty(p string, v interface{}) error
+	Destination() string
+	Path() ObjectPath
+}
+
+// Object represents a remote object on which methods can be invoked.
+type Object struct {
+	conn *Conn
+	dest string
+	path ObjectPath
+}
+
+// Call calls a method with (*Object).Go and waits for its reply.
+func (o *Object) Call(method string, flags Flags, args ...interface{}) *Call {
+	return <-o.createCall(context.Background(), method, flags, make(chan *Call, 1), args...).Done
+}
+
+// CallWithContext acts like Call but takes a context
+func (o *Object) CallWithContext(ctx context.Context, method string, flags Flags, args ...interface{}) *Call {
+	return <-o.createCall(ctx, method, flags, make(chan *Call, 1), args...).Done
+}
+
+// AddMatchSignal subscribes BusObject to signals from specified interface,
+// method (member). Additional filter rules can be added via WithMatch* option constructors.
+// Note: To filter events by object path you have to specify this path via an option.
+//
+// Deprecated: use (*Conn) AddMatchSignal instead.
+func (o *Object) AddMatchSignal(iface, member string, options ...MatchOption) *Call {
+	base := []MatchOption{
+		withMatchType("signal"),
+		WithMatchInterface(iface),
+		WithMatchMember(member),
+	}
+
+	options = append(base, options...)
+	return o.conn.BusObject().Call(
+		"org.freedesktop.DBus.AddMatch",
+		0,
+		formatMatchOptions(options),
+	)
+}
+
+// RemoveMatchSignal unsubscribes BusObject from signals from specified interface,
+// method (member). Additional filter rules can be added via WithMatch* option constructors
+//
+// Deprecated: use (*Conn) RemoveMatchSignal instead.
+func (o *Object) RemoveMatchSignal(iface, member string, options ...MatchOption) *Call {
+	base := []MatchOption{
+		withMatchType("signal"),
+		WithMatchInterface(iface),
+		WithMatchMember(member),
+	}
+
+	options = append(base, options...)
+	return o.conn.BusObject().Call(
+		"org.freedesktop.DBus.RemoveMatch",
+		0,
+		formatMatchOptions(options),
+	)
+}
+
+// Go calls a method with the given arguments asynchronously. It returns a
+// Call structure representing this method call. The passed channel will
+// return the same value once the call is done. If ch is nil, a new channel
+// will be allocated. Otherwise, ch has to be buffered or Go will panic.
+//
+// If the flags include FlagNoReplyExpected, ch is ignored and a Call structure
+// is returned with any error in Err and a closed channel in Done containing
+// the returned Call as it's one entry.
+//
+// If the method parameter contains a dot ('.'), the part before the last dot
+// specifies the interface on which the method is called.
+func (o *Object) Go(method string, flags Flags, ch chan *Call, args ...interface{}) *Call {
+	return o.createCall(context.Background(), method, flags, ch, args...)
+}
+
+// GoWithContext acts like Go but takes a context
+func (o *Object) GoWithContext(ctx context.Context, method string, flags Flags, ch chan *Call, args ...interface{}) *Call {
+	return o.createCall(ctx, method, flags, ch, args...)
+}
+
+func (o *Object) createCall(ctx context.Context, method string, flags Flags, ch chan *Call, args ...interface{}) *Call {
+	if ctx == nil {
+		panic("nil context")
+	}
+	iface := ""
+	i := strings.LastIndex(method, ".")
+	if i != -1 {
+		iface = method[:i]
+	}
+	method = method[i+1:]
+	msg := new(Message)
+	msg.Type = TypeMethodCall
+	msg.Flags = flags & (FlagNoAutoStart | FlagNoReplyExpected)
+	msg.Headers = make(map[HeaderField]Variant)
+	msg.Headers[FieldPath] = MakeVariant(o.path)
+	msg.Headers[FieldDestination] = MakeVariant(o.dest)
+	msg.Headers[FieldMember] = MakeVariant(method)
+	if iface != "" {
+		msg.Headers[FieldInterface] = MakeVariant(iface)
+	}
+	msg.Body = args
+	if len(args) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(args...))
+	}
+	return o.conn.SendWithContext(ctx, msg, ch)
+}
+
+// GetProperty calls org.freedesktop.DBus.Properties.Get on the given
+// object. The property name must be given in interface.member notation.
+func (o *Object) GetProperty(p string) (Variant, error) {
+	var result Variant
+	err := o.StoreProperty(p, &result)
+	return result, err
+}
+
+// StoreProperty calls org.freedesktop.DBus.Properties.Get on the given
+// object. The property name must be given in interface.member notation.
+// It stores the returned property into the provided value.
+func (o *Object) StoreProperty(p string, value interface{}) error {
+	idx := strings.LastIndex(p, ".")
+	if idx == -1 || idx+1 == len(p) {
+		return errors.New("dbus: invalid property " + p)
+	}
+
+	iface := p[:idx]
+	prop := p[idx+1:]
+
+	return o.Call("org.freedesktop.DBus.Properties.Get", 0, iface, prop).
+		Store(value)
+}
+
+// SetProperty calls org.freedesktop.DBus.Properties.Set on the given
+// object. The property name must be given in interface.member notation.
+func (o *Object) SetProperty(p string, v interface{}) error {
+	idx := strings.LastIndex(p, ".")
+	if idx == -1 || idx+1 == len(p) {
+		return errors.New("dbus: invalid property " + p)
+	}
+
+	iface := p[:idx]
+	prop := p[idx+1:]
+
+	return o.Call("org.freedesktop.DBus.Properties.Set", 0, iface, prop, v).Err
+}
+
+// Destination returns the destination that calls on (o *Object) are sent to.
+func (o *Object) Destination() string {
+	return o.dest
+}
+
+// Path returns the path that calls on (o *Object") are sent to.
+func (o *Object) Path() ObjectPath {
+	return o.path
+}

--- a/vendor/github.com/godbus/dbus/v5/sequence.go
+++ b/vendor/github.com/godbus/dbus/v5/sequence.go
@@ -1,0 +1,24 @@
+package dbus
+
+// Sequence represents the value of a monotonically increasing counter.
+type Sequence uint64
+
+const (
+	// NoSequence indicates the absence of a sequence value.
+	NoSequence Sequence = 0
+)
+
+// sequenceGenerator represents a monotonically increasing counter.
+type sequenceGenerator struct {
+	nextSequence Sequence
+}
+
+func (generator *sequenceGenerator) next() Sequence {
+	result := generator.nextSequence
+	generator.nextSequence++
+	return result
+}
+
+func newSequenceGenerator() *sequenceGenerator {
+	return &sequenceGenerator{nextSequence: 1}
+}

--- a/vendor/github.com/godbus/dbus/v5/sequential_handler.go
+++ b/vendor/github.com/godbus/dbus/v5/sequential_handler.go
@@ -1,0 +1,125 @@
+package dbus
+
+import (
+	"sync"
+)
+
+// NewSequentialSignalHandler returns an instance of a new
+// signal handler that guarantees sequential processing of signals. It is a
+// guarantee of this signal handler that signals will be written to
+// channels in the order they are received on the DBus connection.
+func NewSequentialSignalHandler() SignalHandler {
+	return &sequentialSignalHandler{}
+}
+
+type sequentialSignalHandler struct {
+	mu      sync.RWMutex
+	closed  bool
+	signals []*sequentialSignalChannelData
+}
+
+func (sh *sequentialSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	if sh.closed {
+		return
+	}
+	for _, scd := range sh.signals {
+		scd.deliver(signal)
+	}
+}
+
+func (sh *sequentialSignalHandler) Terminate() {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+
+	for _, scd := range sh.signals {
+		scd.close()
+		close(scd.ch)
+	}
+	sh.closed = true
+	sh.signals = nil
+}
+
+func (sh *sequentialSignalHandler) AddSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	sh.signals = append(sh.signals, newSequentialSignalChannelData(ch))
+}
+
+func (sh *sequentialSignalHandler) RemoveSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	for i := len(sh.signals) - 1; i >= 0; i-- {
+		if ch == sh.signals[i].ch {
+			sh.signals[i].close()
+			copy(sh.signals[i:], sh.signals[i+1:])
+			sh.signals[len(sh.signals)-1] = nil
+			sh.signals = sh.signals[:len(sh.signals)-1]
+		}
+	}
+}
+
+type sequentialSignalChannelData struct {
+	ch   chan<- *Signal
+	in   chan *Signal
+	done chan struct{}
+}
+
+func newSequentialSignalChannelData(ch chan<- *Signal) *sequentialSignalChannelData {
+	scd := &sequentialSignalChannelData{
+		ch:   ch,
+		in:   make(chan *Signal),
+		done: make(chan struct{}),
+	}
+	go scd.bufferSignals()
+	return scd
+}
+
+func (scd *sequentialSignalChannelData) bufferSignals() {
+	defer close(scd.done)
+
+	// Ensure that signals are delivered to scd.ch in the same
+	// order they are received from scd.in.
+	var queue []*Signal
+	for {
+		if len(queue) == 0 {
+			signal, ok := <- scd.in
+			if !ok {
+				return
+			}
+			queue = append(queue, signal)
+		}
+		select {
+		case scd.ch <- queue[0]:
+			copy(queue, queue[1:])
+			queue[len(queue)-1] = nil
+			queue = queue[:len(queue)-1]
+		case signal, ok := <-scd.in:
+			if !ok {
+				return
+			}
+			queue = append(queue, signal)
+		}
+	}
+}
+
+func (scd *sequentialSignalChannelData) deliver(signal *Signal) {
+	scd.in <- signal
+}
+
+func (scd *sequentialSignalChannelData) close() {
+	close(scd.in)
+	// Ensure that bufferSignals() has exited and won't attempt
+	// any future sends on scd.ch
+	<-scd.done
+}

--- a/vendor/github.com/godbus/dbus/v5/server_interfaces.go
+++ b/vendor/github.com/godbus/dbus/v5/server_interfaces.go
@@ -1,0 +1,107 @@
+package dbus
+
+// Terminator allows a handler to implement a shutdown mechanism that
+// is called when the connection terminates.
+type Terminator interface {
+	Terminate()
+}
+
+// Handler is the representation of a D-Bus Application.
+//
+// The Handler must have a way to lookup objects given
+// an ObjectPath. The returned object must implement the
+// ServerObject interface.
+type Handler interface {
+	LookupObject(path ObjectPath) (ServerObject, bool)
+}
+
+// ServerObject is the representation of an D-Bus Object.
+//
+// Objects are registered at a path for a given Handler.
+// The Objects implement D-Bus interfaces. The semantics
+// of Interface lookup is up to the implementation of
+// the ServerObject. The ServerObject implementation may
+// choose to implement empty string as a valid interface
+// represeting all methods or not per the D-Bus specification.
+type ServerObject interface {
+	LookupInterface(name string) (Interface, bool)
+}
+
+// An Interface is the representation of a D-Bus Interface.
+//
+// Interfaces are a grouping of methods implemented by the Objects.
+// Interfaces are responsible for routing method calls.
+type Interface interface {
+	LookupMethod(name string) (Method, bool)
+}
+
+// A Method represents the exposed methods on D-Bus.
+type Method interface {
+	// Call requires that all arguments are decoded before being passed to it.
+	Call(args ...interface{}) ([]interface{}, error)
+	NumArguments() int
+	NumReturns() int
+	// ArgumentValue returns a representative value for the argument at position
+	// it should be of the proper type. reflect.Zero would be a good mechanism
+	// to use for this Value.
+	ArgumentValue(position int) interface{}
+	// ReturnValue returns a representative value for the return at position
+	// it should be of the proper type. reflect.Zero would be a good mechanism
+	// to use for this Value.
+	ReturnValue(position int) interface{}
+}
+
+// An Argument Decoder can decode arguments using the non-standard mechanism
+//
+// If a method implements this interface then the non-standard
+// decoder will be used.
+//
+// Method arguments must be decoded from the message.
+// The mechanism for doing this will vary based on the
+// implementation of the method. A normal approach is provided
+// as part of this library, but may be replaced with
+// any other decoding scheme.
+type ArgumentDecoder interface {
+	// To decode the arguments of a method the sender and message are
+	// provided in case the semantics of the implementer provides access
+	// to these as part of the method invocation.
+	DecodeArguments(conn *Conn, sender string, msg *Message, args []interface{}) ([]interface{}, error)
+}
+
+// A SignalHandler is responsible for delivering a signal.
+//
+// Signal delivery may be changed from the default channel
+// based approach by Handlers implementing the SignalHandler
+// interface.
+type SignalHandler interface {
+	DeliverSignal(iface, name string, signal *Signal)
+}
+
+// SignalRegistrar manages signal delivery channels.
+//
+// This is an optional set of methods for `SignalHandler`.
+type SignalRegistrar interface {
+	AddSignal(ch chan<- *Signal)
+	RemoveSignal(ch chan<- *Signal)
+}
+
+// A DBusError is used to convert a generic object to a D-Bus error.
+//
+// Any custom error mechanism may implement this interface to provide
+// a custom encoding of the error on D-Bus. By default if a normal
+// error is returned, it will be encoded as the generic
+// "org.freedesktop.DBus.Error.Failed" error. By implementing this
+// interface as well a custom encoding may be provided.
+type DBusError interface {
+	DBusError() (string, []interface{})
+}
+
+// SerialGenerator is responsible for serials generation.
+//
+// Different approaches for the serial generation can be used,
+// maintaining a map guarded with a mutex (the standard way) or
+// simply increment an atomic counter.
+type SerialGenerator interface {
+	GetSerial() uint32
+	RetireSerial(serial uint32)
+}

--- a/vendor/github.com/godbus/dbus/v5/sig.go
+++ b/vendor/github.com/godbus/dbus/v5/sig.go
@@ -1,0 +1,293 @@
+package dbus
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var sigToType = map[byte]reflect.Type{
+	'y': byteType,
+	'b': boolType,
+	'n': int16Type,
+	'q': uint16Type,
+	'i': int32Type,
+	'u': uint32Type,
+	'x': int64Type,
+	't': uint64Type,
+	'd': float64Type,
+	's': stringType,
+	'g': signatureType,
+	'o': objectPathType,
+	'v': variantType,
+	'h': unixFDIndexType,
+}
+
+// Signature represents a correct type signature as specified by the D-Bus
+// specification. The zero value represents the empty signature, "".
+type Signature struct {
+	str string
+}
+
+// SignatureOf returns the concatenation of all the signatures of the given
+// values. It panics if one of them is not representable in D-Bus.
+func SignatureOf(vs ...interface{}) Signature {
+	var s string
+	for _, v := range vs {
+		s += getSignature(reflect.TypeOf(v), &depthCounter{})
+	}
+	return Signature{s}
+}
+
+// SignatureOfType returns the signature of the given type. It panics if the
+// type is not representable in D-Bus.
+func SignatureOfType(t reflect.Type) Signature {
+	return Signature{getSignature(t, &depthCounter{})}
+}
+
+// getSignature returns the signature of the given type and panics on unknown types.
+func getSignature(t reflect.Type, depth *depthCounter) (sig string) {
+	if !depth.Valid() {
+		panic("container nesting too deep")
+	}
+	defer func() {
+		if len(sig) > 255 {
+			panic("signature exceeds the length limitation")
+		}
+	}()
+	// handle simple types first
+	switch t.Kind() {
+	case reflect.Uint8:
+		return "y"
+	case reflect.Bool:
+		return "b"
+	case reflect.Int16:
+		return "n"
+	case reflect.Uint16:
+		return "q"
+	case reflect.Int, reflect.Int32:
+		if t == unixFDType {
+			return "h"
+		}
+		return "i"
+	case reflect.Uint, reflect.Uint32:
+		if t == unixFDIndexType {
+			return "h"
+		}
+		return "u"
+	case reflect.Int64:
+		return "x"
+	case reflect.Uint64:
+		return "t"
+	case reflect.Float64:
+		return "d"
+	case reflect.Ptr:
+		return getSignature(t.Elem(), depth)
+	case reflect.String:
+		if t == objectPathType {
+			return "o"
+		}
+		return "s"
+	case reflect.Struct:
+		if t == variantType {
+			return "v"
+		} else if t == signatureType {
+			return "g"
+		}
+		var s string
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if field.PkgPath == "" && field.Tag.Get("dbus") != "-" {
+				s += getSignature(t.Field(i).Type, depth.EnterStruct())
+			}
+		}
+		if len(s) == 0 {
+			panic(InvalidTypeError{t})
+		}
+		return "(" + s + ")"
+	case reflect.Array, reflect.Slice:
+		return "a" + getSignature(t.Elem(), depth.EnterArray())
+	case reflect.Map:
+		if !isKeyType(t.Key()) {
+			panic(InvalidTypeError{t})
+		}
+		return "a{" + getSignature(t.Key(), depth.EnterArray().EnterDictEntry()) + getSignature(t.Elem(), depth.EnterArray().EnterDictEntry()) + "}"
+	case reflect.Interface:
+		return "v"
+	}
+	panic(InvalidTypeError{t})
+}
+
+// ParseSignature returns the signature represented by this string, or a
+// SignatureError if the string is not a valid signature.
+func ParseSignature(s string) (sig Signature, err error) {
+	if len(s) == 0 {
+		return
+	}
+	if len(s) > 255 {
+		return Signature{""}, SignatureError{s, "too long"}
+	}
+	sig.str = s
+	for err == nil && len(s) != 0 {
+		err, s = validSingle(s, &depthCounter{})
+	}
+	if err != nil {
+		sig = Signature{""}
+	}
+
+	return
+}
+
+// ParseSignatureMust behaves like ParseSignature, except that it panics if s
+// is not valid.
+func ParseSignatureMust(s string) Signature {
+	sig, err := ParseSignature(s)
+	if err != nil {
+		panic(err)
+	}
+	return sig
+}
+
+// Empty returns whether the signature is the empty signature.
+func (s Signature) Empty() bool {
+	return s.str == ""
+}
+
+// Single returns whether the signature represents a single, complete type.
+func (s Signature) Single() bool {
+	err, r := validSingle(s.str, &depthCounter{})
+	return err != nil && r == ""
+}
+
+// String returns the signature's string representation.
+func (s Signature) String() string {
+	return s.str
+}
+
+// A SignatureError indicates that a signature passed to a function or received
+// on a connection is not a valid signature.
+type SignatureError struct {
+	Sig    string
+	Reason string
+}
+
+func (e SignatureError) Error() string {
+	return fmt.Sprintf("dbus: invalid signature: %q (%s)", e.Sig, e.Reason)
+}
+
+type depthCounter struct {
+	arrayDepth, structDepth, dictEntryDepth int
+}
+
+func (cnt *depthCounter) Valid() bool {
+	return cnt.arrayDepth <= 32 && cnt.structDepth <= 32 && cnt.dictEntryDepth <= 32
+}
+
+func (cnt depthCounter) EnterArray() *depthCounter {
+	cnt.arrayDepth++
+	return &cnt
+}
+
+func (cnt depthCounter) EnterStruct() *depthCounter {
+	cnt.structDepth++
+	return &cnt
+}
+
+func (cnt depthCounter) EnterDictEntry() *depthCounter {
+	cnt.dictEntryDepth++
+	return &cnt
+}
+
+// Try to read a single type from this string. If it was successful, err is nil
+// and rem is the remaining unparsed part. Otherwise, err is a non-nil
+// SignatureError and rem is "". depth is the current recursion depth which may
+// not be greater than 64 and should be given as 0 on the first call.
+func validSingle(s string, depth *depthCounter) (err error, rem string) {
+	if s == "" {
+		return SignatureError{Sig: s, Reason: "empty signature"}, ""
+	}
+	if !depth.Valid() {
+		return SignatureError{Sig: s, Reason: "container nesting too deep"}, ""
+	}
+	switch s[0] {
+	case 'y', 'b', 'n', 'q', 'i', 'u', 'x', 't', 'd', 's', 'g', 'o', 'v', 'h':
+		return nil, s[1:]
+	case 'a':
+		if len(s) > 1 && s[1] == '{' {
+			i := findMatching(s[1:], '{', '}')
+			if i == -1 {
+				return SignatureError{Sig: s, Reason: "unmatched '{'"}, ""
+			}
+			i++
+			rem = s[i+1:]
+			s = s[2:i]
+			if err, _ = validSingle(s[:1], depth.EnterArray().EnterDictEntry()); err != nil {
+				return err, ""
+			}
+			err, nr := validSingle(s[1:], depth.EnterArray().EnterDictEntry())
+			if err != nil {
+				return err, ""
+			}
+			if nr != "" {
+				return SignatureError{Sig: s, Reason: "too many types in dict"}, ""
+			}
+			return nil, rem
+		}
+		return validSingle(s[1:], depth.EnterArray())
+	case '(':
+		i := findMatching(s, '(', ')')
+		if i == -1 {
+			return SignatureError{Sig: s, Reason: "unmatched ')'"}, ""
+		}
+		rem = s[i+1:]
+		s = s[1:i]
+		for err == nil && s != "" {
+			err, s = validSingle(s, depth.EnterStruct())
+		}
+		if err != nil {
+			rem = ""
+		}
+		return
+	}
+	return SignatureError{Sig: s, Reason: "invalid type character"}, ""
+}
+
+func findMatching(s string, left, right rune) int {
+	n := 0
+	for i, v := range s {
+		if v == left {
+			n++
+		} else if v == right {
+			n--
+		}
+		if n == 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+// typeFor returns the type of the given signature. It ignores any left over
+// characters and panics if s doesn't start with a valid type signature.
+func typeFor(s string) (t reflect.Type) {
+	err, _ := validSingle(s, &depthCounter{})
+	if err != nil {
+		panic(err)
+	}
+
+	if t, ok := sigToType[s[0]]; ok {
+		return t
+	}
+	switch s[0] {
+	case 'a':
+		if s[1] == '{' {
+			i := strings.LastIndex(s, "}")
+			t = reflect.MapOf(sigToType[s[2]], typeFor(s[3:i]))
+		} else {
+			t = reflect.SliceOf(typeFor(s[1:]))
+		}
+	case '(':
+		t = interfacesType
+	}
+	return
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_darwin.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_darwin.go
@@ -1,0 +1,6 @@
+package dbus
+
+func (t *unixTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_generic.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_generic.go
@@ -1,0 +1,52 @@
+package dbus
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"unsafe"
+)
+
+var nativeEndian binary.ByteOrder
+
+func detectEndianness() binary.ByteOrder {
+	var x uint32 = 0x01020304
+	if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+}
+
+func init() {
+	nativeEndian = detectEndianness()
+}
+
+type genericTransport struct {
+	io.ReadWriteCloser
+}
+
+func (t genericTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}
+
+func (t genericTransport) SupportsUnixFDs() bool {
+	return false
+}
+
+func (t genericTransport) EnableUnixFDs() {}
+
+func (t genericTransport) ReadMessage() (*Message, error) {
+	return DecodeMessage(t)
+}
+
+func (t genericTransport) SendMessage(msg *Message) error {
+	fds, err := msg.CountFds()
+	if err != nil {
+		return err
+	}
+	if fds != 0 {
+		return errors.New("dbus: unix fd passing not enabled")
+	}
+	return msg.EncodeTo(t, nativeEndian)
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_nonce_tcp.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_nonce_tcp.go
@@ -1,0 +1,39 @@
+//+build !windows
+
+package dbus
+
+import (
+	"errors"
+	"io/ioutil"
+	"net"
+)
+
+func init() {
+	transports["nonce-tcp"] = newNonceTcpTransport
+}
+
+func newNonceTcpTransport(keys string) (transport, error) {
+	host := getKey(keys, "host")
+	port := getKey(keys, "port")
+	noncefile := getKey(keys, "noncefile")
+	if host == "" || port == "" || noncefile == "" {
+		return nil, errors.New("dbus: unsupported address (must set host, port and noncefile)")
+	}
+	protocol, err := tcpFamily(keys)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.Dial(protocol, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadFile(noncefile)
+	if err != nil {
+		return nil, err
+	}
+	_, err = socket.Write(b)
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(socket)
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_tcp.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_tcp.go
@@ -1,0 +1,41 @@
+package dbus
+
+import (
+	"errors"
+	"net"
+)
+
+func init() {
+	transports["tcp"] = newTcpTransport
+}
+
+func tcpFamily(keys string) (string, error) {
+	switch getKey(keys, "family") {
+	case "":
+		return "tcp", nil
+	case "ipv4":
+		return "tcp4", nil
+	case "ipv6":
+		return "tcp6", nil
+	default:
+		return "", errors.New("dbus: invalid tcp family (must be ipv4 or ipv6)")
+	}
+}
+
+func newTcpTransport(keys string) (transport, error) {
+	host := getKey(keys, "host")
+	port := getKey(keys, "port")
+	if host == "" || port == "" {
+		return nil, errors.New("dbus: unsupported address (must set host and port)")
+	}
+
+	protocol, err := tcpFamily(keys)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.Dial(protocol, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(socket)
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unix.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unix.go
@@ -1,0 +1,212 @@
+//+build !windows,!solaris
+
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+)
+
+type oobReader struct {
+	conn *net.UnixConn
+	oob  []byte
+	buf  [4096]byte
+}
+
+func (o *oobReader) Read(b []byte) (n int, err error) {
+	n, oobn, flags, _, err := o.conn.ReadMsgUnix(b, o.buf[:])
+	if err != nil {
+		return n, err
+	}
+	if flags&syscall.MSG_CTRUNC != 0 {
+		return n, errors.New("dbus: control data truncated (too many fds received)")
+	}
+	o.oob = append(o.oob, o.buf[:oobn]...)
+	return n, nil
+}
+
+type unixTransport struct {
+	*net.UnixConn
+	rdr        *oobReader
+	hasUnixFDs bool
+}
+
+func newUnixTransport(keys string) (transport, error) {
+	var err error
+
+	t := new(unixTransport)
+	abstract := getKey(keys, "abstract")
+	path := getKey(keys, "path")
+	switch {
+	case abstract == "" && path == "":
+		return nil, errors.New("dbus: invalid address (neither path nor abstract set)")
+	case abstract != "" && path == "":
+		t.UnixConn, err = net.DialUnix("unix", nil, &net.UnixAddr{Name: "@" + abstract, Net: "unix"})
+		if err != nil {
+			return nil, err
+		}
+		return t, nil
+	case abstract == "" && path != "":
+		t.UnixConn, err = net.DialUnix("unix", nil, &net.UnixAddr{Name: path, Net: "unix"})
+		if err != nil {
+			return nil, err
+		}
+		return t, nil
+	default:
+		return nil, errors.New("dbus: invalid address (both path and abstract set)")
+	}
+}
+
+func init() {
+	transports["unix"] = newUnixTransport
+}
+
+func (t *unixTransport) EnableUnixFDs() {
+	t.hasUnixFDs = true
+}
+
+func (t *unixTransport) ReadMessage() (*Message, error) {
+	var (
+		blen, hlen uint32
+		csheader   [16]byte
+		headers    []header
+		order      binary.ByteOrder
+		unixfds    uint32
+	)
+	// To be sure that all bytes of out-of-band data are read, we use a special
+	// reader that uses ReadUnix on the underlying connection instead of Read
+	// and gathers the out-of-band data in a buffer.
+	if t.rdr == nil {
+		t.rdr = &oobReader{conn: t.UnixConn}
+	} else {
+		t.rdr.oob = nil
+	}
+
+	// read the first 16 bytes (the part of the header that has a constant size),
+	// from which we can figure out the length of the rest of the message
+	if _, err := io.ReadFull(t.rdr, csheader[:]); err != nil {
+		return nil, err
+	}
+	switch csheader[0] {
+	case 'l':
+		order = binary.LittleEndian
+	case 'B':
+		order = binary.BigEndian
+	default:
+		return nil, InvalidMessageError("invalid byte order")
+	}
+	// csheader[4:8] -> length of message body, csheader[12:16] -> length of
+	// header fields (without alignment)
+	binary.Read(bytes.NewBuffer(csheader[4:8]), order, &blen)
+	binary.Read(bytes.NewBuffer(csheader[12:]), order, &hlen)
+	if hlen%8 != 0 {
+		hlen += 8 - (hlen % 8)
+	}
+
+	// decode headers and look for unix fds
+	headerdata := make([]byte, hlen+4)
+	copy(headerdata, csheader[12:])
+	if _, err := io.ReadFull(t.rdr, headerdata[4:]); err != nil {
+		return nil, err
+	}
+	dec := newDecoder(bytes.NewBuffer(headerdata), order, make([]int, 0))
+	dec.pos = 12
+	vs, err := dec.Decode(Signature{"a(yv)"})
+	if err != nil {
+		return nil, err
+	}
+	Store(vs, &headers)
+	for _, v := range headers {
+		if v.Field == byte(FieldUnixFDs) {
+			unixfds, _ = v.Variant.value.(uint32)
+		}
+	}
+	all := make([]byte, 16+hlen+blen)
+	copy(all, csheader[:])
+	copy(all[16:], headerdata[4:])
+	if _, err := io.ReadFull(t.rdr, all[16+hlen:]); err != nil {
+		return nil, err
+	}
+	if unixfds != 0 {
+		if !t.hasUnixFDs {
+			return nil, errors.New("dbus: got unix fds on unsupported transport")
+		}
+		// read the fds from the OOB data
+		scms, err := syscall.ParseSocketControlMessage(t.rdr.oob)
+		if err != nil {
+			return nil, err
+		}
+		if len(scms) != 1 {
+			return nil, errors.New("dbus: received more than one socket control message")
+		}
+		fds, err := syscall.ParseUnixRights(&scms[0])
+		if err != nil {
+			return nil, err
+		}
+		msg, err := DecodeMessageWithFDs(bytes.NewBuffer(all), fds)
+		if err != nil {
+			return nil, err
+		}
+		// substitute the values in the message body (which are indices for the
+		// array receiver via OOB) with the actual values
+		for i, v := range msg.Body {
+			switch index := v.(type) {
+			case UnixFDIndex:
+				if uint32(index) >= unixfds {
+					return nil, InvalidMessageError("invalid index for unix fd")
+				}
+				msg.Body[i] = UnixFD(fds[index])
+			case []UnixFDIndex:
+				fdArray := make([]UnixFD, len(index))
+				for k, j := range index {
+					if uint32(j) >= unixfds {
+						return nil, InvalidMessageError("invalid index for unix fd")
+					}
+					fdArray[k] = UnixFD(fds[j])
+				}
+				msg.Body[i] = fdArray
+			}
+		}
+		return msg, nil
+	}
+	return DecodeMessage(bytes.NewBuffer(all))
+}
+
+func (t *unixTransport) SendMessage(msg *Message) error {
+	fdcnt, err := msg.CountFds()
+	if err != nil {
+		return err
+	}
+	if fdcnt != 0 {
+		if !t.hasUnixFDs {
+			return errors.New("dbus: unix fd passing not enabled")
+		}
+		msg.Headers[FieldUnixFDs] = MakeVariant(uint32(fdcnt))
+		buf := new(bytes.Buffer)
+		fds, err := msg.EncodeToWithFDs(buf, nativeEndian)
+		if err != nil {
+			return err
+		}
+		oob := syscall.UnixRights(fds...)
+		n, oobn, err := t.UnixConn.WriteMsgUnix(buf.Bytes(), oob, nil)
+		if err != nil {
+			return err
+		}
+		if n != buf.Len() || oobn != len(oob) {
+			return io.ErrShortWrite
+		}
+	} else {
+		if err := msg.EncodeTo(t, nativeEndian); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *unixTransport) SupportsUnixFDs() bool {
+	return true
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_dragonfly.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_dragonfly.go
@@ -1,0 +1,95 @@
+// The UnixCredentials system call is currently only implemented on Linux
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// https://golang.org/s/go1.4-syscall
+// http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
+
+// Local implementation of the UnixCredentials system call for DragonFly BSD
+
+package dbus
+
+/*
+#include <sys/ucred.h>
+*/
+import "C"
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// http://golang.org/src/pkg/syscall/ztypes_linux_amd64.go
+// http://golang.org/src/pkg/syscall/ztypes_dragonfly_amd64.go
+type Ucred struct {
+	Pid int32
+	Uid uint32
+	Gid uint32
+}
+
+// http://golang.org/src/pkg/syscall/types_linux.go
+// http://golang.org/src/pkg/syscall/types_dragonfly.go
+// https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/ucred.h
+const (
+	SizeofUcred = C.sizeof_struct_ucred
+)
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgAlignOf(salen int) int {
+	// From http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+	//salign := sizeofPtr
+	// NOTE: It seems like 64-bit Darwin and DragonFly BSD kernels
+	// still require 32-bit aligned access to network subsystem.
+	//if darwin64Bit || dragonfly64Bit {
+	//	salign = 4
+	//}
+	salign := 4
+	return (salen + salign - 1) & ^(salign - 1)
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgData(h *syscall.Cmsghdr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(unsafe.Pointer(h)) + uintptr(cmsgAlignOf(syscall.SizeofCmsghdr)))
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// UnixCredentials encodes credentials into a socket control message
+// for sending to another process. This can be used for
+// authentication.
+func UnixCredentials(ucred *Ucred) []byte {
+	b := make([]byte, syscall.CmsgSpace(SizeofUcred))
+	h := (*syscall.Cmsghdr)(unsafe.Pointer(&b[0]))
+	h.Level = syscall.SOL_SOCKET
+	h.Type = syscall.SCM_CREDS
+	h.SetLen(syscall.CmsgLen(SizeofUcred))
+	*((*Ucred)(cmsgData(h))) = *ucred
+	return b
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// ParseUnixCredentials decodes a socket control message that contains
+// credentials in a Ucred structure. To receive such a message, the
+// SO_PASSCRED option must be enabled on the socket.
+func ParseUnixCredentials(m *syscall.SocketControlMessage) (*Ucred, error) {
+	if m.Header.Level != syscall.SOL_SOCKET {
+		return nil, syscall.EINVAL
+	}
+	if m.Header.Type != syscall.SCM_CREDS {
+		return nil, syscall.EINVAL
+	}
+	ucred := *(*Ucred)(unsafe.Pointer(&m.Data[0]))
+	return &ucred, nil
+}
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := UnixCredentials(ucred)
+	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_freebsd.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_freebsd.go
@@ -1,0 +1,92 @@
+// The UnixCredentials system call is currently only implemented on Linux
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// https://golang.org/s/go1.4-syscall
+// http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
+
+// Local implementation of the UnixCredentials system call for FreeBSD
+
+package dbus
+
+/*
+const int sizeofPtr = sizeof(void*);
+#define _WANT_UCRED
+#include <sys/types.h>
+#include <sys/ucred.h>
+*/
+import "C"
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// http://golang.org/src/pkg/syscall/ztypes_linux_amd64.go
+// https://golang.org/src/syscall/ztypes_freebsd_amd64.go
+type Ucred struct {
+	Pid int32
+	Uid uint32
+	Gid uint32
+}
+
+// http://golang.org/src/pkg/syscall/types_linux.go
+// https://golang.org/src/syscall/types_freebsd.go
+// https://github.com/freebsd/freebsd/blob/master/sys/sys/ucred.h
+const (
+	SizeofUcred = C.sizeof_struct_ucred
+)
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgAlignOf(salen int) int {
+	salign := C.sizeofPtr
+
+	return (salen + salign - 1) & ^(salign - 1)
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgData(h *syscall.Cmsghdr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(unsafe.Pointer(h)) + uintptr(cmsgAlignOf(syscall.SizeofCmsghdr)))
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// UnixCredentials encodes credentials into a socket control message
+// for sending to another process. This can be used for
+// authentication.
+func UnixCredentials(ucred *Ucred) []byte {
+	b := make([]byte, syscall.CmsgSpace(SizeofUcred))
+	h := (*syscall.Cmsghdr)(unsafe.Pointer(&b[0]))
+	h.Level = syscall.SOL_SOCKET
+	h.Type = syscall.SCM_CREDS
+	h.SetLen(syscall.CmsgLen(SizeofUcred))
+	*((*Ucred)(cmsgData(h))) = *ucred
+	return b
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// ParseUnixCredentials decodes a socket control message that contains
+// credentials in a Ucred structure. To receive such a message, the
+// SO_PASSCRED option must be enabled on the socket.
+func ParseUnixCredentials(m *syscall.SocketControlMessage) (*Ucred, error) {
+	if m.Header.Level != syscall.SOL_SOCKET {
+		return nil, syscall.EINVAL
+	}
+	if m.Header.Type != syscall.SCM_CREDS {
+		return nil, syscall.EINVAL
+	}
+	ucred := *(*Ucred)(unsafe.Pointer(&m.Data[0]))
+	return &ucred, nil
+}
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := UnixCredentials(ucred)
+	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_linux.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_linux.go
@@ -1,0 +1,25 @@
+// The UnixCredentials system call is currently only implemented on Linux
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// https://golang.org/s/go1.4-syscall
+// http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
+
+package dbus
+
+import (
+	"io"
+	"os"
+	"syscall"
+)
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &syscall.Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := syscall.UnixCredentials(ucred)
+	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_netbsd.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_netbsd.go
@@ -1,0 +1,14 @@
+package dbus
+
+import "io"
+
+func (t *unixTransport) SendNullByte() error {
+	n, _, err := t.UnixConn.WriteMsgUnix([]byte{0}, nil, nil)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_openbsd.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_openbsd.go
@@ -1,0 +1,14 @@
+package dbus
+
+import "io"
+
+func (t *unixTransport) SendNullByte() error {
+	n, _, err := t.UnixConn.WriteMsgUnix([]byte{0}, nil, nil)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_zos.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_zos.go
@@ -1,0 +1,6 @@
+package dbus
+
+func (t *unixTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}

--- a/vendor/github.com/godbus/dbus/v5/variant.go
+++ b/vendor/github.com/godbus/dbus/v5/variant.go
@@ -1,0 +1,150 @@
+package dbus
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+)
+
+// Variant represents the D-Bus variant type.
+type Variant struct {
+	sig   Signature
+	value interface{}
+}
+
+// MakeVariant converts the given value to a Variant. It panics if v cannot be
+// represented as a D-Bus type.
+func MakeVariant(v interface{}) Variant {
+	return MakeVariantWithSignature(v, SignatureOf(v))
+}
+
+// MakeVariantWithSignature converts the given value to a Variant.
+func MakeVariantWithSignature(v interface{}, s Signature) Variant {
+	return Variant{s, v}
+}
+
+// ParseVariant parses the given string as a variant as described at
+// https://developer.gnome.org/glib/stable/gvariant-text.html. If sig is not
+// empty, it is taken to be the expected signature for the variant.
+func ParseVariant(s string, sig Signature) (Variant, error) {
+	tokens := varLex(s)
+	p := &varParser{tokens: tokens}
+	n, err := varMakeNode(p)
+	if err != nil {
+		return Variant{}, err
+	}
+	if sig.str == "" {
+		sig, err = varInfer(n)
+		if err != nil {
+			return Variant{}, err
+		}
+	}
+	v, err := n.Value(sig)
+	if err != nil {
+		return Variant{}, err
+	}
+	return MakeVariant(v), nil
+}
+
+// format returns a formatted version of v and whether this string can be parsed
+// unambiguously.
+func (v Variant) format() (string, bool) {
+	switch v.sig.str[0] {
+	case 'b', 'i':
+		return fmt.Sprint(v.value), true
+	case 'n', 'q', 'u', 'x', 't', 'd', 'h':
+		return fmt.Sprint(v.value), false
+	case 's':
+		return strconv.Quote(v.value.(string)), true
+	case 'o':
+		return strconv.Quote(string(v.value.(ObjectPath))), false
+	case 'g':
+		return strconv.Quote(v.value.(Signature).str), false
+	case 'v':
+		s, unamb := v.value.(Variant).format()
+		if !unamb {
+			return "<@" + v.value.(Variant).sig.str + " " + s + ">", true
+		}
+		return "<" + s + ">", true
+	case 'y':
+		return fmt.Sprintf("%#x", v.value.(byte)), false
+	}
+	rv := reflect.ValueOf(v.value)
+	switch rv.Kind() {
+	case reflect.Slice:
+		if rv.Len() == 0 {
+			return "[]", false
+		}
+		unamb := true
+		buf := bytes.NewBuffer([]byte("["))
+		for i := 0; i < rv.Len(); i++ {
+			// TODO: slooow
+			s, b := MakeVariant(rv.Index(i).Interface()).format()
+			unamb = unamb && b
+			buf.WriteString(s)
+			if i != rv.Len()-1 {
+				buf.WriteString(", ")
+			}
+		}
+		buf.WriteByte(']')
+		return buf.String(), unamb
+	case reflect.Map:
+		if rv.Len() == 0 {
+			return "{}", false
+		}
+		unamb := true
+		var buf bytes.Buffer
+		kvs := make([]string, rv.Len())
+		for i, k := range rv.MapKeys() {
+			s, b := MakeVariant(k.Interface()).format()
+			unamb = unamb && b
+			buf.Reset()
+			buf.WriteString(s)
+			buf.WriteString(": ")
+			s, b = MakeVariant(rv.MapIndex(k).Interface()).format()
+			unamb = unamb && b
+			buf.WriteString(s)
+			kvs[i] = buf.String()
+		}
+		buf.Reset()
+		buf.WriteByte('{')
+		sort.Strings(kvs)
+		for i, kv := range kvs {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(kv)
+		}
+		buf.WriteByte('}')
+		return buf.String(), unamb
+	}
+	return `"INVALID"`, true
+}
+
+// Signature returns the D-Bus signature of the underlying value of v.
+func (v Variant) Signature() Signature {
+	return v.sig
+}
+
+// String returns the string representation of the underlying value of v as
+// described at https://developer.gnome.org/glib/stable/gvariant-text.html.
+func (v Variant) String() string {
+	s, unamb := v.format()
+	if !unamb {
+		return "@" + v.sig.str + " " + s
+	}
+	return s
+}
+
+// Value returns the underlying value of v.
+func (v Variant) Value() interface{} {
+	return v.value
+}
+
+// Store converts the variant into a native go type using the same
+// mechanism as the "Store" function.
+func (v Variant) Store(value interface{}) error {
+	return storeInterfaces(v.value, value)
+}

--- a/vendor/github.com/godbus/dbus/v5/variant_lexer.go
+++ b/vendor/github.com/godbus/dbus/v5/variant_lexer.go
@@ -1,0 +1,284 @@
+package dbus
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Heavily inspired by the lexer from text/template.
+
+type varToken struct {
+	typ varTokenType
+	val string
+}
+
+type varTokenType byte
+
+const (
+	tokEOF varTokenType = iota
+	tokError
+	tokNumber
+	tokString
+	tokBool
+	tokArrayStart
+	tokArrayEnd
+	tokDictStart
+	tokDictEnd
+	tokVariantStart
+	tokVariantEnd
+	tokComma
+	tokColon
+	tokType
+	tokByteString
+)
+
+type varLexer struct {
+	input  string
+	start  int
+	pos    int
+	width  int
+	tokens []varToken
+}
+
+type lexState func(*varLexer) lexState
+
+func varLex(s string) []varToken {
+	l := &varLexer{input: s}
+	l.run()
+	return l.tokens
+}
+
+func (l *varLexer) accept(valid string) bool {
+	if strings.ContainsRune(valid, l.next()) {
+		return true
+	}
+	l.backup()
+	return false
+}
+
+func (l *varLexer) backup() {
+	l.pos -= l.width
+}
+
+func (l *varLexer) emit(t varTokenType) {
+	l.tokens = append(l.tokens, varToken{t, l.input[l.start:l.pos]})
+	l.start = l.pos
+}
+
+func (l *varLexer) errorf(format string, v ...interface{}) lexState {
+	l.tokens = append(l.tokens, varToken{
+		tokError,
+		fmt.Sprintf(format, v...),
+	})
+	return nil
+}
+
+func (l *varLexer) ignore() {
+	l.start = l.pos
+}
+
+func (l *varLexer) next() rune {
+	var r rune
+
+	if l.pos >= len(l.input) {
+		l.width = 0
+		return -1
+	}
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += l.width
+	return r
+}
+
+func (l *varLexer) run() {
+	for state := varLexNormal; state != nil; {
+		state = state(l)
+	}
+}
+
+func (l *varLexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+func varLexNormal(l *varLexer) lexState {
+	for {
+		r := l.next()
+		switch {
+		case r == -1:
+			l.emit(tokEOF)
+			return nil
+		case r == '[':
+			l.emit(tokArrayStart)
+		case r == ']':
+			l.emit(tokArrayEnd)
+		case r == '{':
+			l.emit(tokDictStart)
+		case r == '}':
+			l.emit(tokDictEnd)
+		case r == '<':
+			l.emit(tokVariantStart)
+		case r == '>':
+			l.emit(tokVariantEnd)
+		case r == ':':
+			l.emit(tokColon)
+		case r == ',':
+			l.emit(tokComma)
+		case r == '\'' || r == '"':
+			l.backup()
+			return varLexString
+		case r == '@':
+			l.backup()
+			return varLexType
+		case unicode.IsSpace(r):
+			l.ignore()
+		case unicode.IsNumber(r) || r == '+' || r == '-':
+			l.backup()
+			return varLexNumber
+		case r == 'b':
+			pos := l.start
+			if n := l.peek(); n == '"' || n == '\'' {
+				return varLexByteString
+			}
+			// not a byte string; try to parse it as a type or bool below
+			l.pos = pos + 1
+			l.width = 1
+			fallthrough
+		default:
+			// either a bool or a type. Try bools first.
+			l.backup()
+			if l.pos+4 <= len(l.input) {
+				if l.input[l.pos:l.pos+4] == "true" {
+					l.pos += 4
+					l.emit(tokBool)
+					continue
+				}
+			}
+			if l.pos+5 <= len(l.input) {
+				if l.input[l.pos:l.pos+5] == "false" {
+					l.pos += 5
+					l.emit(tokBool)
+					continue
+				}
+			}
+			// must be a type.
+			return varLexType
+		}
+	}
+}
+
+var varTypeMap = map[string]string{
+	"boolean":    "b",
+	"byte":       "y",
+	"int16":      "n",
+	"uint16":     "q",
+	"int32":      "i",
+	"uint32":     "u",
+	"int64":      "x",
+	"uint64":     "t",
+	"double":     "f",
+	"string":     "s",
+	"objectpath": "o",
+	"signature":  "g",
+}
+
+func varLexByteString(l *varLexer) lexState {
+	q := l.next()
+Loop:
+	for {
+		switch l.next() {
+		case '\\':
+			if r := l.next(); r != -1 {
+				break
+			}
+			fallthrough
+		case -1:
+			return l.errorf("unterminated bytestring")
+		case q:
+			break Loop
+		}
+	}
+	l.emit(tokByteString)
+	return varLexNormal
+}
+
+func varLexNumber(l *varLexer) lexState {
+	l.accept("+-")
+	digits := "0123456789"
+	if l.accept("0") {
+		if l.accept("x") {
+			digits = "0123456789abcdefABCDEF"
+		} else {
+			digits = "01234567"
+		}
+	}
+	for strings.ContainsRune(digits, l.next()) {
+	}
+	l.backup()
+	if l.accept(".") {
+		for strings.ContainsRune(digits, l.next()) {
+		}
+		l.backup()
+	}
+	if l.accept("eE") {
+		l.accept("+-")
+		for strings.ContainsRune("0123456789", l.next()) {
+		}
+		l.backup()
+	}
+	if r := l.peek(); unicode.IsLetter(r) {
+		l.next()
+		return l.errorf("bad number syntax: %q", l.input[l.start:l.pos])
+	}
+	l.emit(tokNumber)
+	return varLexNormal
+}
+
+func varLexString(l *varLexer) lexState {
+	q := l.next()
+Loop:
+	for {
+		switch l.next() {
+		case '\\':
+			if r := l.next(); r != -1 {
+				break
+			}
+			fallthrough
+		case -1:
+			return l.errorf("unterminated string")
+		case q:
+			break Loop
+		}
+	}
+	l.emit(tokString)
+	return varLexNormal
+}
+
+func varLexType(l *varLexer) lexState {
+	at := l.accept("@")
+	for {
+		r := l.next()
+		if r == -1 {
+			break
+		}
+		if unicode.IsSpace(r) {
+			l.backup()
+			break
+		}
+	}
+	if at {
+		if _, err := ParseSignature(l.input[l.start+1 : l.pos]); err != nil {
+			return l.errorf("%s", err)
+		}
+	} else {
+		if _, ok := varTypeMap[l.input[l.start:l.pos]]; ok {
+			l.emit(tokType)
+			return varLexNormal
+		}
+		return l.errorf("unrecognized type %q", l.input[l.start:l.pos])
+	}
+	l.emit(tokType)
+	return varLexNormal
+}

--- a/vendor/github.com/godbus/dbus/v5/variant_parser.go
+++ b/vendor/github.com/godbus/dbus/v5/variant_parser.go
@@ -1,0 +1,817 @@
+package dbus
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+type varParser struct {
+	tokens []varToken
+	i      int
+}
+
+func (p *varParser) backup() {
+	p.i--
+}
+
+func (p *varParser) next() varToken {
+	if p.i < len(p.tokens) {
+		t := p.tokens[p.i]
+		p.i++
+		return t
+	}
+	return varToken{typ: tokEOF}
+}
+
+type varNode interface {
+	Infer() (Signature, error)
+	String() string
+	Sigs() sigSet
+	Value(Signature) (interface{}, error)
+}
+
+func varMakeNode(p *varParser) (varNode, error) {
+	var sig Signature
+
+	for {
+		t := p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokNumber:
+			return varMakeNumNode(t, sig)
+		case tokString:
+			return varMakeStringNode(t, sig)
+		case tokBool:
+			if sig.str != "" && sig.str != "b" {
+				return nil, varTypeError{t.val, sig}
+			}
+			b, err := strconv.ParseBool(t.val)
+			if err != nil {
+				return nil, err
+			}
+			return boolNode(b), nil
+		case tokArrayStart:
+			return varMakeArrayNode(p, sig)
+		case tokVariantStart:
+			return varMakeVariantNode(p, sig)
+		case tokDictStart:
+			return varMakeDictNode(p, sig)
+		case tokType:
+			if sig.str != "" {
+				return nil, errors.New("unexpected type annotation")
+			}
+			if t.val[0] == '@' {
+				sig.str = t.val[1:]
+			} else {
+				sig.str = varTypeMap[t.val]
+			}
+		case tokByteString:
+			if sig.str != "" && sig.str != "ay" {
+				return nil, varTypeError{t.val, sig}
+			}
+			b, err := varParseByteString(t.val)
+			if err != nil {
+				return nil, err
+			}
+			return byteStringNode(b), nil
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+	}
+}
+
+type varTypeError struct {
+	val string
+	sig Signature
+}
+
+func (e varTypeError) Error() string {
+	return fmt.Sprintf("dbus: can't parse %q as type %q", e.val, e.sig.str)
+}
+
+type sigSet map[Signature]bool
+
+func (s sigSet) Empty() bool {
+	return len(s) == 0
+}
+
+func (s sigSet) Intersect(s2 sigSet) sigSet {
+	r := make(sigSet)
+	for k := range s {
+		if s2[k] {
+			r[k] = true
+		}
+	}
+	return r
+}
+
+func (s sigSet) Single() (Signature, bool) {
+	if len(s) == 1 {
+		for k := range s {
+			return k, true
+		}
+	}
+	return Signature{}, false
+}
+
+func (s sigSet) ToArray() sigSet {
+	r := make(sigSet, len(s))
+	for k := range s {
+		r[Signature{"a" + k.str}] = true
+	}
+	return r
+}
+
+type numNode struct {
+	sig Signature
+	str string
+	val interface{}
+}
+
+var numSigSet = sigSet{
+	Signature{"y"}: true,
+	Signature{"n"}: true,
+	Signature{"q"}: true,
+	Signature{"i"}: true,
+	Signature{"u"}: true,
+	Signature{"x"}: true,
+	Signature{"t"}: true,
+	Signature{"d"}: true,
+}
+
+func (n numNode) Infer() (Signature, error) {
+	if strings.ContainsAny(n.str, ".e") {
+		return Signature{"d"}, nil
+	}
+	return Signature{"i"}, nil
+}
+
+func (n numNode) String() string {
+	return n.str
+}
+
+func (n numNode) Sigs() sigSet {
+	if n.sig.str != "" {
+		return sigSet{n.sig: true}
+	}
+	if strings.ContainsAny(n.str, ".e") {
+		return sigSet{Signature{"d"}: true}
+	}
+	return numSigSet
+}
+
+func (n numNode) Value(sig Signature) (interface{}, error) {
+	if n.sig.str != "" && n.sig != sig {
+		return nil, varTypeError{n.str, sig}
+	}
+	if n.val != nil {
+		return n.val, nil
+	}
+	return varNumAs(n.str, sig)
+}
+
+func varMakeNumNode(tok varToken, sig Signature) (varNode, error) {
+	if sig.str == "" {
+		return numNode{str: tok.val}, nil
+	}
+	num, err := varNumAs(tok.val, sig)
+	if err != nil {
+		return nil, err
+	}
+	return numNode{sig: sig, val: num}, nil
+}
+
+func varNumAs(s string, sig Signature) (interface{}, error) {
+	isUnsigned := false
+	size := 32
+	switch sig.str {
+	case "n":
+		size = 16
+	case "i":
+	case "x":
+		size = 64
+	case "y":
+		size = 8
+		isUnsigned = true
+	case "q":
+		size = 16
+		isUnsigned = true
+	case "u":
+		isUnsigned = true
+	case "t":
+		size = 64
+		isUnsigned = true
+	case "d":
+		d, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, err
+		}
+		return d, nil
+	default:
+		return nil, varTypeError{s, sig}
+	}
+	base := 10
+	if strings.HasPrefix(s, "0x") {
+		base = 16
+		s = s[2:]
+	}
+	if strings.HasPrefix(s, "0") && len(s) != 1 {
+		base = 8
+		s = s[1:]
+	}
+	if isUnsigned {
+		i, err := strconv.ParseUint(s, base, size)
+		if err != nil {
+			return nil, err
+		}
+		var v interface{} = i
+		switch sig.str {
+		case "y":
+			v = byte(i)
+		case "q":
+			v = uint16(i)
+		case "u":
+			v = uint32(i)
+		}
+		return v, nil
+	}
+	i, err := strconv.ParseInt(s, base, size)
+	if err != nil {
+		return nil, err
+	}
+	var v interface{} = i
+	switch sig.str {
+	case "n":
+		v = int16(i)
+	case "i":
+		v = int32(i)
+	}
+	return v, nil
+}
+
+type stringNode struct {
+	sig Signature
+	str string      // parsed
+	val interface{} // has correct type
+}
+
+var stringSigSet = sigSet{
+	Signature{"s"}: true,
+	Signature{"g"}: true,
+	Signature{"o"}: true,
+}
+
+func (n stringNode) Infer() (Signature, error) {
+	return Signature{"s"}, nil
+}
+
+func (n stringNode) String() string {
+	return n.str
+}
+
+func (n stringNode) Sigs() sigSet {
+	if n.sig.str != "" {
+		return sigSet{n.sig: true}
+	}
+	return stringSigSet
+}
+
+func (n stringNode) Value(sig Signature) (interface{}, error) {
+	if n.sig.str != "" && n.sig != sig {
+		return nil, varTypeError{n.str, sig}
+	}
+	if n.val != nil {
+		return n.val, nil
+	}
+	switch {
+	case sig.str == "g":
+		return Signature{n.str}, nil
+	case sig.str == "o":
+		return ObjectPath(n.str), nil
+	case sig.str == "s":
+		return n.str, nil
+	default:
+		return nil, varTypeError{n.str, sig}
+	}
+}
+
+func varMakeStringNode(tok varToken, sig Signature) (varNode, error) {
+	if sig.str != "" && sig.str != "s" && sig.str != "g" && sig.str != "o" {
+		return nil, fmt.Errorf("invalid type %q for string", sig.str)
+	}
+	s, err := varParseString(tok.val)
+	if err != nil {
+		return nil, err
+	}
+	n := stringNode{str: s}
+	if sig.str == "" {
+		return stringNode{str: s}, nil
+	}
+	n.sig = sig
+	switch sig.str {
+	case "o":
+		n.val = ObjectPath(s)
+	case "g":
+		n.val = Signature{s}
+	case "s":
+		n.val = s
+	}
+	return n, nil
+}
+
+func varParseString(s string) (string, error) {
+	// quotes are guaranteed to be there
+	s = s[1 : len(s)-1]
+	buf := new(bytes.Buffer)
+	for len(s) != 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			return "", errors.New("invalid UTF-8")
+		}
+		s = s[size:]
+		if r != '\\' {
+			buf.WriteRune(r)
+			continue
+		}
+		r, size = utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			return "", errors.New("invalid UTF-8")
+		}
+		s = s[size:]
+		switch r {
+		case 'a':
+			buf.WriteRune(0x7)
+		case 'b':
+			buf.WriteRune(0x8)
+		case 'f':
+			buf.WriteRune(0xc)
+		case 'n':
+			buf.WriteRune('\n')
+		case 'r':
+			buf.WriteRune('\r')
+		case 't':
+			buf.WriteRune('\t')
+		case '\n':
+		case 'u':
+			if len(s) < 4 {
+				return "", errors.New("short unicode escape")
+			}
+			r, err := strconv.ParseUint(s[:4], 16, 32)
+			if err != nil {
+				return "", err
+			}
+			buf.WriteRune(rune(r))
+			s = s[4:]
+		case 'U':
+			if len(s) < 8 {
+				return "", errors.New("short unicode escape")
+			}
+			r, err := strconv.ParseUint(s[:8], 16, 32)
+			if err != nil {
+				return "", err
+			}
+			buf.WriteRune(rune(r))
+			s = s[8:]
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String(), nil
+}
+
+var boolSigSet = sigSet{Signature{"b"}: true}
+
+type boolNode bool
+
+func (boolNode) Infer() (Signature, error) {
+	return Signature{"b"}, nil
+}
+
+func (b boolNode) String() string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func (boolNode) Sigs() sigSet {
+	return boolSigSet
+}
+
+func (b boolNode) Value(sig Signature) (interface{}, error) {
+	if sig.str != "b" {
+		return nil, varTypeError{b.String(), sig}
+	}
+	return bool(b), nil
+}
+
+type arrayNode struct {
+	set      sigSet
+	children []varNode
+	val      interface{}
+}
+
+func (n arrayNode) Infer() (Signature, error) {
+	for _, v := range n.children {
+		csig, err := varInfer(v)
+		if err != nil {
+			continue
+		}
+		return Signature{"a" + csig.str}, nil
+	}
+	return Signature{}, fmt.Errorf("can't infer type for %q", n.String())
+}
+
+func (n arrayNode) String() string {
+	s := "["
+	for i, v := range n.children {
+		s += v.String()
+		if i != len(n.children)-1 {
+			s += ", "
+		}
+	}
+	return s + "]"
+}
+
+func (n arrayNode) Sigs() sigSet {
+	return n.set
+}
+
+func (n arrayNode) Value(sig Signature) (interface{}, error) {
+	if n.set.Empty() {
+		// no type information whatsoever, so this must be an empty slice
+		return reflect.MakeSlice(typeFor(sig.str), 0, 0).Interface(), nil
+	}
+	if !n.set[sig] {
+		return nil, varTypeError{n.String(), sig}
+	}
+	s := reflect.MakeSlice(typeFor(sig.str), len(n.children), len(n.children))
+	for i, v := range n.children {
+		rv, err := v.Value(Signature{sig.str[1:]})
+		if err != nil {
+			return nil, err
+		}
+		s.Index(i).Set(reflect.ValueOf(rv))
+	}
+	return s.Interface(), nil
+}
+
+func varMakeArrayNode(p *varParser, sig Signature) (varNode, error) {
+	var n arrayNode
+	if sig.str != "" {
+		n.set = sigSet{sig: true}
+	}
+	if t := p.next(); t.typ == tokArrayEnd {
+		return n, nil
+	} else {
+		p.backup()
+	}
+Loop:
+	for {
+		t := p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		}
+		p.backup()
+		cn, err := varMakeNode(p)
+		if err != nil {
+			return nil, err
+		}
+		if cset := cn.Sigs(); !cset.Empty() {
+			if n.set.Empty() {
+				n.set = cset.ToArray()
+			} else {
+				nset := cset.ToArray().Intersect(n.set)
+				if nset.Empty() {
+					return nil, fmt.Errorf("can't parse %q with given type information", cn.String())
+				}
+				n.set = nset
+			}
+		}
+		n.children = append(n.children, cn)
+		switch t := p.next(); t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokArrayEnd:
+			break Loop
+		case tokComma:
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+	}
+	return n, nil
+}
+
+type variantNode struct {
+	n varNode
+}
+
+var variantSet = sigSet{
+	Signature{"v"}: true,
+}
+
+func (variantNode) Infer() (Signature, error) {
+	return Signature{"v"}, nil
+}
+
+func (n variantNode) String() string {
+	return "<" + n.n.String() + ">"
+}
+
+func (variantNode) Sigs() sigSet {
+	return variantSet
+}
+
+func (n variantNode) Value(sig Signature) (interface{}, error) {
+	if sig.str != "v" {
+		return nil, varTypeError{n.String(), sig}
+	}
+	sig, err := varInfer(n.n)
+	if err != nil {
+		return nil, err
+	}
+	v, err := n.n.Value(sig)
+	if err != nil {
+		return nil, err
+	}
+	return MakeVariant(v), nil
+}
+
+func varMakeVariantNode(p *varParser, sig Signature) (varNode, error) {
+	n, err := varMakeNode(p)
+	if err != nil {
+		return nil, err
+	}
+	if t := p.next(); t.typ != tokVariantEnd {
+		return nil, fmt.Errorf("unexpected %q", t.val)
+	}
+	vn := variantNode{n}
+	if sig.str != "" && sig.str != "v" {
+		return nil, varTypeError{vn.String(), sig}
+	}
+	return variantNode{n}, nil
+}
+
+type dictEntry struct {
+	key, val varNode
+}
+
+type dictNode struct {
+	kset, vset sigSet
+	children   []dictEntry
+	val        interface{}
+}
+
+func (n dictNode) Infer() (Signature, error) {
+	for _, v := range n.children {
+		ksig, err := varInfer(v.key)
+		if err != nil {
+			continue
+		}
+		vsig, err := varInfer(v.val)
+		if err != nil {
+			continue
+		}
+		return Signature{"a{" + ksig.str + vsig.str + "}"}, nil
+	}
+	return Signature{}, fmt.Errorf("can't infer type for %q", n.String())
+}
+
+func (n dictNode) String() string {
+	s := "{"
+	for i, v := range n.children {
+		s += v.key.String() + ": " + v.val.String()
+		if i != len(n.children)-1 {
+			s += ", "
+		}
+	}
+	return s + "}"
+}
+
+func (n dictNode) Sigs() sigSet {
+	r := sigSet{}
+	for k := range n.kset {
+		for v := range n.vset {
+			sig := "a{" + k.str + v.str + "}"
+			r[Signature{sig}] = true
+		}
+	}
+	return r
+}
+
+func (n dictNode) Value(sig Signature) (interface{}, error) {
+	set := n.Sigs()
+	if set.Empty() {
+		// no type information -> empty dict
+		return reflect.MakeMap(typeFor(sig.str)).Interface(), nil
+	}
+	if !set[sig] {
+		return nil, varTypeError{n.String(), sig}
+	}
+	m := reflect.MakeMap(typeFor(sig.str))
+	ksig := Signature{sig.str[2:3]}
+	vsig := Signature{sig.str[3 : len(sig.str)-1]}
+	for _, v := range n.children {
+		kv, err := v.key.Value(ksig)
+		if err != nil {
+			return nil, err
+		}
+		vv, err := v.val.Value(vsig)
+		if err != nil {
+			return nil, err
+		}
+		m.SetMapIndex(reflect.ValueOf(kv), reflect.ValueOf(vv))
+	}
+	return m.Interface(), nil
+}
+
+func varMakeDictNode(p *varParser, sig Signature) (varNode, error) {
+	var n dictNode
+
+	if sig.str != "" {
+		if len(sig.str) < 5 {
+			return nil, fmt.Errorf("invalid signature %q for dict type", sig)
+		}
+		ksig := Signature{string(sig.str[2])}
+		vsig := Signature{sig.str[3 : len(sig.str)-1]}
+		n.kset = sigSet{ksig: true}
+		n.vset = sigSet{vsig: true}
+	}
+	if t := p.next(); t.typ == tokDictEnd {
+		return n, nil
+	} else {
+		p.backup()
+	}
+Loop:
+	for {
+		t := p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		}
+		p.backup()
+		kn, err := varMakeNode(p)
+		if err != nil {
+			return nil, err
+		}
+		if kset := kn.Sigs(); !kset.Empty() {
+			if n.kset.Empty() {
+				n.kset = kset
+			} else {
+				n.kset = kset.Intersect(n.kset)
+				if n.kset.Empty() {
+					return nil, fmt.Errorf("can't parse %q with given type information", kn.String())
+				}
+			}
+		}
+		t = p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokColon:
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+		t = p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		}
+		p.backup()
+		vn, err := varMakeNode(p)
+		if err != nil {
+			return nil, err
+		}
+		if vset := vn.Sigs(); !vset.Empty() {
+			if n.vset.Empty() {
+				n.vset = vset
+			} else {
+				n.vset = n.vset.Intersect(vset)
+				if n.vset.Empty() {
+					return nil, fmt.Errorf("can't parse %q with given type information", vn.String())
+				}
+			}
+		}
+		n.children = append(n.children, dictEntry{kn, vn})
+		t = p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokDictEnd:
+			break Loop
+		case tokComma:
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+	}
+	return n, nil
+}
+
+type byteStringNode []byte
+
+var byteStringSet = sigSet{
+	Signature{"ay"}: true,
+}
+
+func (byteStringNode) Infer() (Signature, error) {
+	return Signature{"ay"}, nil
+}
+
+func (b byteStringNode) String() string {
+	return string(b)
+}
+
+func (b byteStringNode) Sigs() sigSet {
+	return byteStringSet
+}
+
+func (b byteStringNode) Value(sig Signature) (interface{}, error) {
+	if sig.str != "ay" {
+		return nil, varTypeError{b.String(), sig}
+	}
+	return []byte(b), nil
+}
+
+func varParseByteString(s string) ([]byte, error) {
+	// quotes and b at start are guaranteed to be there
+	b := make([]byte, 0, 1)
+	s = s[2 : len(s)-1]
+	for len(s) != 0 {
+		c := s[0]
+		s = s[1:]
+		if c != '\\' {
+			b = append(b, c)
+			continue
+		}
+		c = s[0]
+		s = s[1:]
+		switch c {
+		case 'a':
+			b = append(b, 0x7)
+		case 'b':
+			b = append(b, 0x8)
+		case 'f':
+			b = append(b, 0xc)
+		case 'n':
+			b = append(b, '\n')
+		case 'r':
+			b = append(b, '\r')
+		case 't':
+			b = append(b, '\t')
+		case 'x':
+			if len(s) < 2 {
+				return nil, errors.New("short escape")
+			}
+			n, err := strconv.ParseUint(s[:2], 16, 8)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, byte(n))
+			s = s[2:]
+		case '0':
+			if len(s) < 3 {
+				return nil, errors.New("short escape")
+			}
+			n, err := strconv.ParseUint(s[:3], 8, 8)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, byte(n))
+			s = s[3:]
+		default:
+			b = append(b, c)
+		}
+	}
+	return append(b, 0), nil
+}
+
+func varInfer(n varNode) (Signature, error) {
+	if sig, ok := n.Sigs().Single(); ok {
+		return sig, nil
+	}
+	return n.Infer()
+}

--- a/vendor/github.com/moby/sys/userns/LICENSE
+++ b/vendor/github.com/moby/sys/userns/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/moby/sys/userns/userns.go
+++ b/vendor/github.com/moby/sys/userns/userns.go
@@ -1,0 +1,16 @@
+// Package userns provides utilities to detect whether we are currently running
+// in a Linux user namespace.
+//
+// This code was migrated from [libcontainer/runc], which based its implementation
+// on code from [lcx/incus].
+//
+// [libcontainer/runc]: https://github.com/opencontainers/runc/blob/3778ae603c706494fd1e2c2faf83b406e38d687d/libcontainer/userns/userns_linux.go#L12-L49
+// [lcx/incus]: https://github.com/lxc/incus/blob/e45085dd42f826b3c8c3228e9733c0b6f998eafe/shared/util.go#L678-L700
+package userns
+
+// RunningInUserNS detects whether we are currently running in a Linux
+// user namespace and memoizes the result. It returns false on non-Linux
+// platforms.
+func RunningInUserNS() bool {
+	return inUserNS()
+}

--- a/vendor/github.com/moby/sys/userns/userns_linux.go
+++ b/vendor/github.com/moby/sys/userns/userns_linux.go
@@ -1,0 +1,53 @@
+package userns
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sync"
+)
+
+var inUserNS = sync.OnceValue(runningInUserNS)
+
+// runningInUserNS detects whether we are currently running in a user namespace.
+//
+// This code was migrated from [libcontainer/runc] and based on an implementation
+// from [lcx/incus].
+//
+// [libcontainer/runc]: https://github.com/opencontainers/runc/blob/3778ae603c706494fd1e2c2faf83b406e38d687d/libcontainer/userns/userns_linux.go#L12-L49
+// [lcx/incus]: https://github.com/lxc/incus/blob/e45085dd42f826b3c8c3228e9733c0b6f998eafe/shared/util.go#L678-L700
+func runningInUserNS() bool {
+	file, err := os.Open("/proc/self/uid_map")
+	if err != nil {
+		// This kernel-provided file only exists if user namespaces are supported.
+		return false
+	}
+	defer file.Close()
+
+	buf := bufio.NewReader(file)
+	l, _, err := buf.ReadLine()
+	if err != nil {
+		return false
+	}
+
+	return uidMapInUserNS(string(l))
+}
+
+func uidMapInUserNS(uidMap string) bool {
+	if uidMap == "" {
+		// File exist but empty (the initial state when userns is created,
+		// see user_namespaces(7)).
+		return true
+	}
+
+	var a, b, c int64
+	if _, err := fmt.Sscanf(uidMap, "%d %d %d", &a, &b, &c); err != nil {
+		// Assume we are in a regular, non user namespace.
+		return false
+	}
+
+	// As per user_namespaces(7), /proc/self/uid_map of
+	// the initial user namespace shows 0 0 4294967295.
+	initNS := a == 0 && b == 0 && c == 4294967295
+	return !initNS
+}

--- a/vendor/github.com/moby/sys/userns/userns_linux_fuzzer.go
+++ b/vendor/github.com/moby/sys/userns/userns_linux_fuzzer.go
@@ -1,0 +1,8 @@
+//go:build linux && gofuzz
+
+package userns
+
+func FuzzUIDMap(uidmap []byte) int {
+	_ = uidMapInUserNS(string(uidmap))
+	return 1
+}

--- a/vendor/github.com/moby/sys/userns/userns_unsupported.go
+++ b/vendor/github.com/moby/sys/userns/userns_unsupported.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package userns
+
+// inUserNS is a stub for non-Linux systems. Always returns false.
+func inUserNS() bool { return false }

--- a/vendor/github.com/opencontainers/cgroups/.golangci-extra.yml
+++ b/vendor/github.com/opencontainers/cgroups/.golangci-extra.yml
@@ -1,0 +1,29 @@
+# This is golangci-lint config file which is used to check NEW code in
+# github PRs only (see lint-extra in .github/workflows/validate.yml).
+#
+# For the default linter config, see .golangci.yml. This config should
+# only enable additional linters and/or linter settings not enabled
+# in the default config.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - godot
+    - revive
+    - staticcheck
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
+  exclusions:
+    generated: strict
+    rules:
+      # Legacy names we can't change without breaking compatibility.
+      - path: stats.go
+        text: "(type|struct field) (CpuUsage|CpuStats) should be "
+      - path: config_linux.go
+        text: "struct field (CpuShares|CpuQuota|CpuBurst|CpuPeriod|CpuRtRuntime|CpuRtPeriod|CpuWeight) should be "
+      - path: devices/config/device.go
+        text: "struct field (Uid|Gid) should be "

--- a/vendor/github.com/opencontainers/cgroups/.golangci.yml
+++ b/vendor/github.com/opencontainers/cgroups/.golangci.yml
@@ -1,0 +1,31 @@
+# For documentation, see https://golangci-lint.run/usage/configuration/
+version: "2"
+
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: strict
+
+linters:
+  enable:
+    - errorlint
+    - nolintlint
+    - unconvert
+    - unparam
+  settings:
+    govet:
+      enable:
+        - nilness
+    staticcheck:
+      checks:
+        - all
+        - -ST1000 # https://staticcheck.dev/docs/checks/#ST1000 Incorrect or missing package comment.
+        - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier.
+        - -ST1005 # https://staticcheck.dev/docs/checks/#ST1005 Incorrectly formatted error string.
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - std-error-handling

--- a/vendor/github.com/opencontainers/cgroups/CODEOWNERS
+++ b/vendor/github.com/opencontainers/cgroups/CODEOWNERS
@@ -1,0 +1,1 @@
+* @opencontainers/cgroups-maintainers

--- a/vendor/github.com/opencontainers/cgroups/CONTRIBUTING.md
+++ b/vendor/github.com/opencontainers/cgroups/CONTRIBUTING.md
@@ -1,0 +1,150 @@
+# Contribution Guidelines
+
+Development happens on GitHub.
+Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
+
+The content of this repository is licensed under the [Apache License, Version 2.0](LICENSE).
+
+## Code of Conduct
+
+Participation in the Open Container community is governed by [Open Container Code of Conduct][code-of-conduct].
+
+## Meetings
+
+The contributors and maintainers of all OCI projects have monthly meetings at 2:00 PM (USA Pacific) on the first Wednesday of every month.
+There is an [iCalendar][rfc5545] format for the meetings [here][meeting.ics].
+Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1 415 968 0849 (no PIN needed).
+An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes from past meetings are archived [here][minutes].
+
+## Mailing list
+
+You can subscribe and browse the mailing list on [Google Groups][mailing-list].
+
+## IRC
+
+OCI discussion happens on #opencontainers on [Freenode][] ([logs][irc-logs]).
+
+## Git
+
+### Security issues
+
+If you are reporting a security issue, do not create an issue or file a pull
+request on GitHub. Instead, disclose the issue responsibly by sending an email
+to security@opencontainers.org (which is inhabited only by the maintainers of
+the various OCI projects).
+
+### Pull requests are always welcome
+
+We are always thrilled to receive pull requests, and do our best to
+process them as fast as possible. Not sure if that typo is worth a pull
+request? Do it! We will appreciate it.
+
+If your pull request is not accepted on the first try, don't be
+discouraged! If there's a problem with the implementation, hopefully you
+received feedback on what to improve.
+
+We're trying very hard to keep the project lean and focused. We don't want it
+to do everything for everybody. This means that we might decide against
+incorporating a new feature.
+
+### Conventions
+
+Fork the repo and make changes on your fork in a feature branch.
+For larger bugs and enhancements, consider filing a leader issue or mailing-list thread for discussion that is independent of the implementation.
+Small changes or changes that have been discussed on the [project mailing list](#mailing-list) may be submitted without a leader issue.
+
+If the project has a test suite, submit unit tests for your changes. Take a
+look at existing tests for inspiration. Run the full test suite on your branch
+before submitting a pull request.
+
+Update the documentation when creating or modifying features. Test
+your documentation changes for clarity, concision, and correctness, as
+well as a clean documentation build.
+
+Pull requests descriptions should be as clear as possible and include a
+reference to all the issues that they address.
+
+Commit messages must start with a capitalized and short summary
+written in the imperative, followed by an optional, more detailed
+explanatory text which is separated from the summary by an empty line.
+
+Code review comments may be added to your pull request. Discuss, then make the
+suggested modifications and push additional commits to your feature branch. Be
+sure to post a comment after pushing. The new commits will show up in the pull
+request automatically, but the reviewers will not be notified unless you
+comment.
+
+Before the pull request is merged, make sure that you squash your commits into
+logical units of work using `git rebase -i` and `git push -f`. After every
+commit the test suite (if any) should be passing. Include documentation changes
+in the same commit so that a revert would remove all traces of the feature or
+fix.
+
+Commits that fix or close an issue should include a reference like `Closes #XXX`
+or `Fixes #XXX`, which will automatically close the issue when merged.
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the
+patch, which certifies that you wrote it or otherwise have the right to
+pass it on as an open-source patch.  The rules are pretty simple: if you
+can certify the below (from [developercertificate.org][]):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.
+
+[code-of-conduct]: https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md
+[developercertificate.org]: http://developercertificate.org/
+[Freenode]: https://freenode.net/
+[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[mailing-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
+[meeting.ics]: https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/
+[rfc5545]: https://tools.ietf.org/html/rfc5545
+[UberConference]: https://www.uberconference.com/opencontainers

--- a/vendor/github.com/opencontainers/cgroups/GOVERNANCE.md
+++ b/vendor/github.com/opencontainers/cgroups/GOVERNANCE.md
@@ -1,0 +1,63 @@
+# Project governance
+
+The [OCI charter][charter] §5.b.viii tasks an OCI Project's maintainers (listed in the repository's MAINTAINERS file and sometimes referred to as "the TDC", [§5.e][charter]) with:
+
+> Creating, maintaining and enforcing governance guidelines for the TDC, approved by the maintainers, and which shall be posted visibly for the TDC.
+
+This section describes generic rules and procedures for fulfilling that mandate.
+
+## Proposing a motion
+
+A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with another maintainer as a co-sponsor.
+
+## Voting
+
+Voting on a proposed motion SHOULD happen on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with maintainers posting LGTM or REJECT.
+Maintainers MAY also explicitly not vote by posting ABSTAIN (which is useful to revert a previous vote).
+Maintainers MAY post multiple times (e.g. as they revise their position based on feedback), but only their final post counts in the tally.
+A proposed motion is adopted if two-thirds of votes cast, a quorum having voted, are in favor of the release.
+
+Voting SHOULD remain open for a week to collect feedback from the wider community and allow the maintainers to digest the proposed motion.
+Under exceptional conditions (e.g. non-major security fix releases) proposals which reach quorum with unanimous support MAY be adopted earlier.
+
+A maintainer MAY choose to reply with REJECT.
+A maintainer posting a REJECT MUST include a list of concerns or links to written documentation for those concerns (e.g. GitHub issues or mailing-list threads).
+The maintainers SHOULD try to resolve the concerns and wait for the rejecting maintainer to change their opinion to LGTM.
+However, a motion MAY be adopted with REJECTs, as outlined in the previous paragraphs.
+
+## Quorum
+
+A quorum is established when at least two-thirds of maintainers have voted.
+
+For projects that are not specifications, a [motion to release](#release-approval) MAY be adopted if the tally is at least three LGTMs and no REJECTs, even if three votes does not meet the usual two-thirds quorum.
+
+## Amendments
+
+The [project governance](#project-governance) rules and procedures MAY be amended or replaced using the procedures themselves.
+The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (go-digest, image-spec, image-tools, runC, runtime-spec, runtime-tools, and selinux).
+
+## Subject templates
+
+Maintainers are busy and get lots of email.
+To make project proposals recognizable, proposed motions SHOULD use the following subject templates.
+
+### Proposing a motion
+
+> [{project} VOTE]: {motion description} (closes {end of voting window})
+
+For example:
+
+> [runtime-spec VOTE]: Tag 0647920 as 1.0.0-rc (closes 2016-06-03 20:00 UTC)
+
+### Tallying results
+
+After voting closes, a maintainer SHOULD post a tally to the motion thread with a subject template like:
+
+> [{project} {status}]: {motion description} (+{LGTMs} -{REJECTs} #{ABSTAINs})
+
+Where `{status}` is either `adopted` or `rejected`.
+For example:
+
+> [runtime-spec adopted]: Tag 0647920 as 1.0.0-rc (+6 -0 #3)
+
+[charter]: https://www.opencontainers.org/about/governance

--- a/vendor/github.com/opencontainers/cgroups/MAINTAINERS
+++ b/vendor/github.com/opencontainers/cgroups/MAINTAINERS
@@ -1,0 +1,8 @@
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (@AkihiroSuda)
+Aleksa Sarai <cyphar@cyphar.com> (@cyphar)
+Kir Kolyshkin <kolyshkin@gmail.com> (@kolyshkin)
+Mrunal Patel <mpatel@redhat.com> (@mrunalp)
+Sebastiaan van Stijn <github@gone.nl> (@thaJeztah)
+Odin Ugedal <odin@uged.al> (@odinuge)
+Peter Hunt <pehunt@redhat.com> (@haircommander)
+Davanum Srinivas <davanum@gmail.com> (@dims)

--- a/vendor/github.com/opencontainers/cgroups/MAINTAINERS_GUIDE.md
+++ b/vendor/github.com/opencontainers/cgroups/MAINTAINERS_GUIDE.md
@@ -1,0 +1,92 @@
+## Introduction
+
+Dear maintainer. Thank you for investing the time and energy to help
+make this project as useful as possible. Maintaining a project is difficult,
+sometimes unrewarding work.  Sure, you will get to contribute cool
+features to the project. But most of your time will be spent reviewing,
+cleaning up, documenting, answering questions, justifying design
+decisions - while everyone has all the fun! But remember - the quality
+of the maintainers work is what distinguishes the good projects from the
+great.  So please be proud of your work, even the unglamourous parts,
+and encourage a culture of appreciation and respect for *every* aspect
+of improving the project - not just the hot new features.
+
+This document is a manual for maintainers old and new. It explains what
+is expected of maintainers, how they should work, and what tools are
+available to them.
+
+This is a living document - if you see something out of date or missing,
+speak up!
+
+## What are a maintainer's responsibilities?
+
+It is every maintainer's responsibility to:
+
+* Expose a clear roadmap for improving their component.
+* Deliver prompt feedback and decisions on pull requests.
+* Be available to anyone with questions, bug reports, criticism etc. on their component.
+  This includes IRC and GitHub issues and pull requests.
+* Make sure their component respects the philosophy, design and roadmap of the project.
+
+## How are decisions made?
+
+This project is an open-source project with an open design philosophy. This
+means that the repository is the source of truth for EVERY aspect of the
+project, including its philosophy, design, roadmap and APIs. *If it's
+part of the project, it's in the repo. It's in the repo, it's part of
+the project.*
+
+As a result, all decisions can be expressed as changes to the
+repository. An implementation change is a change to the source code. An
+API change is a change to the API specification. A philosophy change is
+a change to the philosophy manifesto. And so on.
+
+All decisions affecting this project, big and small, follow the same procedure:
+
+1. Discuss a proposal on the [mailing list](CONTRIBUTING.md#mailing-list).
+   Anyone can do this.
+2. Open a pull request.
+   Anyone can do this.
+3. Discuss the pull request.
+   Anyone can do this.
+4. Endorse (`LGTM`) or oppose (`Rejected`) the pull request.
+   The relevant maintainers do this (see below [Who decides what?](#who-decides-what)).
+   Changes that affect project management (changing policy, cutting releases, etc.) are [proposed and voted on the mailing list](GOVERNANCE.md).
+5. Merge or close the pull request.
+   The relevant maintainers do this.
+
+### I'm a maintainer, should I make pull requests too?
+
+Yes. Nobody should ever push to master directly. All changes should be
+made through a pull request.
+
+## Who decides what?
+
+All decisions are pull requests, and the relevant maintainers make
+decisions by accepting or refusing the pull request. Review and acceptance
+by anyone is denoted by adding a comment in the pull request: `LGTM`.
+However, only currently listed `MAINTAINERS` are counted towards the required
+two LGTMs. In addition, if a maintainer has created a pull request, they cannot
+count toward the two LGTM rule (to ensure equal amounts of review for every pull
+request, no matter who wrote it).
+
+Overall the maintainer system works because of mutual respect.
+The maintainers trust one another to act in the best interests of the project.
+Sometimes maintainers can disagree and this is part of a healthy project to represent the points of view of various people.
+In the case where maintainers cannot find agreement on a specific change, maintainers should use the [governance procedure](GOVERNANCE.md) to attempt to reach a consensus.
+
+### How are maintainers added?
+
+The best maintainers have a vested interest in the project.  Maintainers
+are first and foremost contributors that have shown they are committed to
+the long term success of the project.  Contributors wanting to become
+maintainers are expected to be deeply involved in contributing code,
+pull request review, and triage of issues in the project for more than two months.
+
+Just contributing does not make you a maintainer, it is about building trust with the current maintainers of the project and being a person that they can depend on to act in the best interest of the project.
+The final vote to add a new maintainer should be approved by the [governance procedure](GOVERNANCE.md).
+
+### How are maintainers removed?
+
+When a maintainer is unable to perform the [required duties](#what-are-a-maintainers-responsibilities) they can be removed by the [governance procedure](GOVERNANCE.md).
+Issues related to a maintainer's performance should be discussed with them among the other maintainers so that they are not surprised by a pull request removing them.

--- a/vendor/github.com/opencontainers/cgroups/README.md
+++ b/vendor/github.com/opencontainers/cgroups/README.md
@@ -1,0 +1,11 @@
+# OCI Project Template
+
+Useful boilerplate and organizational information for all OCI projects.
+
+* README (this file)
+* [The Apache License, Version 2.0](LICENSE)
+* [A list of maintainers](MAINTAINERS)
+* [Maintainer guidelines](MAINTAINERS_GUIDE.md)
+* [Contributor guidelines](CONTRIBUTING.md)
+* [Project governance](GOVERNANCE.md)
+* [Release procedures](RELEASES.md)

--- a/vendor/github.com/opencontainers/cgroups/RELEASES.md
+++ b/vendor/github.com/opencontainers/cgroups/RELEASES.md
@@ -1,0 +1,51 @@
+# Releases
+
+The release process hopes to encourage early, consistent consensus-building during project development.
+The mechanisms used are regular community communication on the mailing list about progress, scheduled meetings for issue resolution and release triage, and regularly paced and communicated releases.
+Releases are proposed and adopted or rejected using the usual [project governance](GOVERNANCE.md) rules and procedures.
+
+An anti-pattern that we want to avoid is heavy development or discussions "late cycle" around major releases.
+We want to build a community that is involved and communicates consistently through all releases instead of relying on "silent periods" as a judge of stability.
+
+## Parallel releases
+
+A single project MAY consider several motions to release in parallel.
+However each motion to release after the initial 0.1.0 MUST be based on a previous release that has already landed.
+
+For example, runtime-spec maintainers may propose a v1.0.0-rc2 on the 1st of the month and a v0.9.1 bugfix on the 2nd of the month.
+They may not propose a v1.0.0-rc3 until the v1.0.0-rc2 is accepted (on the 7th if the vote initiated on the 1st passes).
+
+## Specifications
+
+The OCI maintains three categories of projects: specifications, applications, and conformance-testing tools.
+However, specification releases have special restrictions in the [OCI charter][charter]:
+
+* They are the target of backwards compatibility (§7.g), and
+* They are subject to the OFWa patent grant (§8.d and e).
+
+To avoid unfortunate side effects (onerous backwards compatibility requirements or Member resignations), the following additional procedures apply to specification releases:
+
+### Planning a release
+
+Every OCI specification project SHOULD hold meetings that involve maintainers reviewing pull requests, debating outstanding issues, and planning releases.
+This meeting MUST be advertised on the project README and MAY happen on a phone call, video conference, or on IRC.
+Maintainers MUST send updates to the dev@opencontainers.org with results of these meetings.
+
+Before the specification reaches v1.0.0, the meetings SHOULD be weekly.
+Once a specification has reached v1.0.0, the maintainers may alter the cadence, but a meeting MUST be held within four weeks of the previous meeting.
+
+The release plans, corresponding milestones and estimated due dates MUST be published on GitHub (e.g. https://github.com/opencontainers/runtime-spec/milestones).
+GitHub milestones and issues are only used for community organization and all releases MUST follow the [project governance](GOVERNANCE.md) rules and procedures.
+
+### Timelines
+
+Specifications have a variety of different timelines in their lifecycle.
+
+* Pre-v1.0.0 specifications SHOULD release on a monthly cadence to garner feedback.
+* Major specification releases MUST release at least three release candidates spaced a minimum of one week apart.
+  This means a major release like a v1.0.0 or v2.0.0 release will take 1 month at minimum: one week for rc1, one week for rc2, one week for rc3, and one week for the major release itself.
+  Maintainers SHOULD strive to make zero breaking changes during this cycle of release candidates and SHOULD restart the three-candidate count when a breaking change is introduced.
+  For example if a breaking change is introduced in v1.0.0-rc2 then the series would end with v1.0.0-rc4 and v1.0.0.
+* Minor and patch releases SHOULD be made on an as-needed basis.
+
+[charter]: https://www.opencontainers.org/about/governance

--- a/vendor/github.com/opencontainers/cgroups/cgroups.go
+++ b/vendor/github.com/opencontainers/cgroups/cgroups.go
@@ -1,0 +1,86 @@
+package cgroups
+
+import (
+	"errors"
+)
+
+var (
+	// ErrDevicesUnsupported is an error returned when a cgroup manager
+	// is not configured to set device rules.
+	ErrDevicesUnsupported = errors.New("cgroup manager is not configured to set device rules")
+
+	// ErrRootless is returned by [Manager.Apply] when there is an error
+	// creating cgroup directory, and cgroup.Rootless is set. In general,
+	// this error is to be ignored.
+	ErrRootless = errors.New("cgroup manager can not access cgroup (rootless container)")
+
+	// DevicesSetV1 and DevicesSetV2 are functions to set devices for
+	// cgroup v1 and v2, respectively. Unless
+	// [github.com/opencontainers/cgroups/devices]
+	// package is imported, it is set to nil, so cgroup managers can't
+	// manage devices.
+	DevicesSetV1 func(path string, r *Resources) error
+	DevicesSetV2 func(path string, r *Resources) error
+)
+
+type Manager interface {
+	// Apply creates a cgroup, if not yet created, and adds a process
+	// with the specified pid into that cgroup.  A special value of -1
+	// can be used to merely create a cgroup.
+	Apply(pid int) error
+
+	// AddPid adds a process with a given pid to an existing cgroup.
+	// The subcgroup argument is either empty, or a path relative to
+	// a cgroup under under the manager's cgroup.
+	AddPid(subcgroup string, pid int) error
+
+	// GetPids returns the PIDs of all processes inside the cgroup.
+	GetPids() ([]int, error)
+
+	// GetAllPids returns the PIDs of all processes inside the cgroup
+	// any all its sub-cgroups.
+	GetAllPids() ([]int, error)
+
+	// GetStats returns cgroups statistics.
+	GetStats() (*Stats, error)
+
+	// Stats returns statistics for specified controllers.
+	Stats(opts *StatsOptions) (*Stats, error)
+
+	// Freeze sets the freezer cgroup to the specified state.
+	Freeze(state FreezerState) error
+
+	// Destroy removes cgroup.
+	Destroy() error
+
+	// Path returns a cgroup path to the specified controller/subsystem.
+	// For cgroupv2, the argument is unused and can be empty.
+	Path(string) string
+
+	// Set sets cgroup resources parameters/limits. If the argument is nil,
+	// the resources specified during Manager creation (or the previous call
+	// to Set) are used.
+	Set(r *Resources) error
+
+	// GetPaths returns cgroup path(s) to save in a state file in order to
+	// restore later.
+	//
+	// For cgroup v1, a key is cgroup subsystem name, and the value is the
+	// path to the cgroup for this subsystem.
+	//
+	// For cgroup v2 unified hierarchy, a key is "", and the value is the
+	// unified path.
+	GetPaths() map[string]string
+
+	// GetCgroups returns the cgroup data as configured.
+	GetCgroups() (*Cgroup, error)
+
+	// GetFreezerState retrieves the current FreezerState of the cgroup.
+	GetFreezerState() (FreezerState, error)
+
+	// Exists returns whether the cgroup path exists or not.
+	Exists() bool
+
+	// OOMKillCount reports OOM kill count for the cgroup.
+	OOMKillCount() (uint64, error)
+}

--- a/vendor/github.com/opencontainers/cgroups/config_blkio_device.go
+++ b/vendor/github.com/opencontainers/cgroups/config_blkio_device.go
@@ -1,0 +1,66 @@
+package cgroups
+
+import "fmt"
+
+// BlockIODevice holds major:minor format supported in blkio cgroup.
+type BlockIODevice struct {
+	// Major is the device's major number
+	Major int64 `json:"major"`
+	// Minor is the device's minor number
+	Minor int64 `json:"minor"`
+}
+
+// WeightDevice struct holds a `major:minor weight`|`major:minor leaf_weight` pair
+type WeightDevice struct {
+	BlockIODevice
+	// Weight is the bandwidth rate for the device, range is from 10 to 1000
+	Weight uint16 `json:"weight"`
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only
+	LeafWeight uint16 `json:"leafWeight"`
+}
+
+// NewWeightDevice returns a configured WeightDevice pointer
+func NewWeightDevice(major, minor int64, weight, leafWeight uint16) *WeightDevice {
+	wd := &WeightDevice{}
+	wd.Major = major
+	wd.Minor = minor
+	wd.Weight = weight
+	wd.LeafWeight = leafWeight
+	return wd
+}
+
+// WeightString formats the struct to be writable to the cgroup specific file
+func (wd *WeightDevice) WeightString() string {
+	return fmt.Sprintf("%d:%d %d", wd.Major, wd.Minor, wd.Weight)
+}
+
+// LeafWeightString formats the struct to be writable to the cgroup specific file
+func (wd *WeightDevice) LeafWeightString() string {
+	return fmt.Sprintf("%d:%d %d", wd.Major, wd.Minor, wd.LeafWeight)
+}
+
+// ThrottleDevice struct holds a `major:minor rate_per_second` pair
+type ThrottleDevice struct {
+	BlockIODevice
+	// Rate is the IO rate limit per cgroup per device
+	Rate uint64 `json:"rate"`
+}
+
+// NewThrottleDevice returns a configured ThrottleDevice pointer
+func NewThrottleDevice(major, minor int64, rate uint64) *ThrottleDevice {
+	td := &ThrottleDevice{}
+	td.Major = major
+	td.Minor = minor
+	td.Rate = rate
+	return td
+}
+
+// String formats the struct to be writable to the cgroup specific file
+func (td *ThrottleDevice) String() string {
+	return fmt.Sprintf("%d:%d %d", td.Major, td.Minor, td.Rate)
+}
+
+// StringName formats the struct to be writable to the cgroup specific file
+func (td *ThrottleDevice) StringName(name string) string {
+	return fmt.Sprintf("%d:%d %s=%d", td.Major, td.Minor, name, td.Rate)
+}

--- a/vendor/github.com/opencontainers/cgroups/config_hugepages.go
+++ b/vendor/github.com/opencontainers/cgroups/config_hugepages.go
@@ -1,0 +1,9 @@
+package cgroups
+
+type HugepageLimit struct {
+	// which type of hugepage to limit.
+	Pagesize string `json:"page_size"`
+
+	// usage limit for hugepage.
+	Limit uint64 `json:"limit"`
+}

--- a/vendor/github.com/opencontainers/cgroups/config_ifprio_map.go
+++ b/vendor/github.com/opencontainers/cgroups/config_ifprio_map.go
@@ -1,0 +1,14 @@
+package cgroups
+
+import (
+	"fmt"
+)
+
+type IfPrioMap struct {
+	Interface string `json:"interface"`
+	Priority  int64  `json:"priority"`
+}
+
+func (i *IfPrioMap) CgroupString() string {
+	return fmt.Sprintf("%s %d", i.Interface, i.Priority)
+}

--- a/vendor/github.com/opencontainers/cgroups/config_linux.go
+++ b/vendor/github.com/opencontainers/cgroups/config_linux.go
@@ -1,0 +1,169 @@
+package cgroups
+
+import (
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	devices "github.com/opencontainers/cgroups/devices/config"
+)
+
+type FreezerState string
+
+const (
+	Undefined FreezerState = ""
+	Frozen    FreezerState = "FROZEN"
+	Thawed    FreezerState = "THAWED"
+)
+
+// Cgroup holds properties of a cgroup on Linux.
+type Cgroup struct {
+	// Name specifies the name of the cgroup
+	Name string `json:"name,omitzero"`
+
+	// Parent specifies the name of parent of cgroup or slice
+	Parent string `json:"parent,omitzero"`
+
+	// Path specifies the path to cgroups that are created and/or joined by the container.
+	// The path is assumed to be relative to the host system cgroup mountpoint.
+	Path string `json:"path,omitzero"`
+
+	// ScopePrefix describes prefix for the scope name.
+	ScopePrefix string `json:"scope_prefix,omitzero"`
+
+	// Resources contains various cgroups settings to apply.
+	*Resources
+
+	// Systemd tells if systemd should be used to manage cgroups.
+	Systemd bool `json:"Systemd,omitzero"`
+
+	// SystemdProps are any additional properties for systemd,
+	// derived from org.systemd.property.xxx annotations.
+	// Ignored unless systemd is used for managing cgroups.
+	SystemdProps []systemdDbus.Property `json:"-"`
+
+	// Rootless tells if rootless cgroups should be used.
+	Rootless bool `json:"Rootless,omitzero"`
+
+	// The host UID that should own the cgroup, or nil to accept
+	// the default ownership.  This should only be set when the
+	// cgroupfs is to be mounted read/write.
+	// Not all cgroup manager implementations support changing
+	// the ownership.
+	OwnerUID *int `json:"owner_uid,omitzero"`
+}
+
+type Resources struct {
+	// Devices is the set of access rules for devices in the container.
+	Devices []*devices.Rule `json:"devices,omitzero"`
+
+	// Memory limit (in bytes).
+	Memory int64 `json:"memory,omitzero"`
+
+	// Memory reservation or soft_limit (in bytes).
+	MemoryReservation int64 `json:"memory_reservation,omitzero"`
+
+	// Total memory usage (memory+swap); use -1 for unlimited swap.
+	MemorySwap int64 `json:"memory_swap,omitzero"`
+
+	// CPU shares (relative weight vs. other containers).
+	CpuShares uint64 `json:"cpu_shares,omitzero"`
+
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	CpuQuota int64 `json:"cpu_quota,omitzero"`
+
+	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a given period.
+	CpuBurst *uint64 `json:"cpu_burst,omitzero"`
+
+	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
+	CpuPeriod uint64 `json:"cpu_period,omitzero"`
+
+	// How many time CPU will use in realtime scheduling (in usecs).
+	CpuRtRuntime int64 `json:"cpu_rt_quota,omitzero"`
+
+	// CPU period to be used for realtime scheduling (in usecs).
+	CpuRtPeriod uint64 `json:"cpu_rt_period,omitzero"`
+
+	// Cpuset CPUs to use.
+	CpusetCpus string `json:"cpuset_cpus,omitzero"`
+
+	// Cpuset memory nodes to use.
+	CpusetMems string `json:"cpuset_mems,omitzero"`
+
+	// Cgroup's SCHED_IDLE value.
+	CPUIdle *int64 `json:"cpu_idle,omitzero"`
+
+	// Process limit; set < `0' to disable limit. `nil` means "keep current limit".
+	PidsLimit *int64 `json:"pids_limit,omitzero"`
+
+	// Specifies per cgroup weight, range is from 10 to 1000.
+	BlkioWeight uint16 `json:"blkio_weight,omitzero"`
+
+	// Tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only.
+	BlkioLeafWeight uint16 `json:"blkio_leaf_weight,omitzero"`
+
+	// Weight per cgroup per device, can override BlkioWeight.
+	BlkioWeightDevice []*WeightDevice `json:"blkio_weight_device,omitzero"`
+
+	// IO read rate limit per cgroup per device, bytes per second.
+	BlkioThrottleReadBpsDevice []*ThrottleDevice `json:"blkio_throttle_read_bps_device,omitzero"`
+
+	// IO write rate limit per cgroup per device, bytes per second.
+	BlkioThrottleWriteBpsDevice []*ThrottleDevice `json:"blkio_throttle_write_bps_device,omitzero"`
+
+	// IO read rate limit per cgroup per device, IO per second.
+	BlkioThrottleReadIOPSDevice []*ThrottleDevice `json:"blkio_throttle_read_iops_device,omitzero"`
+
+	// IO write rate limit per cgroup per device, IO per second.
+	BlkioThrottleWriteIOPSDevice []*ThrottleDevice `json:"blkio_throttle_write_iops_device,omitzero"`
+
+	// Freeze value for the process.
+	Freezer FreezerState `json:"freezer,omitzero"`
+
+	// Hugetlb limit (in bytes).
+	HugetlbLimit []*HugepageLimit `json:"hugetlb_limit,omitzero"`
+
+	// Whether to disable OOM killer.
+	OomKillDisable bool `json:"oom_kill_disable,omitzero"`
+
+	// Tuning swappiness behaviour per cgroup.
+	MemorySwappiness *uint64 `json:"memory_swappiness,omitzero"`
+
+	// Set priority of network traffic for container.
+	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap,omitzero"`
+
+	// Set class identifier for container's network packets.
+	NetClsClassid uint32 `json:"net_cls_classid_u,omitzero"`
+
+	// Rdma resource restriction configuration.
+	Rdma map[string]LinuxRdma `json:"rdma,omitzero"`
+
+	// Used on cgroups v2:
+
+	// CpuWeight sets a proportional bandwidth limit.
+	CpuWeight uint64 `json:"cpu_weight,omitzero"`
+
+	// Unified is cgroupv2-only key-value map.
+	Unified map[string]string `json:"unified,omitzero"`
+
+	// SkipDevices allows to skip configuring device permissions.
+	// Used by e.g. kubelet while creating a parent cgroup (kubepods)
+	// common for many containers, and by runc update.
+	//
+	// NOTE it is impossible to start a container which has this flag set.
+	SkipDevices bool `json:"-"`
+
+	// SkipFreezeOnSet is a flag for cgroup manager to skip the cgroup
+	// freeze when setting resources. Only applicable to systemd legacy
+	// (i.e. cgroup v1) manager (which uses freeze by default to avoid
+	// spurious permission errors caused by systemd inability to update
+	// device rules in a non-disruptive manner).
+	//
+	// If not set, a few methods (such as looking into cgroup's
+	// devices.list and querying the systemd unit properties) are used
+	// during Set() to figure out whether the freeze is required. Those
+	// methods may be relatively slow, thus this flag.
+	SkipFreezeOnSet bool `json:"-"`
+
+	// MemoryCheckBeforeUpdate is a flag for cgroup v2 managers to check
+	// if the new memory limits (Memory and MemorySwap) being set are lower
+	// than the current memory usage, and reject if so.
+	MemoryCheckBeforeUpdate bool `json:"memory_check_before_update,omitzero"`
+}

--- a/vendor/github.com/opencontainers/cgroups/config_rdma.go
+++ b/vendor/github.com/opencontainers/cgroups/config_rdma.go
@@ -1,0 +1,9 @@
+package cgroups
+
+// LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11)
+type LinuxRdma struct {
+	// Maximum number of HCA handles that can be opened. Default is "no limit".
+	HcaHandles *uint32 `json:"hca_handles,omitzero"`
+	// Maximum number of HCA objects that can be created. Default is "no limit".
+	HcaObjects *uint32 `json:"hca_objects,omitzero"`
+}

--- a/vendor/github.com/opencontainers/cgroups/config_unsupported.go
+++ b/vendor/github.com/opencontainers/cgroups/config_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package cgroups
+
+// Cgroup holds properties of a cgroup on Linux
+// TODO Windows: This can ultimately be entirely factored out on Windows as
+// cgroups are a Unix-specific construct.
+type Cgroup struct{}

--- a/vendor/github.com/opencontainers/cgroups/file.go
+++ b/vendor/github.com/opencontainers/cgroups/file.go
@@ -1,0 +1,216 @@
+package cgroups
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// OpenFile opens a cgroup file in a given dir with given flags.
+// It is supposed to be used for cgroup files only, and returns
+// an error if the file is not a cgroup file.
+//
+// Arguments dir and file are joined together to form an absolute path
+// to a file being opened.
+func OpenFile(dir, file string, flags int) (*os.File, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("no directory specified for %s", file)
+	}
+	return openFile(dir, file, flags)
+}
+
+// ReadFile reads data from a cgroup file in dir.
+// It is supposed to be used for cgroup files only.
+func ReadFile(dir, file string) (string, error) {
+	fd, err := OpenFile(dir, file, unix.O_RDONLY)
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+	var buf bytes.Buffer
+
+	_, err = buf.ReadFrom(fd)
+	return buf.String(), err
+}
+
+// WriteFile writes data to a cgroup file in dir.
+// It is supposed to be used for cgroup files only.
+func WriteFile(dir, file, data string) error {
+	fd, err := OpenFile(dir, file, unix.O_WRONLY)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	if _, err := fd.WriteString(data); err != nil {
+		// Having data in the error message helps in debugging.
+		return fmt.Errorf("failed to write %q: %w", data, err)
+	}
+	return nil
+}
+
+// WriteFileByLine is the same as WriteFile, except if data contains newlines,
+// it is written line by line.
+func WriteFileByLine(dir, file, data string) error {
+	i := strings.Index(data, "\n")
+	if i == -1 {
+		return WriteFile(dir, file, data)
+	}
+
+	fd, err := OpenFile(dir, file, unix.O_WRONLY)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	start := 0
+	for {
+		var line string
+		if i == -1 {
+			line = data[start:]
+		} else {
+			line = data[start : start+i+1]
+		}
+		_, err := fd.WriteString(line)
+		if err != nil {
+			return fmt.Errorf("failed to write %q: %w", line, err)
+		}
+		if i == -1 {
+			break
+		}
+		start += i + 1
+		i = strings.Index(data[start:], "\n")
+	}
+	return nil
+}
+
+const (
+	cgroupfsDir    = "/sys/fs/cgroup"
+	cgroupfsPrefix = cgroupfsDir + "/"
+)
+
+var (
+	// TestMode is set to true by unit tests that need "fake" cgroupfs.
+	TestMode bool
+
+	cgroupRootHandle *os.File
+	prepOnce         sync.Once
+	prepErr          error
+	resolveFlags     uint64
+)
+
+func prepareOpenat2() error {
+	prepOnce.Do(func() {
+		fd, err := unix.Openat2(-1, cgroupfsDir, &unix.OpenHow{
+			Flags: unix.O_DIRECTORY | unix.O_PATH | unix.O_CLOEXEC,
+		})
+		if err != nil {
+			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
+			if err != unix.ENOSYS {
+				logrus.Warnf("falling back to securejoin: %s", prepErr)
+			} else {
+				logrus.Debug("openat2 not available, falling back to securejoin")
+			}
+			return
+		}
+		file := os.NewFile(uintptr(fd), cgroupfsDir)
+
+		var st unix.Statfs_t
+		if err := unix.Fstatfs(int(file.Fd()), &st); err != nil {
+			prepErr = &os.PathError{Op: "statfs", Path: cgroupfsDir, Err: err}
+			logrus.Warnf("falling back to securejoin: %s", prepErr)
+			return
+		}
+
+		cgroupRootHandle = file
+		resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS
+		if st.Type == unix.CGROUP2_SUPER_MAGIC {
+			// cgroupv2 has a single mountpoint and no "cpu,cpuacct" symlinks
+			resolveFlags |= unix.RESOLVE_NO_XDEV | unix.RESOLVE_NO_SYMLINKS
+		}
+	})
+
+	return prepErr
+}
+
+func openFile(dir, file string, flags int) (*os.File, error) {
+	mode := os.FileMode(0)
+	if TestMode && flags&os.O_WRONLY != 0 {
+		// "emulate" cgroup fs for unit tests
+		flags |= os.O_TRUNC | os.O_CREATE
+		mode = 0o600
+	}
+	// NOTE it is important to use filepath.Clean("/"+file) here
+	// (see https://github.com/opencontainers/runc/issues/4103)!
+	path := filepath.Join(dir, filepath.Clean("/"+file))
+
+	if prepareOpenat2() != nil {
+		return openFallback(path, flags, mode)
+	}
+	relPath, ok := strings.CutPrefix(path, cgroupfsPrefix)
+	if !ok { // Non-standard path, old system?
+		return openFallback(path, flags, mode)
+	}
+
+	fd, err := unix.Openat2(int(cgroupRootHandle.Fd()), relPath,
+		&unix.OpenHow{
+			Resolve: resolveFlags,
+			Flags:   uint64(flags) | unix.O_CLOEXEC,
+			Mode:    uint64(mode),
+		})
+	if err != nil {
+		err = &os.PathError{Op: "openat2", Path: path, Err: err}
+		// Check if cgroupRootHandle is still opened to cgroupfsDir
+		// (happens when this package is incorrectly used
+		// across the chroot/pivot_root/mntns boundary, or
+		// when /sys/fs/cgroup is remounted).
+		//
+		// TODO: if such usage will ever be common, amend this
+		// to reopen cgroupRootHandle and retry openat2.
+		fdDest, fdErr := os.Readlink("/proc/thread-self/fd/" + strconv.Itoa(int(cgroupRootHandle.Fd())))
+		if fdErr == nil && fdDest != cgroupfsDir {
+			// Wrap the error so it is clear that cgroupRootHandle
+			// is opened to an unexpected/wrong directory.
+			err = fmt.Errorf("cgroupRootHandle %d unexpectedly opened to %s != %s: %w",
+				cgroupRootHandle.Fd(), fdDest, cgroupfsDir, err)
+		}
+		return nil, err
+	}
+
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+var errNotCgroupfs = errors.New("not a cgroup file")
+
+// Can be changed by unit tests.
+var openFallback = openAndCheck
+
+// openAndCheck is used when openat2(2) is not available. It checks the opened
+// file is on cgroupfs, returning an error otherwise.
+func openAndCheck(path string, flags int, mode os.FileMode) (*os.File, error) {
+	fd, err := os.OpenFile(path, flags, mode)
+	if err != nil {
+		return nil, err
+	}
+	if TestMode {
+		return fd, nil
+	}
+	// Check this is a cgroupfs file.
+	var st unix.Statfs_t
+	if err := unix.Fstatfs(int(fd.Fd()), &st); err != nil {
+		_ = fd.Close()
+		return nil, &os.PathError{Op: "statfs", Path: path, Err: err}
+	}
+	if st.Type != unix.CGROUP_SUPER_MAGIC && st.Type != unix.CGROUP2_SUPER_MAGIC {
+		_ = fd.Close()
+		return nil, &os.PathError{Op: "open", Path: path, Err: errNotCgroupfs}
+	}
+
+	return fd, nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/cpu.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/cpu.go
@@ -1,0 +1,123 @@
+package fs2
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fscommon"
+)
+
+func isCPUSet(r *cgroups.Resources) bool {
+	return r.CpuWeight != 0 || r.CpuQuota != 0 || r.CpuPeriod != 0 || r.CPUIdle != nil || r.CpuBurst != nil
+}
+
+func setCPU(dirPath string, r *cgroups.Resources) error {
+	if !isCPUSet(r) {
+		return nil
+	}
+
+	if r.CPUIdle != nil {
+		if err := cgroups.WriteFile(dirPath, "cpu.idle", strconv.FormatInt(*r.CPUIdle, 10)); err != nil {
+			return err
+		}
+	}
+
+	// NOTE: .CpuShares is not used here. Conversion is the caller's responsibility.
+	if r.CpuWeight != 0 {
+		if err := cgroups.WriteFile(dirPath, "cpu.weight", strconv.FormatUint(r.CpuWeight, 10)); err != nil {
+			return err
+		}
+	}
+
+	var burst string
+	if r.CpuBurst != nil {
+		burst = strconv.FormatUint(*r.CpuBurst, 10)
+		if err := cgroups.WriteFile(dirPath, "cpu.max.burst", burst); err != nil {
+			// Sometimes when the burst to be set is larger
+			// than the current one, it is rejected by the kernel
+			// (EINVAL) as old_quota/new_burst exceeds the parent
+			// cgroup quota limit. If this happens and the quota is
+			// going to be set, ignore the error for now and retry
+			// after setting the quota.
+			if !errors.Is(err, unix.EINVAL) || r.CpuQuota == 0 {
+				return err
+			}
+		} else {
+			burst = ""
+		}
+	}
+	if r.CpuQuota != 0 || r.CpuPeriod != 0 {
+		str := "max"
+		if r.CpuQuota > 0 {
+			str = strconv.FormatInt(r.CpuQuota, 10)
+		}
+		period := r.CpuPeriod
+		if period == 0 {
+			// This default value is documented in
+			// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+			period = 100000
+		}
+		str += " " + strconv.FormatUint(period, 10)
+		if err := cgroups.WriteFile(dirPath, "cpu.max", str); err != nil {
+			return err
+		}
+		if burst != "" {
+			if err := cgroups.WriteFile(dirPath, "cpu.max.burst", burst); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func statCpu(dirPath string, stats *cgroups.Stats) error {
+	const file = "cpu.stat"
+	f, err := cgroups.OpenFile(dirPath, file, os.O_RDONLY)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		t, v, err := fscommon.ParseKeyValue(sc.Text())
+		if err != nil {
+			return &parseError{Path: dirPath, File: file, Err: err}
+		}
+		switch t {
+		case "usage_usec":
+			stats.CpuStats.CpuUsage.TotalUsage = v * 1000
+
+		case "user_usec":
+			stats.CpuStats.CpuUsage.UsageInUsermode = v * 1000
+
+		case "system_usec":
+			stats.CpuStats.CpuUsage.UsageInKernelmode = v * 1000
+
+		case "nr_periods":
+			stats.CpuStats.ThrottlingData.Periods = v
+
+		case "nr_throttled":
+			stats.CpuStats.ThrottlingData.ThrottledPeriods = v
+
+		case "throttled_usec":
+			stats.CpuStats.ThrottlingData.ThrottledTime = v * 1000
+
+		case "nr_bursts":
+			stats.CpuStats.BurstData.BurstsPeriods = v
+
+		case "burst_usec":
+			stats.CpuStats.BurstData.BurstTime = v * 1000
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return &parseError{Path: dirPath, File: file, Err: err}
+	}
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/cpuset.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/cpuset.go
@@ -1,0 +1,27 @@
+package fs2
+
+import (
+	"github.com/opencontainers/cgroups"
+)
+
+func isCpusetSet(r *cgroups.Resources) bool {
+	return r.CpusetCpus != "" || r.CpusetMems != ""
+}
+
+func setCpuset(dirPath string, r *cgroups.Resources) error {
+	if !isCpusetSet(r) {
+		return nil
+	}
+
+	if r.CpusetCpus != "" {
+		if err := cgroups.WriteFile(dirPath, "cpuset.cpus", r.CpusetCpus); err != nil {
+			return err
+		}
+	}
+	if r.CpusetMems != "" {
+		if err := cgroups.WriteFile(dirPath, "cpuset.mems", r.CpusetMems); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/create.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/create.go
@@ -1,0 +1,150 @@
+package fs2
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opencontainers/cgroups"
+)
+
+func supportedControllers() (string, error) {
+	return cgroups.ReadFile(UnifiedMountpoint, "/cgroup.controllers")
+}
+
+// needAnyControllers returns whether we enable some supported controllers or not,
+// based on (1) controllers available and (2) resources that are being set.
+// We don't check "pseudo" controllers such as
+// "freezer" and "devices".
+func needAnyControllers(r *cgroups.Resources) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+
+	// list of all available controllers
+	content, err := supportedControllers()
+	if err != nil {
+		return false, err
+	}
+	avail := make(map[string]struct{})
+	for ctr := range strings.FieldsSeq(content) {
+		avail[ctr] = struct{}{}
+	}
+
+	// check whether the controller if available or not
+	have := func(controller string) bool {
+		_, ok := avail[controller]
+		return ok
+	}
+
+	if isPidsSet(r) && have("pids") {
+		return true, nil
+	}
+	if isMemorySet(r) && have("memory") {
+		return true, nil
+	}
+	if isIoSet(r) && have("io") {
+		return true, nil
+	}
+	if isCPUSet(r) && have("cpu") {
+		return true, nil
+	}
+	if isCpusetSet(r) && have("cpuset") {
+		return true, nil
+	}
+	if isHugeTlbSet(r) && have("hugetlb") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// containsDomainController returns whether the current config contains domain controller or not.
+// Refer to: http://man7.org/linux/man-pages/man7/cgroups.7.html
+// As at Linux 4.19, the following controllers are threaded: cpu, perf_event, and pids.
+func containsDomainController(r *cgroups.Resources) bool {
+	return isMemorySet(r) || isIoSet(r) || isCPUSet(r) || isHugeTlbSet(r)
+}
+
+// CreateCgroupPath creates cgroupv2 path, enabling all the supported controllers.
+func CreateCgroupPath(path string, c *cgroups.Cgroup) (Err error) {
+	if !strings.HasPrefix(path, UnifiedMountpoint) {
+		return fmt.Errorf("invalid cgroup path %s", path)
+	}
+
+	content, err := supportedControllers()
+	if err != nil {
+		return err
+	}
+
+	const (
+		cgTypeFile  = "cgroup.type"
+		cgStCtlFile = "cgroup.subtree_control"
+	)
+	ctrs := strings.Fields(content)
+	res := "+" + strings.Join(ctrs, " +")
+
+	elements := strings.Split(path, "/")
+	elements = elements[3:]
+	current := "/sys/fs"
+	for i, e := range elements {
+		current = filepath.Join(current, e)
+		if i > 0 {
+			if err := os.Mkdir(current, 0o755); err != nil {
+				if !os.IsExist(err) {
+					return err
+				}
+			} else {
+				// If the directory was created, be sure it is not left around on errors.
+				current := current
+				defer func() {
+					if Err != nil {
+						os.Remove(current)
+					}
+				}()
+			}
+			cgType, _ := cgroups.ReadFile(current, cgTypeFile)
+			cgType = strings.TrimSpace(cgType)
+			switch cgType {
+			// If the cgroup is in an invalid mode (usually this means there's an internal
+			// process in the cgroup tree, because we created a cgroup under an
+			// already-populated-by-other-processes cgroup), then we have to error out if
+			// the user requested controllers which are not thread-aware. However, if all
+			// the controllers requested are thread-aware we can simply put the cgroup into
+			// threaded mode.
+			case "domain invalid":
+				if containsDomainController(c.Resources) {
+					return fmt.Errorf("cannot enter cgroupv2 %q with domain controllers -- it is in an invalid state", current)
+				} else {
+					// Not entirely correct (in theory we'd always want to be a domain --
+					// since that means we're a properly delegated cgroup subtree) but in
+					// this case there's not much we can do and it's better than giving an
+					// error.
+					_ = cgroups.WriteFile(current, cgTypeFile, "threaded")
+				}
+			// If the cgroup is in (threaded) or (domain threaded) mode, we can only use thread-aware controllers
+			// (and you cannot usually take a cgroup out of threaded mode).
+			case "domain threaded":
+				fallthrough
+			case "threaded":
+				if containsDomainController(c.Resources) {
+					return fmt.Errorf("cannot enter cgroupv2 %q with domain controllers -- it is in %s mode", current, cgType)
+				}
+			}
+		}
+		// enable all supported controllers
+		if i < len(elements)-1 {
+			if err := cgroups.WriteFile(current, cgStCtlFile, res); err != nil {
+				// try write one by one
+				for ctr := range strings.SplitSeq(res, " ") {
+					_ = cgroups.WriteFile(current, cgStCtlFile, ctr)
+				}
+			}
+			// Some controllers might not be enabled when rootless or containerized,
+			// but we don't catch the error here. (Caught in setXXX() functions.)
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/defaultpath.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/defaultpath.go
@@ -1,0 +1,80 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs2
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/internal/path"
+)
+
+const UnifiedMountpoint = "/sys/fs/cgroup"
+
+func defaultDirPath(c *cgroups.Cgroup) (string, error) {
+	innerPath, err := path.Inner(c)
+	if err != nil {
+		return "", err
+	}
+
+	if filepath.IsAbs(innerPath) {
+		return filepath.Join(UnifiedMountpoint, innerPath), nil
+	}
+
+	// we don't need to use /proc/thread-self here because runc always runs
+	// with every thread in the same cgroup. This lets us avoid having to do
+	// runtime.LockOSThread.
+	ownCgroup, err := parseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	// The current user scope most probably has tasks in it already,
+	// making it impossible to enable controllers for its sub-cgroup.
+	// A parent cgroup (with no tasks in it) is what we need.
+	ownCgroup = filepath.Dir(ownCgroup)
+
+	return filepath.Join(UnifiedMountpoint, ownCgroup, innerPath), nil
+}
+
+// parseCgroupFile parses /proc/PID/cgroup file and return string
+func parseCgroupFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return parseCgroupFromReader(f)
+}
+
+func parseCgroupFromReader(r io.Reader) (string, error) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		// "0::/user.slice/user-1001.slice/session-1.scope"
+		if path, ok := strings.CutPrefix(s.Text(), "0::"); ok {
+			return path, nil
+		}
+	}
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("cgroup path not found")
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/freezer.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/freezer.go
@@ -1,0 +1,140 @@
+package fs2
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/cgroups"
+)
+
+func setFreezer(dirPath string, state cgroups.FreezerState) error {
+	var stateStr string
+	switch state {
+	case cgroups.Undefined:
+		return nil
+	case cgroups.Frozen:
+		stateStr = "1"
+	case cgroups.Thawed:
+		stateStr = "0"
+	default:
+		return fmt.Errorf("invalid freezer state %q requested", state)
+	}
+
+	fd, err := cgroups.OpenFile(dirPath, "cgroup.freeze", unix.O_RDWR)
+	if err != nil {
+		// We can ignore this request as long as the user didn't ask us to
+		// freeze the container (since without the freezer cgroup, that's a
+		// no-op).
+		if state != cgroups.Frozen {
+			return nil
+		}
+		return fmt.Errorf("freezer not supported: %w", err)
+	}
+	defer fd.Close()
+
+	if _, err := fd.WriteString(stateStr); err != nil {
+		return err
+	}
+	// Confirm that the cgroup did actually change states.
+	if actualState, err := readFreezer(dirPath, fd); err != nil {
+		return err
+	} else if actualState != state {
+		return fmt.Errorf(`expected "cgroup.freeze" to be in state %q but was in %q`, state, actualState)
+	}
+	return nil
+}
+
+func getFreezer(dirPath string) (cgroups.FreezerState, error) {
+	fd, err := cgroups.OpenFile(dirPath, "cgroup.freeze", unix.O_RDONLY)
+	if err != nil {
+		// If the kernel is too old, then we just treat the freezer as
+		// being in an "undefined" state and ignore the error.
+		return cgroups.Undefined, ignoreNotExistOrNoDeviceError(err)
+	}
+	defer fd.Close()
+
+	return readFreezer(dirPath, fd)
+}
+
+func readFreezer(dirPath string, fd *os.File) (cgroups.FreezerState, error) {
+	if _, err := fd.Seek(0, 0); err != nil {
+		// If the cgroup path is deleted at this point, then we just treat the freezer as
+		// being in an "undefined" state and ignore the error.
+		return cgroups.Undefined, ignoreNotExistOrNoDeviceError(err)
+	}
+	state := make([]byte, 2)
+	if _, err := fd.Read(state); err != nil {
+		// If the cgroup path is deleted at this point, then we just treat the freezer as
+		// being in an "undefined" state and ignore the error.
+		return cgroups.Undefined, ignoreNotExistOrNoDeviceError(err)
+	}
+	switch string(state) {
+	case "0\n":
+		return cgroups.Thawed, nil
+	case "1\n":
+		return waitFrozen(dirPath)
+	default:
+		return cgroups.Undefined, fmt.Errorf(`unknown "cgroup.freeze" state: %q`, state)
+	}
+}
+
+// ignoreNotExistOrNoDeviceError checks if the error is either a "not exist" error
+// or a "no device" error, and returns nil in those cases. Otherwise, it returns the error.
+func ignoreNotExistOrNoDeviceError(err error) error {
+	// We can safely ignore the error in the following two common situations:
+	// 1. The cgroup path does not exist at the time of opening(eg: the kernel is too old)
+	//    — indicated by os.IsNotExist.
+	// 2. The cgroup path is deleted during the seek/read operation — indicated by
+	//    errors.Is(err, unix.ENODEV).
+	// These conditions are expected and do not require special handling.
+	if os.IsNotExist(err) || errors.Is(err, unix.ENODEV) {
+		return nil
+	}
+	return err
+}
+
+// waitFrozen polls cgroup.events until it sees "frozen 1" in it.
+func waitFrozen(dirPath string) (cgroups.FreezerState, error) {
+	fd, err := cgroups.OpenFile(dirPath, "cgroup.events", unix.O_RDONLY)
+	if err != nil {
+		return cgroups.Undefined, err
+	}
+	defer fd.Close()
+
+	// XXX: Simple wait/read/retry is used here. An implementation
+	// based on poll(2) or inotify(7) is possible, but it makes the code
+	// much more complicated. Maybe address this later.
+	const (
+		// Perform maxIter with waitTime in between iterations.
+		waitTime = 10 * time.Millisecond
+		maxIter  = 1000
+	)
+	scanner := bufio.NewScanner(fd)
+	for i := 0; scanner.Scan(); {
+		if i == maxIter {
+			return cgroups.Undefined, fmt.Errorf("timeout of %s reached waiting for the cgroup to freeze", waitTime*maxIter)
+		}
+		if val, ok := strings.CutPrefix(scanner.Text(), "frozen "); ok {
+			if val[0] == '1' {
+				return cgroups.Frozen, nil
+			}
+
+			i++
+			// wait, then re-read
+			time.Sleep(waitTime)
+			_, err := fd.Seek(0, 0)
+			if err != nil {
+				return cgroups.Undefined, err
+			}
+		}
+	}
+	// Should only reach here either on read error,
+	// or if the file does not contain "frozen " line.
+	return cgroups.Undefined, scanner.Err()
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/fs2.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/fs2.go
@@ -1,0 +1,364 @@
+package fs2
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fscommon"
+)
+
+type parseError = fscommon.ParseError
+
+type Manager struct {
+	config *cgroups.Cgroup
+	// dirPath is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope"
+	dirPath string
+	// controllers is content of "cgroup.controllers" file.
+	// excludes pseudo-controllers ("devices" and "freezer").
+	controllers map[string]struct{}
+}
+
+// NewManager creates a manager for cgroup v2 unified hierarchy.
+// dirPath is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope".
+// If dirPath is empty, it is automatically set using config.
+func NewManager(config *cgroups.Cgroup, dirPath string) (*Manager, error) {
+	if dirPath == "" {
+		var err error
+		dirPath, err = defaultDirPath(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	m := &Manager{
+		config:  config,
+		dirPath: dirPath,
+	}
+	return m, nil
+}
+
+func (m *Manager) getControllers() error {
+	if m.controllers != nil {
+		return nil
+	}
+
+	data, err := cgroups.ReadFile(m.dirPath, "cgroup.controllers")
+	if err != nil {
+		if m.config.Rootless && m.config.Path == "" {
+			return nil
+		}
+		return err
+	}
+	fields := strings.Fields(data)
+	m.controllers = make(map[string]struct{}, len(fields))
+	for _, c := range fields {
+		m.controllers[c] = struct{}{}
+	}
+
+	return nil
+}
+
+func (m *Manager) Apply(pid int) error {
+	if err := CreateCgroupPath(m.dirPath, m.config); err != nil {
+		// Related tests:
+		// - "runc create (no limits + no cgrouppath + no permission) succeeds"
+		// - "runc create (rootless + no limits + cgrouppath + no permission) fails with permission error"
+		// - "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
+		if m.config.Rootless {
+			if m.config.Path == "" {
+				if blNeed, nErr := needAnyControllers(m.config.Resources); nErr == nil && !blNeed {
+					return cgroups.ErrRootless
+				}
+				return fmt.Errorf("rootless needs no limits + no cgrouppath when no permission is granted for cgroups: %w", err)
+			}
+		}
+		return err
+	}
+	if err := cgroups.WriteCgroupProc(m.dirPath, pid); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddPid adds a process with a given pid to an existing cgroup.
+// The subcgroup argument is either empty, or a path relative to
+// a cgroup under under the manager's cgroup.
+func (m *Manager) AddPid(subcgroup string, pid int) error {
+	path := filepath.Join(m.dirPath, subcgroup)
+	if !strings.HasPrefix(path, m.dirPath) {
+		return fmt.Errorf("bad sub cgroup path: %s", subcgroup)
+	}
+
+	return cgroups.WriteCgroupProc(path, pid)
+}
+
+func (m *Manager) GetPids() ([]int, error) {
+	return cgroups.GetPids(m.dirPath)
+}
+
+func (m *Manager) GetAllPids() ([]int, error) {
+	return cgroups.GetAllPids(m.dirPath)
+}
+
+func (m *Manager) GetStats() (*cgroups.Stats, error) {
+	return m.Stats(nil)
+}
+
+// Stats returns cgroup statistics for the specified controllers.
+func (m *Manager) Stats(opts *cgroups.StatsOptions) (*cgroups.Stats, error) {
+	// Default: query all controllers
+	controllers := cgroups.AllControllers
+	if opts != nil && opts.Controllers != 0 {
+		controllers = opts.Controllers
+	}
+
+	var errs []error
+	var err error
+	st := cgroups.NewStats()
+
+	// pids (since kernel 4.5)
+	if controllers&cgroups.Pids != 0 {
+		if err = statPids(m.dirPath, st); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// memory (since kernel 4.5)
+	if controllers&cgroups.Memory != 0 {
+		if err = statMemory(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+
+		if st.MemoryStats.PSI, err = statPSI(m.dirPath, "memory.pressure"); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// io (since kernel 4.5)
+	if controllers&cgroups.IO != 0 {
+		if err = statIo(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+
+		if st.BlkioStats.PSI, err = statPSI(m.dirPath, "io.pressure"); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// cpu (since kernel 4.15)
+	// Note cpu.stat is available even if the controller is not enabled.
+	if controllers&cgroups.CPU != 0 {
+		if err = statCpu(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+
+		// PSI (since kernel 4.20)
+		if st.CpuStats.PSI, err = statPSI(m.dirPath, "cpu.pressure"); err != nil {
+			errs = append(errs, err)
+		}
+
+	}
+
+	// hugetlb (since kernel 5.6)
+	if controllers&cgroups.HugeTLB != 0 {
+		if err := statHugeTlb(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+
+	// rdma (since kernel 4.11)
+	if controllers&cgroups.RDMA != 0 {
+		if err := fscommon.RdmaGetStats(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+
+	// misc (since kernel 5.13)
+	if controllers&cgroups.Misc != 0 {
+		if err := statMisc(m.dirPath, st); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 && !m.config.Rootless {
+		return st, fmt.Errorf("error while statting cgroup v2: %+v", errs)
+	}
+	return st, nil
+}
+
+func (m *Manager) Freeze(state cgroups.FreezerState) error {
+	if m.config.Resources == nil {
+		return errors.New("cannot toggle freezer: cgroups not configured for container")
+	}
+	if err := setFreezer(m.dirPath, state); err != nil {
+		return err
+	}
+	m.config.Resources.Freezer = state
+	return nil
+}
+
+func (m *Manager) Destroy() error {
+	return cgroups.RemovePath(m.dirPath)
+}
+
+func (m *Manager) Path(_ string) string {
+	return m.dirPath
+}
+
+func (m *Manager) Set(r *cgroups.Resources) error {
+	if r == nil {
+		return nil
+	}
+	if err := m.getControllers(); err != nil {
+		return err
+	}
+	// pids (since kernel 4.5)
+	if err := setPids(m.dirPath, r); err != nil {
+		return err
+	}
+	// memory (since kernel 4.5)
+	if err := setMemory(m.dirPath, r); err != nil {
+		return err
+	}
+	// io (since kernel 4.5)
+	if err := setIo(m.dirPath, r); err != nil {
+		return err
+	}
+	// cpu (since kernel 4.15)
+	if err := setCPU(m.dirPath, r); err != nil {
+		return err
+	}
+	// devices (since kernel 4.15, pseudo-controller)
+	//
+	// When rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
+	// However, errors from other subsystems are not ignored.
+	// see @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
+	if err := setDevices(m.dirPath, r); err != nil {
+		if !m.config.Rootless || errors.Is(err, cgroups.ErrDevicesUnsupported) {
+			return err
+		}
+	}
+	// cpuset (since kernel 5.0)
+	if err := setCpuset(m.dirPath, r); err != nil {
+		return err
+	}
+	// hugetlb (since kernel 5.6)
+	if err := setHugeTlb(m.dirPath, r); err != nil {
+		return err
+	}
+	// rdma (since kernel 4.11)
+	if err := fscommon.RdmaSet(m.dirPath, r); err != nil {
+		return err
+	}
+	// freezer (since kernel 5.2, pseudo-controller)
+	if err := setFreezer(m.dirPath, r.Freezer); err != nil {
+		return err
+	}
+	if err := m.setUnified(r.Unified); err != nil {
+		return err
+	}
+	m.config.Resources = r
+	return nil
+}
+
+func setDevices(dirPath string, r *cgroups.Resources) error {
+	if cgroups.DevicesSetV2 == nil {
+		if len(r.Devices) > 0 {
+			return cgroups.ErrDevicesUnsupported
+		}
+		return nil
+	}
+	return cgroups.DevicesSetV2(dirPath, r)
+}
+
+func (m *Manager) setUnified(res map[string]string) error {
+	for k, v := range res {
+		if strings.Contains(k, "/") {
+			return fmt.Errorf("unified resource %q must be a file name (no slashes)", k)
+		}
+		if err := cgroups.WriteFileByLine(m.dirPath, k, v); err != nil {
+			// Check for both EPERM and ENOENT since O_CREAT is used by WriteFile.
+			if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
+				// Check if a controller is available,
+				// to give more specific error if not.
+				c, _, ok := strings.Cut(k, ".")
+				if !ok {
+					return fmt.Errorf("unified resource %q must be in the form CONTROLLER.PARAMETER", k)
+				}
+				if _, ok := m.controllers[c]; !ok && c != "cgroup" {
+					return fmt.Errorf("unified resource %q can't be set: controller %q not available", k, c)
+				}
+			}
+			return fmt.Errorf("unable to set unified resource %q: %w", k, err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) GetPaths() map[string]string {
+	paths := make(map[string]string, 1)
+	paths[""] = m.dirPath
+	return paths
+}
+
+func (m *Manager) GetCgroups() (*cgroups.Cgroup, error) {
+	return m.config, nil
+}
+
+func (m *Manager) GetFreezerState() (cgroups.FreezerState, error) {
+	return getFreezer(m.dirPath)
+}
+
+func (m *Manager) Exists() bool {
+	return cgroups.PathExists(m.dirPath)
+}
+
+func OOMKillCount(path string) (uint64, error) {
+	return fscommon.GetValueByKey(path, "memory.events", "oom_kill")
+}
+
+func (m *Manager) OOMKillCount() (uint64, error) {
+	c, err := OOMKillCount(m.dirPath)
+	if err != nil && m.config.Rootless && os.IsNotExist(err) {
+		err = nil
+	}
+
+	return c, err
+}
+
+func CheckMemoryUsage(dirPath string, r *cgroups.Resources) error {
+	if !r.MemoryCheckBeforeUpdate {
+		return nil
+	}
+
+	if r.Memory <= 0 && r.MemorySwap <= 0 {
+		return nil
+	}
+
+	usage, err := fscommon.GetCgroupParamUint(dirPath, "memory.current")
+	if err != nil {
+		// This check is on best-effort basis, so if we can't read the
+		// current usage (cgroup not yet created, or any other error),
+		// we should not fail.
+		return nil
+	}
+
+	if r.MemorySwap > 0 {
+		if uint64(r.MemorySwap) <= usage {
+			return fmt.Errorf("rejecting memory+swap limit %d <= usage %d", r.MemorySwap, usage)
+		}
+	}
+
+	if r.Memory > 0 {
+		if uint64(r.Memory) <= usage {
+			return fmt.Errorf("rejecting memory limit %d <= usage %d", r.Memory, usage)
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/hugetlb.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/hugetlb.go
@@ -1,0 +1,70 @@
+package fs2
+
+import (
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fscommon"
+)
+
+func isHugeTlbSet(r *cgroups.Resources) bool {
+	return len(r.HugetlbLimit) > 0
+}
+
+func setHugeTlb(dirPath string, r *cgroups.Resources) error {
+	if !isHugeTlbSet(r) {
+		return nil
+	}
+	const suffix = ".max"
+	skipRsvd := false
+	for _, hugetlb := range r.HugetlbLimit {
+		prefix := "hugetlb." + hugetlb.Pagesize
+		val := strconv.FormatUint(hugetlb.Limit, 10)
+		if err := cgroups.WriteFile(dirPath, prefix+suffix, val); err != nil {
+			return err
+		}
+		if skipRsvd {
+			continue
+		}
+		if err := cgroups.WriteFile(dirPath, prefix+".rsvd"+suffix, val); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				skipRsvd = true
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
+	hugetlbStats := cgroups.HugetlbStats{}
+	rsvd := ".rsvd"
+
+	for _, pagesize := range cgroups.HugePageSizes() {
+		prefix := "hugetlb." + pagesize
+	again:
+		value, err := fscommon.GetCgroupParamUint(dirPath, prefix+rsvd+".current")
+		if err != nil {
+			if rsvd != "" && errors.Is(err, os.ErrNotExist) {
+				rsvd = ""
+				goto again
+			}
+			return err
+		}
+		hugetlbStats.Usage = value
+
+		value, err = fscommon.GetValueByKey(dirPath, prefix+".events", "max")
+		if err != nil {
+			return err
+		}
+		hugetlbStats.Failcnt = value
+
+		stats.HugetlbStats[pagesize] = hugetlbStats
+	}
+
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/io.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/io.go
@@ -1,0 +1,203 @@
+package fs2
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/opencontainers/cgroups"
+)
+
+func isIoSet(r *cgroups.Resources) bool {
+	return r.BlkioWeight != 0 ||
+		len(r.BlkioWeightDevice) > 0 ||
+		len(r.BlkioThrottleReadBpsDevice) > 0 ||
+		len(r.BlkioThrottleWriteBpsDevice) > 0 ||
+		len(r.BlkioThrottleReadIOPSDevice) > 0 ||
+		len(r.BlkioThrottleWriteIOPSDevice) > 0
+}
+
+// bfqDeviceWeightSupported checks for per-device BFQ weight support (added
+// in kernel v5.4, commit 795fe54c2a8) by reading from "io.bfq.weight".
+func bfqDeviceWeightSupported(bfq *os.File) bool {
+	if bfq == nil {
+		return false
+	}
+	_, _ = bfq.Seek(0, 0)
+	buf := make([]byte, 32)
+	_, _ = bfq.Read(buf)
+	// If only a single number (default weight) if read back, we have older kernel.
+	_, err := strconv.ParseInt(string(bytes.TrimSpace(buf)), 10, 64)
+	return err != nil
+}
+
+func setIo(dirPath string, r *cgroups.Resources) error {
+	if !isIoSet(r) {
+		return nil
+	}
+
+	// If BFQ IO scheduler is available, use it.
+	var bfq *os.File
+	if r.BlkioWeight != 0 || len(r.BlkioWeightDevice) > 0 {
+		var err error
+		bfq, err = cgroups.OpenFile(dirPath, "io.bfq.weight", os.O_RDWR)
+		if err == nil {
+			defer bfq.Close()
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	if r.BlkioWeight != 0 {
+		if bfq != nil { // Use BFQ.
+			if _, err := bfq.WriteString(strconv.FormatUint(uint64(r.BlkioWeight), 10)); err != nil {
+				return err
+			}
+		} else {
+			// Fallback to io.weight with a conversion scheme.
+			v := cgroups.ConvertBlkIOToIOWeightValue(r.BlkioWeight)
+			if err := cgroups.WriteFile(dirPath, "io.weight", strconv.FormatUint(v, 10)); err != nil {
+				return err
+			}
+		}
+	}
+	if bfqDeviceWeightSupported(bfq) {
+		for _, wd := range r.BlkioWeightDevice {
+			if _, err := bfq.WriteString(wd.WeightString() + "\n"); err != nil {
+				return fmt.Errorf("setting device weight %q: %w", wd.WeightString(), err)
+			}
+		}
+	}
+	for _, td := range r.BlkioThrottleReadBpsDevice {
+		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("rbps")); err != nil {
+			return err
+		}
+	}
+	for _, td := range r.BlkioThrottleWriteBpsDevice {
+		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("wbps")); err != nil {
+			return err
+		}
+	}
+	for _, td := range r.BlkioThrottleReadIOPSDevice {
+		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("riops")); err != nil {
+			return err
+		}
+	}
+	for _, td := range r.BlkioThrottleWriteIOPSDevice {
+		if err := cgroups.WriteFile(dirPath, "io.max", td.StringName("wiops")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readCgroup2MapFile(dirPath string, name string) (map[string][]string, error) {
+	ret := map[string][]string{}
+	f, err := cgroups.OpenFile(dirPath, name, os.O_RDONLY)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		ret[parts[0]] = parts[1:]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, &parseError{Path: dirPath, File: name, Err: err}
+	}
+	return ret, nil
+}
+
+func statIo(dirPath string, stats *cgroups.Stats) error {
+	const file = "io.stat"
+	values, err := readCgroup2MapFile(dirPath, file)
+	if err != nil {
+		return err
+	}
+	// more details on the io.stat file format: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
+	var parsedStats cgroups.BlkioStats
+	for k, v := range values {
+		d := strings.Split(k, ":")
+		if len(d) != 2 {
+			continue
+		}
+		major, err := strconv.ParseUint(d[0], 10, 64)
+		if err != nil {
+			return &parseError{Path: dirPath, File: file, Err: err}
+		}
+		minor, err := strconv.ParseUint(d[1], 10, 64)
+		if err != nil {
+			return &parseError{Path: dirPath, File: file, Err: err}
+		}
+
+		for _, item := range v {
+			d := strings.Split(item, "=")
+			if len(d) != 2 {
+				continue
+			}
+			op := d[0]
+
+			// Map to the cgroupv1 naming and layout (in separate tables).
+			var targetTable *[]cgroups.BlkioStatEntry
+			switch op {
+			// Equivalent to cgroupv1's blkio.io_service_bytes.
+			case "rbytes":
+				op = "Read"
+				targetTable = &parsedStats.IoServiceBytesRecursive
+			case "wbytes":
+				op = "Write"
+				targetTable = &parsedStats.IoServiceBytesRecursive
+			// Equivalent to cgroupv1's blkio.io_serviced.
+			case "rios":
+				op = "Read"
+				targetTable = &parsedStats.IoServicedRecursive
+			case "wios":
+				op = "Write"
+				targetTable = &parsedStats.IoServicedRecursive
+
+			case "cost.usage":
+				op = "Count"
+				targetTable = &parsedStats.IoCostUsage
+			case "cost.wait":
+				op = "Count"
+				targetTable = &parsedStats.IoCostWait
+			case "cost.indebt":
+				op = "Count"
+				targetTable = &parsedStats.IoCostIndebt
+			case "cost.indelay":
+				op = "Count"
+				targetTable = &parsedStats.IoCostIndelay
+
+			default:
+				logrus.Debugf("cgroupv2 io stats: unknown entry %s", item)
+				continue
+			}
+
+			value, err := strconv.ParseUint(d[1], 10, 64)
+			if err != nil {
+				return &parseError{Path: dirPath, File: file, Err: err}
+			}
+
+			entry := cgroups.BlkioStatEntry{
+				Op:    op,
+				Major: major,
+				Minor: minor,
+				Value: value,
+			}
+			*targetTable = append(*targetTable, entry)
+		}
+	}
+	stats.BlkioStats = parsedStats
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/memory.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/memory.go
@@ -1,0 +1,238 @@
+package fs2
+
+import (
+	"bufio"
+	"errors"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fscommon"
+)
+
+// numToStr converts an int64 value to a string for writing to a
+// cgroupv2 files with .min, .max, .low, or .high suffix.
+// The value of -1 is converted to "max" for cgroupv1 compatibility
+// (which used to write -1 to remove the limit).
+func numToStr(value int64) string {
+	switch value {
+	case 0:
+		return ""
+	case -1:
+		return "max"
+	}
+	return strconv.FormatInt(value, 10)
+}
+
+func isMemorySet(r *cgroups.Resources) bool {
+	return r.MemoryReservation != 0 || r.Memory != 0 || r.MemorySwap != 0
+}
+
+func setMemory(dirPath string, r *cgroups.Resources) error {
+	if !isMemorySet(r) {
+		return nil
+	}
+
+	if err := CheckMemoryUsage(dirPath, r); err != nil {
+		return err
+	}
+
+	swap, err := cgroups.ConvertMemorySwapToCgroupV2Value(r.MemorySwap, r.Memory)
+	if err != nil {
+		return err
+	}
+	swapStr := numToStr(swap)
+	if swapStr == "" && swap == 0 && r.MemorySwap > 0 {
+		// memory and memorySwap set to the same value -- disable swap
+		swapStr = "0"
+	}
+	// never write empty string to `memory.swap.max`, it means set to 0.
+	if swapStr != "" {
+		if err := cgroups.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
+			// If swap is not enabled, silently ignore setting to max or disabling it.
+			if !(errors.Is(err, os.ErrNotExist) && (swapStr == "max" || swapStr == "0")) { //nolint:staticcheck // Ignore "QF1001: could apply De Morgan's law".
+				return err
+			}
+		}
+	}
+
+	if val := numToStr(r.Memory); val != "" {
+		if err := cgroups.WriteFile(dirPath, "memory.max", val); err != nil {
+			return err
+		}
+	}
+
+	// cgroup.Resources.KernelMemory is ignored
+
+	if val := numToStr(r.MemoryReservation); val != "" {
+		if err := cgroups.WriteFile(dirPath, "memory.low", val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func statMemory(dirPath string, stats *cgroups.Stats) error {
+	const file = "memory.stat"
+	statsFile, err := cgroups.OpenFile(dirPath, file, os.O_RDONLY)
+	if err != nil {
+		return err
+	}
+	defer statsFile.Close()
+
+	sc := bufio.NewScanner(statsFile)
+	for sc.Scan() {
+		t, v, err := fscommon.ParseKeyValue(sc.Text())
+		if err != nil {
+			return &parseError{Path: dirPath, File: file, Err: err}
+		}
+		stats.MemoryStats.Stats[t] = v
+	}
+	if err := sc.Err(); err != nil {
+		return &parseError{Path: dirPath, File: file, Err: err}
+	}
+	stats.MemoryStats.Cache = stats.MemoryStats.Stats["file"]
+	// Unlike cgroup v1 which has memory.use_hierarchy binary knob,
+	// cgroup v2 is always hierarchical.
+	stats.MemoryStats.UseHierarchy = true
+
+	memoryUsage, err := getMemoryDataV2(dirPath, "")
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) && dirPath == UnifiedMountpoint {
+			// The root cgroup does not have memory.{current,max,peak}
+			// so emulate those using data from /proc/meminfo and
+			// /sys/fs/cgroup/memory.stat
+			return rootStatsFromMeminfo(stats)
+		}
+		return err
+	}
+	stats.MemoryStats.Usage = memoryUsage
+	swapOnlyUsage, err := getMemoryDataV2(dirPath, "swap")
+	if err != nil {
+		return err
+	}
+	stats.MemoryStats.SwapOnlyUsage = swapOnlyUsage
+	swapUsage := swapOnlyUsage
+	// As cgroup v1 reports SwapUsage values as mem+swap combined,
+	// while in cgroup v2 swap values do not include memory,
+	// report combined mem+swap for v1 compatibility.
+	swapUsage.Usage += memoryUsage.Usage
+	if swapUsage.Limit != math.MaxUint64 {
+		swapUsage.Limit += memoryUsage.Limit
+	}
+	// The `MaxUsage` of mem+swap cannot simply combine mem with
+	// swap. So set it to 0 for v1 compatibility.
+	swapUsage.MaxUsage = 0
+	stats.MemoryStats.SwapUsage = swapUsage
+
+	return nil
+}
+
+func getMemoryDataV2(path, name string) (cgroups.MemoryData, error) {
+	memoryData := cgroups.MemoryData{}
+
+	moduleName := "memory"
+	if name != "" {
+		moduleName = "memory." + name
+	}
+	usage := moduleName + ".current"
+	limit := moduleName + ".max"
+	maxUsage := moduleName + ".peak"
+
+	value, err := fscommon.GetCgroupParamUint(path, usage)
+	if err != nil {
+		if name != "" && os.IsNotExist(err) {
+			// Ignore EEXIST as there's no swap accounting
+			// if kernel CONFIG_MEMCG_SWAP is not set or
+			// swapaccount=0 kernel boot parameter is given.
+			return cgroups.MemoryData{}, nil
+		}
+		return cgroups.MemoryData{}, err
+	}
+	memoryData.Usage = value
+
+	value, err = fscommon.GetCgroupParamUint(path, limit)
+	if err != nil {
+		return cgroups.MemoryData{}, err
+	}
+	memoryData.Limit = value
+
+	// `memory.peak` since kernel 5.19
+	// `memory.swap.peak` since kernel 6.5
+	value, err = fscommon.GetCgroupParamUint(path, maxUsage)
+	if err != nil && !os.IsNotExist(err) {
+		return cgroups.MemoryData{}, err
+	}
+	memoryData.MaxUsage = value
+
+	return memoryData, nil
+}
+
+func rootStatsFromMeminfo(stats *cgroups.Stats) error {
+	const file = "/proc/meminfo"
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Fields we are interested in.
+	var (
+		swap_free  uint64
+		swap_total uint64
+	)
+	mem := map[string]*uint64{
+		"SwapFree":  &swap_free,
+		"SwapTotal": &swap_total,
+	}
+
+	found := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		parts := strings.SplitN(sc.Text(), ":", 3)
+		if len(parts) != 2 {
+			// Should not happen.
+			continue
+		}
+		k := parts[0]
+		p, ok := mem[k]
+		if !ok {
+			// Unknown field -- not interested.
+			continue
+		}
+		vStr := strings.TrimSpace(strings.TrimSuffix(parts[1], " kB"))
+		*p, err = strconv.ParseUint(vStr, 10, 64)
+		if err != nil {
+			return &parseError{File: file, Err: errors.New("bad value for " + k)}
+		}
+
+		found++
+		if found == len(mem) {
+			// Got everything we need -- skip the rest.
+			break
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return &parseError{Path: "", File: file, Err: err}
+	}
+
+	// cgroup v1 `usage_in_bytes` reports memory usage as the sum of
+	// - rss (NR_ANON_MAPPED)
+	// - cache (NR_FILE_PAGES)
+	// cgroup v1 reports SwapUsage values as mem+swap combined
+	// cgroup v2 reports rss and cache as anon and file.
+	// sum `anon` + `file` to report the same value as `usage_in_bytes` in v1.
+	// sum swap usage as combined mem+swap usage for consistency as well.
+	stats.MemoryStats.Usage.Usage = stats.MemoryStats.Stats["anon"] + stats.MemoryStats.Stats["file"]
+	stats.MemoryStats.Usage.Limit = math.MaxUint64
+	stats.MemoryStats.SwapUsage.Usage = (swap_total - swap_free) * 1024
+	stats.MemoryStats.SwapUsage.Limit = math.MaxUint64
+	stats.MemoryStats.SwapUsage.Usage += stats.MemoryStats.Usage.Usage
+
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/misc.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/misc.go
@@ -1,0 +1,52 @@
+package fs2
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fscommon"
+)
+
+func statMisc(dirPath string, stats *cgroups.Stats) error {
+	for _, file := range []string{"current", "events"} {
+		fd, err := cgroups.OpenFile(dirPath, "misc."+file, os.O_RDONLY)
+		if err != nil {
+			return err
+		}
+
+		s := bufio.NewScanner(fd)
+		for s.Scan() {
+			key, value, err := fscommon.ParseKeyValue(s.Text())
+			if err != nil {
+				fd.Close()
+				return err
+			}
+
+			key = strings.TrimSuffix(key, ".max")
+
+			if _, ok := stats.MiscStats[key]; !ok {
+				stats.MiscStats[key] = cgroups.MiscStats{}
+			}
+
+			tmp := stats.MiscStats[key]
+
+			switch file {
+			case "current":
+				tmp.Usage = value
+			case "events":
+				tmp.Events = value
+			}
+
+			stats.MiscStats[key] = tmp
+		}
+		fd.Close()
+
+		if err := s.Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/pids.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/pids.go
@@ -1,0 +1,79 @@
+package fs2
+
+import (
+	"errors"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/opencontainers/cgroups/fscommon"
+)
+
+func isPidsSet(r *cgroups.Resources) bool {
+	return r.PidsLimit != nil
+}
+
+func setPids(dirPath string, r *cgroups.Resources) error {
+	if !isPidsSet(r) {
+		return nil
+	}
+	val := "max"
+	if limit := *r.PidsLimit; limit > 0 {
+		val = strconv.FormatInt(limit, 10)
+	} else if limit == 0 {
+		// systemd doesn't support setting pids.max to "0", so when setting
+		// TasksMax we need to remap it to "1". We do the same thing here to
+		// avoid flip-flop behaviour between the fs and systemd drivers. In
+		// practice, the pids cgroup behaviour is basically identical.
+		val = "1"
+	}
+	if err := cgroups.WriteFile(dirPath, "pids.max", val); err != nil {
+		return err
+	}
+	return nil
+}
+
+func statPidsFromCgroupProcs(dirPath string, stats *cgroups.Stats) error {
+	// if the controller is not enabled, let's read PIDS from cgroups.procs
+	// (or threads if cgroup.threads is enabled)
+	contents, err := cgroups.ReadFile(dirPath, "cgroup.procs")
+	if errors.Is(err, unix.ENOTSUP) {
+		contents, err = cgroups.ReadFile(dirPath, "cgroup.threads")
+	}
+	if err != nil {
+		return err
+	}
+	pids := strings.Count(contents, "\n")
+	stats.PidsStats.Current = uint64(pids)
+	stats.PidsStats.Limit = 0
+	return nil
+}
+
+func statPids(dirPath string, stats *cgroups.Stats) error {
+	current, err := fscommon.GetCgroupParamUint(dirPath, "pids.current")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return statPidsFromCgroupProcs(dirPath, stats)
+		}
+		return err
+	}
+
+	max, err := fscommon.GetCgroupParamUint(dirPath, "pids.max")
+	if err != nil {
+		return err
+	}
+	// If no limit is set, read from pids.max returns "max", which is
+	// converted to MaxUint64 by GetCgroupParamUint. Historically, we
+	// represent "no limit" for pids as 0, thus this conversion.
+	if max == math.MaxUint64 {
+		max = 0
+	}
+
+	stats.PidsStats.Current = current
+	stats.PidsStats.Limit = max
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fs2/psi.go
+++ b/vendor/github.com/opencontainers/cgroups/fs2/psi.go
@@ -1,0 +1,89 @@
+package fs2
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/cgroups"
+)
+
+func statPSI(dirPath string, file string) (*cgroups.PSIStats, error) {
+	f, err := cgroups.OpenFile(dirPath, file, os.O_RDONLY)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Kernel < 4.20, or CONFIG_PSI is not set,
+			// or PSI stats are turned off for the cgroup
+			// ("echo 0 > cgroup.pressure", kernel >= 6.1).
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var psistats cgroups.PSIStats
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		parts := strings.Fields(sc.Text())
+		var pv *cgroups.PSIData
+		switch parts[0] {
+		case "some":
+			pv = &psistats.Some
+		case "full":
+			pv = &psistats.Full
+		}
+		if pv != nil {
+			*pv, err = parsePSIData(parts[1:])
+			if err != nil {
+				return nil, &parseError{Path: dirPath, File: file, Err: err}
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		if errors.Is(err, unix.ENOTSUP) {
+			// Some kernels (e.g. CS9) may return ENOTSUP on read
+			// if psi=1 kernel cmdline parameter is required.
+			return nil, nil
+		}
+		return nil, &parseError{Path: dirPath, File: file, Err: err}
+	}
+	return &psistats, nil
+}
+
+func parsePSIData(psi []string) (cgroups.PSIData, error) {
+	data := cgroups.PSIData{}
+	for _, f := range psi {
+		key, val, ok := strings.Cut(f, "=")
+		if !ok {
+			return data, fmt.Errorf("invalid psi data: %q", f)
+		}
+		var pv *float64
+		switch key {
+		case "avg10":
+			pv = &data.Avg10
+		case "avg60":
+			pv = &data.Avg60
+		case "avg300":
+			pv = &data.Avg300
+		case "total":
+			v, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return data, fmt.Errorf("invalid %s PSI value: %w", key, err)
+			}
+			data.Total = v
+		}
+		if pv != nil {
+			v, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				return data, fmt.Errorf("invalid %s PSI value: %w", key, err)
+			}
+			*pv = v
+		}
+	}
+	return data, nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fscommon/rdma.go
+++ b/vendor/github.com/opencontainers/cgroups/fscommon/rdma.go
@@ -1,0 +1,120 @@
+package fscommon
+
+import (
+	"bufio"
+	"errors"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/cgroups"
+)
+
+// parseRdmaKV parses raw string to RdmaEntry.
+func parseRdmaKV(raw string, entry *cgroups.RdmaEntry) error {
+	var value uint32
+
+	k, v, ok := strings.Cut(raw, "=")
+
+	if !ok {
+		return errors.New("Unable to parse RDMA entry")
+	}
+
+	if v == "max" {
+		value = math.MaxUint32
+	} else {
+		val64, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return err
+		}
+		value = uint32(val64)
+	}
+	switch k {
+	case "hca_handle":
+		entry.HcaHandles = value
+	case "hca_object":
+		entry.HcaObjects = value
+	}
+
+	return nil
+}
+
+// readRdmaEntries reads and converts array of rawstrings to RdmaEntries from file.
+// example entry: mlx4_0 hca_handle=2 hca_object=2000
+func readRdmaEntries(dir, file string) ([]cgroups.RdmaEntry, error) {
+	rdmaEntries := make([]cgroups.RdmaEntry, 0)
+	fd, err := cgroups.OpenFile(dir, file, unix.O_RDONLY)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+	scanner := bufio.NewScanner(fd)
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), " ", 4)
+		if len(parts) == 3 {
+			entry := new(cgroups.RdmaEntry)
+			entry.Device = parts[0]
+			err = parseRdmaKV(parts[1], entry)
+			if err != nil {
+				continue
+			}
+			err = parseRdmaKV(parts[2], entry)
+			if err != nil {
+				continue
+			}
+
+			rdmaEntries = append(rdmaEntries, *entry)
+		}
+	}
+	return rdmaEntries, scanner.Err()
+}
+
+// RdmaGetStats returns rdma stats such as totalLimit and current entries.
+func RdmaGetStats(path string, stats *cgroups.Stats) error {
+	currentEntries, err := readRdmaEntries(path, "rdma.current")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = nil
+		}
+		return err
+	}
+	maxEntries, err := readRdmaEntries(path, "rdma.max")
+	if err != nil {
+		return err
+	}
+	// If device got removed between reading two files, ignore returning stats.
+	if len(currentEntries) != len(maxEntries) {
+		return nil
+	}
+
+	stats.RdmaStats = cgroups.RdmaStats{
+		RdmaLimit:   maxEntries,
+		RdmaCurrent: currentEntries,
+	}
+
+	return nil
+}
+
+func createCmdString(device string, limits cgroups.LinuxRdma) string {
+	cmdString := device
+	if limits.HcaHandles != nil {
+		cmdString += " hca_handle=" + strconv.FormatUint(uint64(*limits.HcaHandles), 10)
+	}
+	if limits.HcaObjects != nil {
+		cmdString += " hca_object=" + strconv.FormatUint(uint64(*limits.HcaObjects), 10)
+	}
+	return cmdString
+}
+
+// RdmaSet sets RDMA resources.
+func RdmaSet(path string, r *cgroups.Resources) error {
+	for device, limits := range r.Rdma {
+		if err := cgroups.WriteFile(path, "rdma.max", createCmdString(device, limits)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/opencontainers/cgroups/fscommon/utils.go
+++ b/vendor/github.com/opencontainers/cgroups/fscommon/utils.go
@@ -1,0 +1,143 @@
+package fscommon
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/cgroups"
+)
+
+var (
+	// Deprecated: use cgroups.OpenFile instead.
+	OpenFile = cgroups.OpenFile
+	// Deprecated: use cgroups.ReadFile instead.
+	ReadFile = cgroups.ReadFile
+	// Deprecated: use cgroups.WriteFile instead.
+	WriteFile = cgroups.WriteFile
+)
+
+// ParseError records a parse error details, including the file path.
+type ParseError struct {
+	Path string
+	File string
+	Err  error
+}
+
+func (e *ParseError) Error() string {
+	return "unable to parse " + path.Join(e.Path, e.File) + ": " + e.Err.Error()
+}
+
+func (e *ParseError) Unwrap() error { return e.Err }
+
+// ParseUint converts a string to an uint64 integer.
+// Negative values are returned at zero as, due to kernel bugs,
+// some of the memory cgroup stats can be negative.
+func ParseUint(s string, base, bitSize int) (uint64, error) {
+	value, err := strconv.ParseUint(s, base, bitSize)
+	if err != nil {
+		intValue, intErr := strconv.ParseInt(s, base, bitSize)
+		// 1. Handle negative values greater than MinInt64 (and)
+		// 2. Handle negative values lesser than MinInt64
+		if intErr == nil && intValue < 0 {
+			return 0, nil
+		} else if errors.Is(intErr, strconv.ErrRange) && intValue < 0 {
+			return 0, nil
+		}
+
+		return value, err
+	}
+
+	return value, nil
+}
+
+// ParseKeyValue parses a space-separated "key value" kind of cgroup
+// parameter and returns its key as a string, and its value as uint64
+// (using [ParseUint] to convert the value). For example,
+// "io_service_bytes 1234" will be returned as "io_service_bytes", 1234.
+func ParseKeyValue(t string) (string, uint64, error) {
+	key, val, ok := strings.Cut(t, " ")
+	if !ok || key == "" || val == "" {
+		return "", 0, fmt.Errorf(`line %q is not in "key value" format`, t)
+	}
+
+	value, err := ParseUint(val, 10, 64)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return key, value, nil
+}
+
+// GetValueByKey reads space-separated "key value" pairs from the specified
+// cgroup file, looking for a specified key, and returns its value as uint64,
+// using [ParseUint] for conversion. If the value is not found, 0 is returned.
+func GetValueByKey(path, file, key string) (uint64, error) {
+	content, err := cgroups.ReadFile(path, file)
+	if err != nil {
+		return 0, err
+	}
+
+	key += " "
+	for line := range strings.SplitSeq(content, "\n") {
+		v, ok := strings.CutPrefix(line, key)
+		if ok {
+			val, err := ParseUint(v, 10, 64)
+			if err != nil {
+				err = &ParseError{Path: path, File: file, Err: err}
+			}
+			return val, err
+		}
+	}
+
+	return 0, nil
+}
+
+// GetCgroupParamUint reads a single uint64 value from the specified cgroup file.
+// If the value read is "max", the math.MaxUint64 is returned.
+func GetCgroupParamUint(path, file string) (uint64, error) {
+	contents, err := GetCgroupParamString(path, file)
+	if err != nil {
+		return 0, err
+	}
+	if contents == "max" {
+		return math.MaxUint64, nil
+	}
+
+	res, err := ParseUint(contents, 10, 64)
+	if err != nil {
+		return res, &ParseError{Path: path, File: file, Err: err}
+	}
+	return res, nil
+}
+
+// GetCgroupParamInt reads a single int64 value from specified cgroup file.
+// If the value read is "max", the math.MaxInt64 is returned.
+func GetCgroupParamInt(path, file string) (int64, error) {
+	contents, err := GetCgroupParamString(path, file)
+	if err != nil {
+		return 0, err
+	}
+	if contents == "max" {
+		return math.MaxInt64, nil
+	}
+
+	res, err := strconv.ParseInt(contents, 10, 64)
+	if err != nil {
+		return res, &ParseError{Path: path, File: file, Err: err}
+	}
+	return res, nil
+}
+
+// GetCgroupParamString reads a string from the specified cgroup file.
+func GetCgroupParamString(path, file string) (string, error) {
+	contents, err := cgroups.ReadFile(path, file)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(contents), nil
+}

--- a/vendor/github.com/opencontainers/cgroups/getallpids.go
+++ b/vendor/github.com/opencontainers/cgroups/getallpids.go
@@ -1,0 +1,27 @@
+package cgroups
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// GetAllPids returns all pids from the cgroup identified by path, and all its
+// sub-cgroups.
+func GetAllPids(path string) ([]int, error) {
+	var pids []int
+	err := filepath.WalkDir(path, func(p string, d fs.DirEntry, iErr error) error {
+		if iErr != nil {
+			return iErr
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		cPids, err := readProcsFile(p)
+		if err != nil {
+			return err
+		}
+		pids = append(pids, cPids...)
+		return nil
+	})
+	return pids, err
+}

--- a/vendor/github.com/opencontainers/cgroups/internal/path/path.go
+++ b/vendor/github.com/opencontainers/cgroups/internal/path/path.go
@@ -1,0 +1,52 @@
+package path
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/opencontainers/cgroups"
+)
+
+// Inner returns a path to cgroup relative to a cgroup mount point, based
+// on cgroup configuration, or an error, if cgroup configuration is invalid.
+// To be used only by fs cgroup managers (systemd has different path rules).
+func Inner(c *cgroups.Cgroup) (string, error) {
+	if (c.Name != "" || c.Parent != "") && c.Path != "" {
+		return "", errors.New("cgroup: either Path or Name and Parent should be used")
+	}
+
+	// XXX: Do not remove cleanPath. Path safety is important! -- cyphar
+	innerPath := cleanPath(c.Path)
+	if innerPath == "" {
+		cgParent := cleanPath(c.Parent)
+		cgName := cleanPath(c.Name)
+		innerPath = filepath.Join(cgParent, cgName)
+	}
+
+	return innerPath, nil
+}
+
+// cleanPath is a copy of github.com/opencontainers/runc/libcontainer/utils.CleanPath.
+func cleanPath(path string) string {
+	// Deal with empty strings nicely.
+	if path == "" {
+		return ""
+	}
+
+	// Ensure that all paths are cleaned (especially problematic ones like
+	// "/../../../../../" which can cause lots of issues).
+
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+
+	// If the path isn't absolute, we need to do more processing to fix paths
+	// such as "../../../../<etc>/some/path". We also shouldn't convert absolute
+	// paths to relative ones.
+	path = filepath.Clean(string(os.PathSeparator) + path)
+	// This can't fail, as (by definition) all paths are relative to root.
+	path, _ = filepath.Rel(string(os.PathSeparator), path)
+
+	return path
+}

--- a/vendor/github.com/opencontainers/cgroups/stats.go
+++ b/vendor/github.com/opencontainers/cgroups/stats.go
@@ -1,0 +1,239 @@
+package cgroups
+
+type ThrottlingData struct {
+	// Number of periods with throttling active
+	Periods uint64 `json:"periods,omitzero"`
+	// Number of periods when the container hit its throttling limit.
+	ThrottledPeriods uint64 `json:"throttled_periods,omitzero"`
+	// Aggregate time the container was throttled for in nanoseconds.
+	ThrottledTime uint64 `json:"throttled_time,omitzero"`
+}
+
+type BurstData struct {
+	// Number of periods bandwidth burst occurs
+	BurstsPeriods uint64 `json:"bursts_periods,omitzero"`
+	// Cumulative wall-time that any cpus has used above quota in respective periods
+	// Units: nanoseconds.
+	BurstTime uint64 `json:"burst_time,omitzero"`
+}
+
+// CpuUsage denotes the usage of a CPU.
+// All CPU stats are aggregate since container inception.
+type CpuUsage struct {
+	// Total CPU time consumed.
+	// Units: nanoseconds.
+	TotalUsage uint64 `json:"total_usage,omitzero"`
+	// Total CPU time consumed per core.
+	// Units: nanoseconds.
+	PercpuUsage []uint64 `json:"percpu_usage,omitzero"`
+	// CPU time consumed per core in kernel mode
+	// Units: nanoseconds.
+	PercpuUsageInKernelmode []uint64 `json:"percpu_usage_in_kernelmode"`
+	// CPU time consumed per core in user mode
+	// Units: nanoseconds.
+	PercpuUsageInUsermode []uint64 `json:"percpu_usage_in_usermode"`
+	// Time spent by tasks of the cgroup in kernel mode.
+	// Units: nanoseconds.
+	UsageInKernelmode uint64 `json:"usage_in_kernelmode"`
+	// Time spent by tasks of the cgroup in user mode.
+	// Units: nanoseconds.
+	UsageInUsermode uint64 `json:"usage_in_usermode"`
+}
+
+type PSIData struct {
+	Avg10  float64 `json:"avg10"`
+	Avg60  float64 `json:"avg60"`
+	Avg300 float64 `json:"avg300"`
+	Total  uint64  `json:"total"`
+}
+
+type PSIStats struct {
+	Some PSIData `json:"some,omitzero"`
+	Full PSIData `json:"full,omitzero"`
+}
+
+type CpuStats struct {
+	CpuUsage       CpuUsage       `json:"cpu_usage,omitzero"`
+	ThrottlingData ThrottlingData `json:"throttling_data,omitzero"`
+	PSI            *PSIStats      `json:"psi,omitzero"`
+	BurstData      BurstData      `json:"burst_data,omitzero"`
+}
+
+type CPUSetStats struct {
+	// List of the physical numbers of the CPUs on which processes
+	// in that cpuset are allowed to execute
+	CPUs []uint16 `json:"cpus,omitzero"`
+	// cpu_exclusive flag
+	CPUExclusive uint64 `json:"cpu_exclusive"`
+	// List of memory nodes on which processes in that cpuset
+	// are allowed to allocate memory
+	Mems []uint16 `json:"mems,omitzero"`
+	// mem_hardwall flag
+	MemHardwall uint64 `json:"mem_hardwall"`
+	// mem_exclusive flag
+	MemExclusive uint64 `json:"mem_exclusive"`
+	// memory_migrate flag
+	MemoryMigrate uint64 `json:"memory_migrate"`
+	// memory_spread page flag
+	MemorySpreadPage uint64 `json:"memory_spread_page"`
+	// memory_spread slab flag
+	MemorySpreadSlab uint64 `json:"memory_spread_slab"`
+	// memory_pressure
+	MemoryPressure uint64 `json:"memory_pressure"`
+	// sched_load balance flag
+	SchedLoadBalance uint64 `json:"sched_load_balance"`
+	// sched_relax_domain_level
+	SchedRelaxDomainLevel int64 `json:"sched_relax_domain_level"`
+}
+
+type MemoryData struct {
+	Usage    uint64 `json:"usage,omitzero"`
+	MaxUsage uint64 `json:"max_usage,omitzero"`
+	Failcnt  uint64 `json:"failcnt"`
+	Limit    uint64 `json:"limit"`
+}
+
+type MemoryStats struct {
+	// memory used for cache
+	Cache uint64 `json:"cache,omitzero"`
+	// usage of memory
+	Usage MemoryData `json:"usage,omitzero"`
+	// usage of memory + swap
+	SwapUsage MemoryData `json:"swap_usage,omitzero"`
+	// usage of swap only
+	SwapOnlyUsage MemoryData `json:"swap_only_usage,omitzero"`
+	// usage of kernel memory
+	KernelUsage MemoryData `json:"kernel_usage,omitzero"`
+	// usage of kernel TCP memory
+	KernelTCPUsage MemoryData `json:"kernel_tcp_usage,omitzero"`
+	// usage of memory pages by NUMA node
+	// see chapter 5.6 of memory controller documentation
+	PageUsageByNUMA PageUsageByNUMA `json:"page_usage_by_numa,omitzero"`
+	// if true, memory usage is accounted for throughout a hierarchy of cgroups.
+	UseHierarchy bool `json:"use_hierarchy"`
+
+	Stats map[string]uint64 `json:"stats,omitzero"`
+	PSI   *PSIStats         `json:"psi,omitzero"`
+}
+
+type PageUsageByNUMA struct {
+	// Embedding is used as types can't be recursive.
+	PageUsageByNUMAInner
+	Hierarchical PageUsageByNUMAInner `json:"hierarchical,omitzero"`
+}
+
+type PageUsageByNUMAInner struct {
+	Total       PageStats `json:"total,omitzero"`
+	File        PageStats `json:"file,omitzero"`
+	Anon        PageStats `json:"anon,omitzero"`
+	Unevictable PageStats `json:"unevictable,omitzero"`
+}
+
+type PageStats struct {
+	Total uint64           `json:"total,omitzero"`
+	Nodes map[uint8]uint64 `json:"nodes,omitzero"`
+}
+
+type PidsStats struct {
+	// number of pids in the cgroup
+	Current uint64 `json:"current,omitzero"`
+	// active pids hard limit
+	Limit uint64 `json:"limit,omitzero"`
+}
+
+type BlkioStatEntry struct {
+	Major uint64 `json:"major,omitzero"`
+	Minor uint64 `json:"minor,omitzero"`
+	Op    string `json:"op,omitzero"`
+	Value uint64 `json:"value,omitzero"`
+}
+
+type BlkioStats struct {
+	// number of bytes transferred to and from the block device
+	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive,omitzero"`
+	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recursive,omitzero"`
+	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive,omitzero"`
+	IoServiceTimeRecursive  []BlkioStatEntry `json:"io_service_time_recursive,omitzero"`
+	IoWaitTimeRecursive     []BlkioStatEntry `json:"io_wait_time_recursive,omitzero"`
+	IoMergedRecursive       []BlkioStatEntry `json:"io_merged_recursive,omitzero"`
+	IoTimeRecursive         []BlkioStatEntry `json:"io_time_recursive,omitzero"`
+	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive,omitzero"`
+	PSI                     *PSIStats        `json:"psi,omitzero"`
+	IoCostUsage             []BlkioStatEntry `json:"io_cost_usage,omitzero"`
+	IoCostWait              []BlkioStatEntry `json:"io_cost_wait,omitzero"`
+	IoCostIndebt            []BlkioStatEntry `json:"io_cost_indebt,omitzero"`
+	IoCostIndelay           []BlkioStatEntry `json:"io_cost_indelay,omitzero"`
+}
+
+type HugetlbStats struct {
+	// current res_counter usage for hugetlb
+	Usage uint64 `json:"usage,omitzero"`
+	// maximum usage ever recorded.
+	MaxUsage uint64 `json:"max_usage,omitzero"`
+	// number of times hugetlb usage allocation failure.
+	Failcnt uint64 `json:"failcnt"`
+}
+
+type RdmaEntry struct {
+	Device     string `json:"device,omitzero"`
+	HcaHandles uint32 `json:"hca_handles,omitzero"`
+	HcaObjects uint32 `json:"hca_objects,omitzero"`
+}
+
+type RdmaStats struct {
+	RdmaLimit   []RdmaEntry `json:"rdma_limit,omitzero"`
+	RdmaCurrent []RdmaEntry `json:"rdma_current,omitzero"`
+}
+
+type MiscStats struct {
+	// current resource usage for a key in misc
+	Usage uint64 `json:"usage,omitzero"`
+	// number of times the resource usage was about to go over the max boundary
+	Events uint64 `json:"events,omitzero"`
+}
+
+type Stats struct {
+	CpuStats    CpuStats    `json:"cpu_stats,omitzero"`
+	CPUSetStats CPUSetStats `json:"cpuset_stats,omitzero"`
+	MemoryStats MemoryStats `json:"memory_stats,omitzero"`
+	PidsStats   PidsStats   `json:"pids_stats,omitzero"`
+	BlkioStats  BlkioStats  `json:"blkio_stats,omitzero"`
+	// the map is in the format "size of hugepage: stats of the hugepage"
+	HugetlbStats map[string]HugetlbStats `json:"hugetlb_stats,omitzero"`
+	RdmaStats    RdmaStats               `json:"rdma_stats,omitzero"`
+	// the map is in the format "misc resource name: stats of the key"
+	MiscStats map[string]MiscStats `json:"misc_stats,omitzero"`
+}
+
+func NewStats() *Stats {
+	memoryStats := MemoryStats{Stats: make(map[string]uint64)}
+	hugetlbStats := make(map[string]HugetlbStats)
+	miscStats := make(map[string]MiscStats)
+	return &Stats{MemoryStats: memoryStats, HugetlbStats: hugetlbStats, MiscStats: miscStats}
+}
+
+// Controller represents a cgroup controller type for stats collection.
+type Controller int
+
+// Controller types for cgroup stats collection.
+const (
+	CPU Controller = 1 << iota
+	Memory
+	Pids
+	IO
+	HugeTLB
+	RDMA
+	Misc
+	CPUSet // v1 only
+)
+
+// AllControllers is a bitmask of all available controllers.
+const AllControllers = CPU | Memory | Pids | IO | HugeTLB | RDMA | Misc | CPUSet
+
+// StatsOptions specifies which controllers to retrieve statistics for.
+type StatsOptions struct {
+	// Controllers is a bitmask of Controller values.
+	// If 0, all available controllers are queried (default behavior).
+	// Use Controller constants like: CPU | Memory | Pids
+	Controllers Controller
+}

--- a/vendor/github.com/opencontainers/cgroups/utils.go
+++ b/vendor/github.com/opencontainers/cgroups/utils.go
@@ -1,0 +1,483 @@
+package cgroups
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/moby/sys/userns"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	CgroupProcesses   = "cgroup.procs"
+	unifiedMountpoint = "/sys/fs/cgroup"
+	hybridMountpoint  = "/sys/fs/cgroup/unified"
+)
+
+var (
+	isUnifiedOnce sync.Once
+	isUnified     bool
+	isHybridOnce  sync.Once
+	isHybrid      bool
+)
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
+func IsCgroup2UnifiedMode() bool {
+	isUnifiedOnce.Do(func() {
+		var st unix.Statfs_t
+		err := unix.Statfs(unifiedMountpoint, &st)
+		if err != nil {
+			level := logrus.WarnLevel
+			if os.IsNotExist(err) && userns.RunningInUserNS() {
+				// For rootless containers, sweep it under the rug.
+				level = logrus.DebugLevel
+			}
+			logrus.StandardLogger().Logf(level,
+				"statfs %s: %v; assuming cgroup v1", unifiedMountpoint, err)
+		}
+		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
+	})
+	return isUnified
+}
+
+// IsCgroup2HybridMode returns whether we are running in cgroup v2 hybrid mode.
+func IsCgroup2HybridMode() bool {
+	isHybridOnce.Do(func() {
+		var st unix.Statfs_t
+		err := unix.Statfs(hybridMountpoint, &st)
+		if err != nil {
+			isHybrid = false
+			if !os.IsNotExist(err) {
+				// Report unexpected errors.
+				logrus.WithError(err).Debugf("statfs(%q) failed", hybridMountpoint)
+			}
+			return
+		}
+		isHybrid = st.Type == unix.CGROUP2_SUPER_MAGIC
+	})
+	return isHybrid
+}
+
+type Mount struct {
+	Mountpoint string
+	Root       string
+	Subsystems []string
+}
+
+// GetCgroupMounts returns the mounts for the cgroup subsystems.
+// all indicates whether to return just the first instance or all the mounts.
+// This function should not be used from cgroupv2 code, as in this case
+// all the controllers are available under the constant unifiedMountpoint.
+func GetCgroupMounts(all bool) ([]Mount, error) {
+	if IsCgroup2UnifiedMode() {
+		// TODO: remove cgroupv2 case once all external users are converted
+		availableControllers, err := GetAllSubsystems()
+		if err != nil {
+			return nil, err
+		}
+		m := Mount{
+			Mountpoint: unifiedMountpoint,
+			Root:       unifiedMountpoint,
+			Subsystems: availableControllers,
+		}
+		return []Mount{m}, nil
+	}
+
+	return getCgroupMountsV1(all)
+}
+
+// GetAllSubsystems returns all the cgroup subsystems supported by the kernel
+func GetAllSubsystems() ([]string, error) {
+	// /proc/cgroups is meaningless for v2
+	// https://github.com/torvalds/linux/blob/v5.3/Documentation/admin-guide/cgroup-v2.rst#deprecated-v1-core-features
+	if IsCgroup2UnifiedMode() {
+		// "pseudo" controllers do not appear in /sys/fs/cgroup/cgroup.controllers.
+		// - devices: implemented in kernel 4.15
+		// - freezer: implemented in kernel 5.2
+		// We assume these are always available, as it is hard to detect availability.
+		pseudo := []string{"devices", "freezer"}
+		data, err := ReadFile("/sys/fs/cgroup", "cgroup.controllers")
+		if err != nil {
+			return nil, err
+		}
+		subsystems := append(pseudo, strings.Fields(data)...)
+		return subsystems, nil
+	}
+	f, err := os.Open("/proc/cgroups")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	subsystems := []string{}
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		text := s.Text()
+		if text[0] != '#' {
+			parts := strings.Fields(text)
+			if len(parts) >= 4 && parts[3] != "0" {
+				subsystems = append(subsystems, parts[0])
+			}
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return subsystems, nil
+}
+
+func readProcsFile(dir string) (out []int, _ error) {
+	file := CgroupProcesses
+	retry := true
+
+again:
+	f, err := OpenFile(dir, file, os.O_RDONLY)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if t := s.Text(); t != "" {
+			pid, err := strconv.Atoi(t)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, pid)
+		}
+	}
+	if errors.Is(s.Err(), unix.ENOTSUP) && retry {
+		// For a threaded cgroup, read returns ENOTSUP, and we should
+		// read from cgroup.threads instead.
+		file = "cgroup.threads"
+		retry = false
+		goto again
+	}
+	return out, s.Err()
+}
+
+// ParseCgroupFile parses the given cgroup file, typically /proc/self/cgroup
+// or /proc/<pid>/cgroup, into a map of subsystems to cgroup paths, e.g.
+//
+//	"cpu": "/user.slice/user-1000.slice"
+//	"pids": "/user.slice/user-1000.slice"
+//
+// etc.
+//
+// Note that for cgroup v2 unified hierarchy, there are no per-controller
+// cgroup paths, so the resulting map will have a single element where the key
+// is empty string ("") and the value is the cgroup path the <pid> is in.
+func ParseCgroupFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return parseCgroupFromReader(f)
+}
+
+// helper function for ParseCgroupFile to make testing easier
+func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
+	s := bufio.NewScanner(r)
+	cgroups := make(map[string]string)
+
+	for s.Scan() {
+		text := s.Text()
+		// from cgroups(7):
+		// /proc/[pid]/cgroup
+		// ...
+		// For each cgroup hierarchy ... there is one entry
+		// containing three colon-separated fields of the form:
+		//     hierarchy-ID:subsystem-list:cgroup-path
+		parts := strings.SplitN(text, ":", 3)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid cgroup entry: must contain at least two colons: %v", text)
+		}
+
+		for subs := range strings.SplitSeq(parts[1], ",") {
+			cgroups[subs] = parts[2]
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return cgroups, nil
+}
+
+func PathExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return true
+}
+
+// rmdir tries to remove a directory, optionally retrying on EBUSY.
+func rmdir(path string, retry bool) error {
+	delay := time.Millisecond
+	tries := 10
+
+again:
+	err := unix.Rmdir(path)
+	switch err {
+	case nil, unix.ENOENT:
+		return nil
+	case unix.EINTR:
+		goto again
+	case unix.EBUSY:
+		if retry && tries > 0 {
+			time.Sleep(delay)
+			delay *= 2
+			tries--
+			goto again
+
+		}
+	}
+	return &os.PathError{Op: "rmdir", Path: path, Err: err}
+}
+
+// RemovePath aims to remove cgroup path. It does so recursively,
+// by removing any subdirectories (sub-cgroups) first.
+func RemovePath(path string) error {
+	// Try the fast path first; don't retry on EBUSY yet.
+	if err := rmdir(path, false); err == nil {
+		return nil
+	}
+
+	// There are many reasons why rmdir can fail, including:
+	// 1. cgroup have existing sub-cgroups;
+	// 2. cgroup (still) have some processes (that are about to vanish);
+	// 3. lack of permission (one example is read-only /sys/fs/cgroup mount,
+	//    in which case rmdir returns EROFS even for for a non-existent path,
+	//    see issue 4518).
+	//
+	// Using os.ReadDir here kills two birds with one stone: check if
+	// the directory exists (handling scenario 3 above), and use
+	// directory contents to remove sub-cgroups (handling scenario 1).
+	infos, err := os.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	// Let's remove sub-cgroups, if any.
+	for _, info := range infos {
+		if info.IsDir() {
+			if err = RemovePath(filepath.Join(path, info.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	// Finally, try rmdir again, this time with retries on EBUSY,
+	// which may help with scenario 2 above.
+	return rmdir(path, true)
+}
+
+// RemovePaths iterates over the provided paths removing them.
+func RemovePaths(paths map[string]string) (err error) {
+	for s, p := range paths {
+		if err := RemovePath(p); err == nil {
+			delete(paths, s)
+		}
+	}
+	if len(paths) == 0 {
+		clear(paths)
+		return nil
+	}
+	return fmt.Errorf("Failed to remove paths: %v", paths)
+}
+
+var (
+	hugePageSizes []string
+	initHPSOnce   sync.Once
+)
+
+func HugePageSizes() []string {
+	initHPSOnce.Do(func() {
+		dir, err := os.OpenFile("/sys/kernel/mm/hugepages", unix.O_DIRECTORY|unix.O_RDONLY, 0)
+		if err != nil {
+			return
+		}
+		files, err := dir.Readdirnames(0)
+		dir.Close()
+		if err != nil {
+			return
+		}
+
+		hugePageSizes, err = getHugePageSizeFromFilenames(files)
+		if err != nil {
+			logrus.Warn("HugePageSizes: ", err)
+		}
+	})
+
+	return hugePageSizes
+}
+
+func getHugePageSizeFromFilenames(fileNames []string) ([]string, error) {
+	pageSizes := make([]string, 0, len(fileNames))
+	var warn error
+
+	for _, file := range fileNames {
+		// example: hugepages-1048576kB
+		val, ok := strings.CutPrefix(file, "hugepages-")
+		if !ok {
+			// Unexpected file name: no prefix found, ignore it.
+			continue
+		}
+		// The suffix is always "kB" (as of Linux 5.13). If we find
+		// something else, produce an error but keep going.
+		eLen := len(val) - 2
+		val = strings.TrimSuffix(val, "kB")
+		if len(val) != eLen {
+			// Highly unlikely.
+			if warn == nil {
+				warn = errors.New(file + `: invalid suffix (expected "kB")`)
+			}
+			continue
+		}
+		size, err := strconv.Atoi(val)
+		if err != nil {
+			// Highly unlikely.
+			if warn == nil {
+				warn = fmt.Errorf("%s: %w", file, err)
+			}
+			continue
+		}
+		// Model after https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb_cgroup.c?id=eff48ddeab782e35e58ccc8853f7386bbae9dec4#n574
+		// but in our case the size is in KB already.
+		if size >= (1 << 20) {
+			val = strconv.Itoa(size>>20) + "GB"
+		} else if size >= (1 << 10) {
+			val = strconv.Itoa(size>>10) + "MB"
+		} else {
+			val += "KB"
+		}
+		pageSizes = append(pageSizes, val)
+	}
+
+	return pageSizes, warn
+}
+
+// GetPids returns all pids, that were added to cgroup at path.
+func GetPids(dir string) ([]int, error) {
+	return readProcsFile(dir)
+}
+
+// WriteCgroupProc writes the specified pid into the cgroup's cgroup.procs file
+func WriteCgroupProc(dir string, pid int) error {
+	// Normally dir should not be empty, one case is that cgroup subsystem
+	// is not mounted, we will get empty dir, and we want it fail here.
+	if dir == "" {
+		return fmt.Errorf("no such directory for %s", CgroupProcesses)
+	}
+
+	// Dont attach any pid to the cgroup if -1 is specified as a pid
+	if pid == -1 {
+		return nil
+	}
+
+	file, err := OpenFile(dir, CgroupProcesses, os.O_WRONLY)
+	if err != nil {
+		return fmt.Errorf("failed to write %v: %w", pid, err)
+	}
+	defer file.Close()
+
+	for range 5 {
+		_, err = file.WriteString(strconv.Itoa(pid))
+		if err == nil {
+			return nil
+		}
+
+		// EINVAL might mean that the task being added to cgroup.procs is in state
+		// TASK_NEW. We should attempt to do so again.
+		if errors.Is(err, unix.EINVAL) {
+			time.Sleep(30 * time.Millisecond)
+			continue
+		}
+
+		return fmt.Errorf("failed to write %v: %w", pid, err)
+	}
+	return err
+}
+
+// ConvertCPUSharesToCgroupV2Value converts CPU shares, used by cgroup v1,
+// to CPU weight, used by cgroup v2.
+//
+// Cgroup v1 CPU shares has a range of [2^1...2^18], i.e. [2...262144],
+// and the default value is 1024.
+//
+// Cgroup v2 CPU weight has a range of [10^0...10^4], i.e. [1...10000],
+// and the default value is 100.
+func ConvertCPUSharesToCgroupV2Value(cpuShares uint64) uint64 {
+	// The value of 0 means "unset".
+	if cpuShares == 0 {
+		return 0
+	}
+	if cpuShares <= 2 {
+		return 1
+	}
+	if cpuShares >= 262144 {
+		return 10000
+	}
+	l := math.Log2(float64(cpuShares))
+	// Quadratic function which fits min, max, and default.
+	exponent := (l*l+125*l)/612.0 - 7.0/34.0
+
+	return uint64(math.Ceil(math.Pow(10, exponent)))
+}
+
+// ConvertMemorySwapToCgroupV2Value converts MemorySwap value from OCI spec
+// for use by cgroup v2 drivers. A conversion is needed since Resources.MemorySwap
+// is defined as memory+swap combined, while in cgroup v2 swap is a separate value,
+// so we need to subtract memory from it where it makes sense.
+func ConvertMemorySwapToCgroupV2Value(memorySwap, memory int64) (int64, error) {
+	switch {
+	case memory == -1 && memorySwap == 0:
+		// For compatibility with cgroup1 controller, set swap to unlimited in
+		// case the memory is set to unlimited and the swap is not explicitly set,
+		// treating the request as "set both memory and swap to unlimited".
+		return -1, nil
+	case memorySwap == -1, memorySwap == 0:
+		// Treat -1 ("max") and 0 ("unset") swap as is.
+		return memorySwap, nil
+	case memory == -1:
+		// Unlimited memory, so treat swap as is.
+		return memorySwap, nil
+	case memory == 0:
+		// Unset or unknown memory, can't calculate swap.
+		return 0, errors.New("unable to set swap limit without memory limit")
+	case memory < 0:
+		// Does not make sense to subtract a negative value.
+		return 0, fmt.Errorf("invalid memory value: %d", memory)
+	case memorySwap < memory:
+		// Sanity check.
+		return 0, errors.New("memory+swap limit should be >= memory limit")
+	}
+
+	return memorySwap - memory, nil
+}
+
+// Since the OCI spec is designed for cgroup v1, in some cases
+// there is need to convert from the cgroup v1 configuration to cgroup v2
+// the formula for BlkIOWeight to IOWeight is y = (1 + (x - 10) * 9999 / 990)
+// convert linearly from [10-1000] to [1-10000]
+func ConvertBlkIOToIOWeightValue(blkIoWeight uint16) uint64 {
+	if blkIoWeight == 0 {
+		return 0
+	}
+	return 1 + (uint64(blkIoWeight)-10)*9999/990
+}

--- a/vendor/github.com/opencontainers/cgroups/v1_utils.go
+++ b/vendor/github.com/opencontainers/cgroups/v1_utils.go
@@ -1,0 +1,276 @@
+package cgroups
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/moby/sys/mountinfo"
+	"golang.org/x/sys/unix"
+)
+
+// Code in this source file are specific to cgroup v1,
+// and must not be used from any cgroup v2 code.
+
+const (
+	CgroupNamePrefix = "name="
+	defaultPrefix    = "/sys/fs/cgroup"
+)
+
+var (
+	errUnified     = errors.New("not implemented for cgroup v2 unified hierarchy")
+	ErrV1NoUnified = errors.New("invalid configuration: cannot use unified on cgroup v1")
+
+	readMountinfoOnce sync.Once
+	readMountinfoErr  error
+	cgroupMountinfo   []*mountinfo.Info
+)
+
+type NotFoundError struct {
+	Subsystem string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("mountpoint for %s not found", e.Subsystem)
+}
+
+func NewNotFoundError(sub string) error {
+	return &NotFoundError{
+		Subsystem: sub,
+	}
+}
+
+func IsNotFound(err error) bool {
+	var nfErr *NotFoundError
+	return errors.As(err, &nfErr)
+}
+
+func tryDefaultPath(cgroupPath, subsystem string) string {
+	if !strings.HasPrefix(defaultPrefix, cgroupPath) {
+		return ""
+	}
+
+	// remove possible prefix
+	subsystem = strings.TrimPrefix(subsystem, CgroupNamePrefix)
+
+	// Make sure we're still under defaultPrefix, and resolve
+	// a possible symlink (like cpu -> cpu,cpuacct).
+	path, err := securejoin.SecureJoin(defaultPrefix, subsystem)
+	if err != nil {
+		return ""
+	}
+
+	// (1) path should be a directory.
+	st, err := os.Lstat(path)
+	if err != nil || !st.IsDir() {
+		return ""
+	}
+
+	// (2) path should be a mount point.
+	pst, err := os.Lstat(filepath.Dir(path))
+	if err != nil {
+		return ""
+	}
+
+	if st.Sys().(*syscall.Stat_t).Dev == pst.Sys().(*syscall.Stat_t).Dev {
+		// parent dir has the same dev -- path is not a mount point
+		return ""
+	}
+
+	// (3) path should have 'cgroup' fs type.
+	fst := unix.Statfs_t{}
+	err = unix.Statfs(path, &fst)
+	if err != nil || fst.Type != unix.CGROUP_SUPER_MAGIC {
+		return ""
+	}
+
+	return path
+}
+
+// readCgroupMountinfo returns a list of cgroup v1 mounts (i.e. the ones
+// with fstype of "cgroup") for the current running process.
+//
+// The results are cached (to avoid re-reading mountinfo which is relatively
+// expensive), so it is assumed that cgroup mounts are not being changed.
+func readCgroupMountinfo() ([]*mountinfo.Info, error) {
+	readMountinfoOnce.Do(func() {
+		// mountinfo.GetMounts uses /proc/thread-self, so we can use it without
+		// issues.
+		cgroupMountinfo, readMountinfoErr = mountinfo.GetMounts(
+			mountinfo.FSTypeFilter("cgroup"),
+		)
+	})
+	return cgroupMountinfo, readMountinfoErr
+}
+
+// https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
+func FindCgroupMountpoint(cgroupPath, subsystem string) (string, error) {
+	if IsCgroup2UnifiedMode() {
+		return "", errUnified
+	}
+
+	// If subsystem is empty, we look for the cgroupv2 hybrid path.
+	if len(subsystem) == 0 {
+		return hybridMountpoint, nil
+	}
+
+	// Avoid parsing mountinfo by trying the default path first, if possible.
+	if path := tryDefaultPath(cgroupPath, subsystem); path != "" {
+		return path, nil
+	}
+
+	mnt, _, err := FindCgroupMountpointAndRoot(cgroupPath, subsystem)
+	return mnt, err
+}
+
+func FindCgroupMountpointAndRoot(cgroupPath, subsystem string) (string, string, error) {
+	if IsCgroup2UnifiedMode() {
+		return "", "", errUnified
+	}
+
+	mi, err := readCgroupMountinfo()
+	if err != nil {
+		return "", "", err
+	}
+
+	return findCgroupMountpointAndRootFromMI(mi, cgroupPath, subsystem)
+}
+
+func findCgroupMountpointAndRootFromMI(mounts []*mountinfo.Info, cgroupPath, subsystem string) (string, string, error) {
+	for _, mi := range mounts {
+		if strings.HasPrefix(mi.Mountpoint, cgroupPath) {
+			if slices.Contains(strings.Split(mi.VFSOptions, ","), subsystem) {
+				return mi.Mountpoint, mi.Root, nil
+			}
+		}
+	}
+
+	return "", "", NewNotFoundError(subsystem)
+}
+
+func (m Mount) GetOwnCgroup(cgroups map[string]string) (string, error) {
+	if len(m.Subsystems) == 0 {
+		return "", errors.New("no subsystem for mount")
+	}
+
+	return getControllerPath(m.Subsystems[0], cgroups)
+}
+
+func getCgroupMountsHelper(ss map[string]bool, mounts []*mountinfo.Info, all bool) ([]Mount, error) {
+	res := make([]Mount, 0, len(ss))
+	numFound := 0
+	for _, mi := range mounts {
+		m := Mount{
+			Mountpoint: mi.Mountpoint,
+			Root:       mi.Root,
+		}
+		for opt := range strings.SplitSeq(mi.VFSOptions, ",") {
+			seen, known := ss[opt]
+			if !known || (!all && seen) {
+				continue
+			}
+			ss[opt] = true
+			opt = strings.TrimPrefix(opt, CgroupNamePrefix)
+			m.Subsystems = append(m.Subsystems, opt)
+			numFound++
+		}
+		if len(m.Subsystems) > 0 || all {
+			res = append(res, m)
+		}
+		if !all && numFound >= len(ss) {
+			break
+		}
+	}
+	return res, nil
+}
+
+func getCgroupMountsV1(all bool) ([]Mount, error) {
+	mi, err := readCgroupMountinfo()
+	if err != nil {
+		return nil, err
+	}
+
+	// We don't need to use /proc/thread-self here because runc always runs
+	// with every thread in the same cgroup. This lets us avoid having to do
+	// runtime.LockOSThread.
+	allSubsystems, err := ParseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return nil, err
+	}
+
+	allMap := make(map[string]bool)
+	for s := range allSubsystems {
+		allMap[s] = false
+	}
+
+	return getCgroupMountsHelper(allMap, mi, all)
+}
+
+// GetOwnCgroup returns the relative path to the cgroup docker is running in.
+func GetOwnCgroup(subsystem string) (string, error) {
+	if IsCgroup2UnifiedMode() {
+		return "", errUnified
+	}
+
+	// We don't need to use /proc/thread-self here because runc always runs
+	// with every thread in the same cgroup. This lets us avoid having to do
+	// runtime.LockOSThread.
+	cgroups, err := ParseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+
+	return getControllerPath(subsystem, cgroups)
+}
+
+func GetOwnCgroupPath(subsystem string) (string, error) {
+	cgroup, err := GetOwnCgroup(subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	// If subsystem is empty, we look for the cgroupv2 hybrid path.
+	if len(subsystem) == 0 {
+		return hybridMountpoint, nil
+	}
+
+	return getCgroupPathHelper(subsystem, cgroup)
+}
+
+func getCgroupPathHelper(subsystem, cgroup string) (string, error) {
+	mnt, root, err := FindCgroupMountpointAndRoot("", subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	// This is needed for nested containers, because in /proc/self/cgroup we
+	// see paths from host, which don't exist in container.
+	relCgroup, err := filepath.Rel(root, cgroup)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(mnt, relCgroup), nil
+}
+
+func getControllerPath(subsystem string, cgroups map[string]string) (string, error) {
+	if IsCgroup2UnifiedMode() {
+		return "", errUnified
+	}
+
+	if p, ok := cgroups[subsystem]; ok {
+		return p, nil
+	}
+
+	if p, ok := cgroups[CgroupNamePrefix+subsystem]; ok {
+		return p, nil
+	}
+
+	return "", NewNotFoundError(subsystem)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/NVIDIA/go-nvlib/pkg/nvpci
 github.com/NVIDIA/go-nvlib/pkg/nvpci/bytes
 github.com/NVIDIA/go-nvlib/pkg/nvpci/mmio
 github.com/NVIDIA/go-nvlib/pkg/pciids
-# github.com/NVIDIA/go-nvml v0.13.3-1
+# github.com/NVIDIA/go-nvml v0.13.3-1.0.20260814002628-7f946c0908a3
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvml/pkg/dl
 github.com/NVIDIA/go-nvml/pkg/nvml
@@ -38,6 +38,9 @@ github.com/containerd/nri/pkg/version
 # github.com/containerd/ttrpc v1.2.7
 ## explicit; go 1.19
 github.com/containerd/ttrpc
+# github.com/coreos/go-systemd/v22 v22.7.0
+## explicit; go 1.23
+github.com/coreos/go-systemd/v22/dbus
 # github.com/cyphar/filepath-securejoin v0.7.0
 ## explicit; go 1.18
 github.com/cyphar/filepath-securejoin
@@ -58,6 +61,9 @@ github.com/davecgh/go-spew/spew
 # github.com/fsnotify/fsnotify v1.7.0
 ## explicit; go 1.17
 github.com/fsnotify/fsnotify
+# github.com/godbus/dbus/v5 v5.1.0
+## explicit; go 1.12
+github.com/godbus/dbus/v5
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
@@ -80,9 +86,16 @@ github.com/moby/sys/reexec
 # github.com/moby/sys/symlink v0.3.0
 ## explicit; go 1.17
 github.com/moby/sys/symlink
+# github.com/moby/sys/userns v0.1.0
+## explicit; go 1.21
+github.com/moby/sys/userns
 # github.com/opencontainers/cgroups v0.0.7
 ## explicit; go 1.24.0
+github.com/opencontainers/cgroups
 github.com/opencontainers/cgroups/devices/config
+github.com/opencontainers/cgroups/fs2
+github.com/opencontainers/cgroups/fscommon
+github.com/opencontainers/cgroups/internal/path
 # github.com/opencontainers/runc v1.4.3
 ## explicit; go 1.24.0
 github.com/opencontainers/runc/internal/linux


### PR DESCRIPTION
This commit introduces a new CDI hook binary called `apply-cuda-memory-limits`. The purpose of this CDI hook is to apply the desired memory limits to a GPU device. 

It reads the following envars from a container spec to fetch the input parameters for the CDI hook

- NVIDIA_GPU_MEMORY_REQUEST(S)
- NVIDIA_GPU_MEMORY_LIMIT(S)

Under the covers, the CDI hooks invokes the new `NVML SetMemoryLimits_v1` method (introduced in CUDA 13.4) to apply the desired CUDA memory limit values to the cgroup of the GPU container in question 

