### PR TITLE
Update golang toolchain

### DIFF
--- a/cmd/nvidia-cdi-hook/cudacompat/cudacompat.go
+++ b/cmd/nvidia-cdi-hook/cudacompat/cudacompat.go
@@ -155,7 +155,7 @@ func (m command) getContainerForwardCompatDir(containerRoot *root, o *options) (
 
 	libs, err := containerRoot.globFiles(filepath.Join(o.cudaCompatContainerRoot, "libcuda.so.*.*"))
 	if err != nil {
-		m.logger.Warningf("Failed to find CUDA compat library: %w", err)
+		m.logger.Warningf("Failed to find CUDA compat library: %v", err)
 		return "", nil
 	}
 
@@ -216,7 +216,7 @@ func (m command) useCompatLibraries(libcudaCompatFile *os.File, hostDriverVersio
 	// libraries in the container should be used over the host driver libraries.
 	cudaCompatHeader, err := GetCUDACompatElfHeaderFromReader(libcudaCompatFile)
 	if err != nil {
-		m.logger.Warningf("failed to get ELF header from CUDA compat library: %w", err)
+		m.logger.Warningf("failed to get ELF header from CUDA compat library: %v", err)
 	}
 	if cudaCompatHeader != nil {
 		return cudaCompatHeader.UseCompat(compatDriverSemver, hostDriverSemver, hostCUDASemver), nil

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -14,7 +14,7 @@
 
 # This Dockerfile is also used to define the golang version used in this project
 # This allows dependabot to manage this version in addition to other images.
-FROM golang:1.26.5
+FROM golang:1.27.0
 
 WORKDIR /work
 COPY * .

--- a/deployments/devel/go.mod
+++ b/deployments/devel/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/k8s-device-plugin/deployments/devel
 
-go 1.25
+go 1.26
 
 require (
 	github.com/google/go-licenses/v2 v2.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nvidia-container-toolkit
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/pkg/nvcdi/driver-wsl.go
+++ b/pkg/nvcdi/driver-wsl.go
@@ -53,7 +53,7 @@ func (l *wsllib) newWSLDriverDiscoverer() (discover.Discover, error) {
 	}
 	defer func() {
 		if err := dxcore.Shutdown(); err != nil {
-			l.logger.Warningf("failed to shutdown dxcore: %w", err)
+			l.logger.Warningf("failed to shutdown dxcore: %v", err)
 		}
 	}()
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nvidia-container-toolkit/tests
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
Go 1.25 is [EOL](https://endoflife.date/go). 

* Bump the minimum required toolchain to 1.26
* Bump CI version (build/test/release) to 1.27

