### PR TITLE
fix: Order container engines after nvidia-cdi-refresh.service

### DIFF
--- a/deployments/systemd/10-container-engines.conf
+++ b/deployments/systemd/10-container-engines.conf
@@ -1,0 +1,33 @@
+# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Order the container engines after this service so that the first container
+# started at boot does not race device node creation and CDI specification
+# generation.
+#
+# This is shipped as a drop-in rather than as part of the unit so that it can be
+# removed without overriding the whole unit: an empty file of the same name in
+# /etc/systemd/system/nvidia-cdi-refresh.service.d/ takes precedence over this
+# one and cancels it. Assigning an empty Before= in a drop-in does not reset the
+# list, so an in-unit ordering could not be undone that way.
+[Unit]
+Before=docker.service containerd.service crio.service
+
+[Service]
+# The unit is Type=oneshot, for which systemd defaults to
+# TimeoutStartSec=infinity. Now that the container engines are ordered after it,
+# bound the start so that a hung nvidia-smi cannot delay them indefinitely; on
+# expiry the engines start and the CDI specification is refreshed on the next
+# trigger. The value matches systemd's DefaultTimeoutStartSec.
+TimeoutStartSec=90s

--- a/packaging/debian/nvidia-container-toolkit-base.install
+++ b/packaging/debian/nvidia-container-toolkit-base.install
@@ -5,3 +5,4 @@ nvidia-cdi-refresh.service /lib/systemd/system/
 nvidia-cdi-refresh.path /lib/systemd/system/
 nvidia-cdi-refresh.env /etc/nvidia-container-toolkit/
 99-nvidia-cdi-refresh.rules /lib/udev/rules.d/
+10-container-engines.conf /lib/systemd/system/nvidia-cdi-refresh.service.d/

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -17,3 +17,4 @@ override_dh_fixperms:
 	chmod 644 debian/$(shell dh_listpackages)/lib/systemd/system/nvidia-cdi-refresh.service || true
 	chmod 644 debian/$(shell dh_listpackages)/lib/systemd/system/nvidia-cdi-refresh.path || true
 	chmod 644 debian/$(shell dh_listpackages)/lib/udev/rules.d/99-nvidia-cdi-refresh.rules || true
+	chmod 644 debian/$(shell dh_listpackages)/lib/systemd/system/nvidia-cdi-refresh.service.d/10-container-engines.conf || true

--- a/packaging/rpm/SPECS/nvidia-container-toolkit.spec
+++ b/packaging/rpm/SPECS/nvidia-container-toolkit.spec
@@ -22,6 +22,7 @@ Source8: nvidia-cdi-refresh.path
 Source9: nvidia-cdi-refresh.env
 Source10: 90-nvidia-container-toolkit.preset
 Source11: 99-nvidia-cdi-refresh.rules
+Source12: 10-container-engines.conf
 
 %if 0%{?rhel} == 7 || 0%{?amzn} == 2
 BuildRequires: systemd
@@ -43,13 +44,14 @@ Requires: nvidia-container-toolkit-base == %{version}-%{release}
 Provides tools and utilities to enable GPU support in containers.
 
 %prep
-cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} %{SOURCE9} %{SOURCE10} %{SOURCE11} .
+cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE8} %{SOURCE9} %{SOURCE10} %{SOURCE11} %{SOURCE12} .
 
 %install
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_presetdir}
 mkdir -p %{buildroot}%{_udevrulesdir}
+mkdir -p %{buildroot}%{_unitdir}/nvidia-cdi-refresh.service.d
 mkdir -p %{buildroot}%{_sysconfdir}/nvidia-container-toolkit
 
 install -m 755 -t %{buildroot}%{_bindir} nvidia-container-runtime-hook
@@ -62,6 +64,7 @@ install -m 644 -t %{buildroot}%{_unitdir} nvidia-cdi-refresh.service
 install -m 644 -t %{buildroot}%{_unitdir} nvidia-cdi-refresh.path
 install -m 644 -t %{buildroot}%{_presetdir} 90-nvidia-container-toolkit.preset
 install -m 644 -t %{buildroot}%{_udevrulesdir} 99-nvidia-cdi-refresh.rules
+install -m 644 -t %{buildroot}%{_unitdir}/nvidia-cdi-refresh.service.d 10-container-engines.conf
 install -m 644 -t %{buildroot}%{_sysconfdir}/nvidia-container-toolkit nvidia-cdi-refresh.env
 
 %post
@@ -162,6 +165,7 @@ fi
 %{_unitdir}/nvidia-cdi-refresh.path
 %{_presetdir}/90-nvidia-container-toolkit.preset
 %{_udevrulesdir}/99-nvidia-cdi-refresh.rules
+%{_unitdir}/nvidia-cdi-refresh.service.d/10-container-engines.conf
 %config(noreplace) %{_sysconfdir}/nvidia-container-toolkit/nvidia-cdi-refresh.env
 
 # The OPERATOR EXTENSIONS package consists of components that are required to enable GPU support in Kubernetes.

--- a/tests/e2e/nvidia-cdi-refresh_test.go
+++ b/tests/e2e/nvidia-cdi-refresh_test.go
@@ -100,6 +100,17 @@ EOF
 	fi
 	`
 
+	nvidiaCdiRefreshOrderingDropInInstalledTemplate = `
+	if [ ! -f /lib/systemd/system/nvidia-cdi-refresh.service.d/10-container-engines.conf ]; then
+		echo "10-container-engines.conf is not installed"
+		exit 1
+	fi
+	if ! systemctl show nvidia-cdi-refresh.service -p Before | grep -q docker.service; then
+		echo "nvidia-cdi-refresh.service is not ordered before docker.service"
+		exit 1
+	fi
+	`
+
 	nvidiaCdiRefreshFileExistsTemplate = `
 	# is /var/run/cdi/nvidia.yaml exists? and exit with 0 if it does not exist
 	if [ ! -f /var/run/cdi/nvidia.yaml ]; then
@@ -221,6 +232,11 @@ var _ = Describe("nvidia-cdi-refresh", Ordered, ContinueOnFailure, Label("system
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should install the container engine ordering drop-in", func(ctx context.Context) {
+			_, _, err := systemdRunner.Run(nvidiaCdiRefreshOrderingDropInInstalledTemplate)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should generate the nvidia.yaml file", func(ctx context.Context) {
 			_, _, err := systemdRunner.Run(nvidiaCdiRefreshFileExistsTemplate)
 			Expect(err).ToNot(HaveOccurred())
@@ -272,6 +288,11 @@ var _ = Describe("nvidia-cdi-refresh", Ordered, ContinueOnFailure, Label("system
 
 		It("should install the nvidia-cdi-refresh udev rules", func(ctx context.Context) {
 			_, _, err := systemdRunner.Run(nvidiaCdiRefreshUdevRulesInstalledTemplate)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should install the container engine ordering drop-in", func(ctx context.Context) {
+			_, _, err := systemdRunner.Run(nvidiaCdiRefreshOrderingDropInInstalledTemplate)
 			Expect(err).ToNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA/nvidia-container-toolkit/pull/1979.

Reviewers: @cdesiniotis @henry118 

Follow-up to #1979, split out at @cdesiniotis' request so that #1979 stayed scoped to device node creation.

## Summary

`nvidia-cdi-refresh.service` is not ordered against any container engine, so a container started early at boot can reach the runtime before the service has created the control device nodes and generated the CDI specification. This adds a drop-in that orders `docker`, `containerd` and `cri-o` after the service, and bounds the service's start time now that engines wait on it.

## Why This Exists

The service is `Type=oneshot`, `WantedBy=multi-user.target`, with no ordering against any engine. A GPU container with `restart=always`, or an early `docker run`, can therefore reach the runtime before the service's `ExecStart` has run: the first container of the boot gets a specification generated before the device nodes exist, and subsequent ones do not. @henry118 identified this ordering as the packaging-level fix for that race in https://github.com/NVIDIA/nvidia-container-toolkit/pull/1979#issuecomment-5319572288.

## Why a drop-in rather than the unit

#1735 was about exactly this class of change: an ordering constraint shipped in the unit could not be removed by users, only worked around by overriding the whole unit. That is still true — verified on systemd 259, assigning an empty `Before=` in a drop-in does **not** reset an in-unit `Before=` list.

Shipping the ordering as a vendor drop-in gives it an off switch. A same-named empty file in `/etc/systemd/system/nvidia-cdi-refresh.service.d/` takes precedence over the vendor copy and cancels it, with no need to override the unit.

## The two cycle scenarios raised in review

@henry118 noted in #1979 that a `Before=` can only produce a cycle if either docker is ordered before us, or a third unit sits between us, and judged both unlikely. I built both on Ubuntu 26.04 / systemd 259 / Docker 29.7.2 to see what actually happens if they do occur.

**A — `docker.service` has `Before=nvidia-cdi-refresh.service`:**

```
systemd[1]: docker.service: Found ordering cycle: nvidia-cdi-refresh.service/start
            after docker.service/start - after nvidia-cdi-refresh.service
systemd[1]: docker.service: Job nvidia-cdi-refresh.service/start deleted to break
            ordering cycle starting with docker.service/start
```

**B — a third unit has `After=docker.service` and `Before=nvidia-cdi-refresh.service`:**

```
systemd[1]: docker.service: Found ordering cycle: nvidia-cdi-refresh.service/start
            after other.service/start after docker.service/start - after
            nvidia-cdi-refresh.service
systemd[1]: docker.service: Job nvidia-cdi-refresh.service/start deleted to break
            ordering cycle starting with docker.service/start
```

In both cases systemd resolves the cycle by deleting **our** job: docker and the third unit start normally, and `nvidia-cdi-refresh.service` does not run, leaving the CDI specification unrefreshed for that boot. Nothing fails loudly — the only signal is the journal line above.

That is milder than #1735, where the job that got deleted belonged to the user's own unit, but it is the same class of problem, and it is the reason the ordering is shipped as a drop-in. A host that hits either scenario can drop an empty same-named file into `/etc/systemd/system/nvidia-cdi-refresh.service.d/` and get the previous behaviour back. Verified against scenario B: with the vendor drop-in cancelled, no cycle is reported, every unit starts, and the specification is regenerated.

## Why TimeoutStartSec

`Type=oneshot` defaults to `TimeoutStartSec=infinity`, and the unit sets no override. Once engines are ordered after it, a `nvidia-smi -L` that hangs — a wedged GPU, a driver still initialising, a fabric manager not yet up — would delay them without bound. The drop-in therefore also sets `TimeoutStartSec=90s`, matching systemd's `DefaultTimeoutStartSec`. On expiry the engines start and the specification is refreshed by the next trigger; the ordering is `Before=`, not `Requires=`, so nothing depends on the service succeeding.

Both settings live in the same drop-in, so removing the drop-in restores the previous behaviour exactly.

## Behavior Changes

- `docker.service`, `containerd.service` and `crio.service` gain an implicit `After=nvidia-cdi-refresh.service` when they are part of the same transaction, so the first container at boot no longer races node creation and CDI generation.
- The service's start is bounded at 90s instead of being unbounded.
- Both are removable by a same-named empty drop-in under `/etc/systemd/system/`.
- Hosts where the unit's `ExecCondition` fails (no NVIDIA kernel module) are unaffected: the job completes immediately and adds no measurable boot delay.

## Implementation Summary

- Add `deployments/systemd/10-container-engines.conf`, installed to `<unitdir>/nvidia-cdi-refresh.service.d/`.
- Install it from the Debian and RPM packaging alongside the existing unit files.
- Extend the `nvidia-cdi-refresh` e2e suite to assert the drop-in is installed and that the resulting `Before=` includes `docker.service`.

## Verification

Ubuntu 26.04, systemd 259, Docker 29.7.2, 2x Tesla P100. The file as shipped in this PR, installed to `/usr/lib/systemd/system/nvidia-cdi-refresh.service.d/`:

```console
# before
Before=shutdown.target multi-user.target
TimeoutStartUSec=infinity

# with the drop-in
Before=containerd.service multi-user.target docker.service shutdown.target crio.service
TimeoutStartUSec=1min 30s
$ systemctl show docker.service -p After | tr ' ' '\n' | grep nvidia
nvidia-cdi-refresh.service
```

No ordering cycles are reported by `systemd-analyze verify`, and the unit still loads.

Cancelling it as a user would, with a same-named empty drop-in under `/etc`:

```console
$ printf '# intentionally empty\n' | \
    sudo tee /etc/systemd/system/nvidia-cdi-refresh.service.d/10-container-engines.conf
$ sudo systemctl daemon-reload
$ systemctl show nvidia-cdi-refresh.service -p Before -p TimeoutStartUSec
Before=multi-user.target shutdown.target
TimeoutStartUSec=infinity
```

For scale, the service took 10.758s wall clock at boot on this two-GPU host, almost all of it the cold `nvidia-smi -L`; that is the delay the ordering introduces before the engines start.