### PR TITLE
fix: fall back to the default runtime when the toolkit config file is missing

### DIFF
--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables.go
@@ -103,6 +103,7 @@ func (t *ToolkitInstaller) collectExecutables(destDir string) ([]Installer, erro
 			Source:            executablePath,
 			WrappedExecutable: dotRealFilename,
 			CheckModules:      executable.requiresKernelModule,
+			ConfigFilePath:    executable.env[config.FilePathOverrideEnvVar],
 			Envvars: map[string]string{
 				"PATH": strings.Join([]string{destDir, "$PATH"}, ":"),
 			},
@@ -147,6 +148,7 @@ type wrapper struct {
 	WrappedExecutable            string
 	CheckModules                 bool
 	DefaultRuntimeExecutablePath string
+	ConfigFilePath               string
 }
 
 type render struct {
@@ -180,6 +182,12 @@ func (w *render) render() (io.Reader, error) {
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
 if [ "${?}" != "0" ]; then
 	echo "nvidia driver modules are not yet loaded, invoking {{ .DefaultRuntimeExecutablePath }} directly" >&2
+	exec {{ .DefaultRuntimeExecutablePath }} "$@"
+fi
+{{- end }}
+{{- if and .CheckModules .ConfigFilePath }}
+if [ ! -f "{{ .ConfigFilePath }}" ]; then
+	echo "nvidia toolkit config {{ .ConfigFilePath }} is missing, invoking {{ .DefaultRuntimeExecutablePath }} directly" >&2
 	exec {{ .DefaultRuntimeExecutablePath }} "$@"
 fi
 {{- end }}

--- a/cmd/nvidia-ctk-installer/toolkit/installer/executables_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/executables_test.go
@@ -59,6 +59,59 @@ fi
 `,
 		},
 		{
+			description: "config check is added when a config path is set",
+			w: &wrapper{
+				WrappedExecutable:            "some-runtime",
+				CheckModules:                 true,
+				DefaultRuntimeExecutablePath: "runc",
+				ConfigFilePath:               "/dest-dir/.config/nvidia-container-runtime/config.toml",
+			},
+			expected: `#! /bin/sh
+cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
+if [ "${?}" != "0" ]; then
+	echo "nvidia driver modules are not yet loaded, invoking runc directly" >&2
+	exec runc "$@"
+fi
+if [ ! -f "/dest-dir/.config/nvidia-container-runtime/config.toml" ]; then
+	echo "nvidia toolkit config /dest-dir/.config/nvidia-container-runtime/config.toml is missing, invoking runc directly" >&2
+	exec runc "$@"
+fi
+	/dest-dir/some-runtime \
+		"$@"
+`,
+		},
+		{
+			description: "config check is not added without the module check",
+			w: &wrapper{
+				WrappedExecutable:            "some-hook",
+				CheckModules:                 false,
+				DefaultRuntimeExecutablePath: "runc",
+				ConfigFilePath:               "/dest-dir/.config/nvidia-container-runtime/config.toml",
+			},
+			expected: `#! /bin/sh
+	/dest-dir/some-hook \
+		"$@"
+`,
+		},
+		{
+			description: "config check is not added without a config path",
+			w: &wrapper{
+				WrappedExecutable:            "some-runtime",
+				CheckModules:                 true,
+				DefaultRuntimeExecutablePath: "runc",
+				ConfigFilePath:               "",
+			},
+			expected: `#! /bin/sh
+cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
+if [ "${?}" != "0" ]; then
+	echo "nvidia driver modules are not yet loaded, invoking runc directly" >&2
+	exec runc "$@"
+fi
+	/dest-dir/some-runtime \
+		"$@"
+`,
+		},
+		{
 			description: "environment is added",
 			w: &wrapper{
 				WrappedExecutable: "some-runtime",

--- a/cmd/nvidia-ctk-installer/toolkit/installer/installer_test.go
+++ b/cmd/nvidia-ctk-installer/toolkit/installer/installer_test.go
@@ -175,6 +175,10 @@ if [ "${?}" != "0" ]; then
 	echo "nvidia driver modules are not yet loaded, invoking runc directly" >&2
 	exec runc "$@"
 fi
+if [ ! -f "/foo/bar/baz/.config/nvidia-container-runtime/config.toml" ]; then
+	echo "nvidia toolkit config /foo/bar/baz/.config/nvidia-container-runtime/config.toml is missing, invoking runc directly" >&2
+	exec runc "$@"
+fi
 NVIDIA_CTK_CONFIG_FILE_PATH=/foo/bar/baz/.config/nvidia-container-runtime/config.toml \
 PATH=/foo/bar/baz:$PATH \
 	/foo/bar/baz/nvidia-container-runtime.real \
@@ -190,6 +194,10 @@ if [ "${?}" != "0" ]; then
 	echo "nvidia driver modules are not yet loaded, invoking runc directly" >&2
 	exec runc "$@"
 fi
+if [ ! -f "/foo/bar/baz/.config/nvidia-container-runtime/config.toml" ]; then
+	echo "nvidia toolkit config /foo/bar/baz/.config/nvidia-container-runtime/config.toml is missing, invoking runc directly" >&2
+	exec runc "$@"
+fi
 NVIDIA_CTK_CONFIG_FILE_PATH=/foo/bar/baz/.config/nvidia-container-runtime/config.toml \
 PATH=/foo/bar/baz:$PATH \
 	/foo/bar/baz/nvidia-container-runtime.cdi.real \
@@ -203,6 +211,10 @@ PATH=/foo/bar/baz:$PATH \
 cat /proc/modules | grep -e "^nvidia " >/dev/null 2>&1
 if [ "${?}" != "0" ]; then
 	echo "nvidia driver modules are not yet loaded, invoking runc directly" >&2
+	exec runc "$@"
+fi
+if [ ! -f "/foo/bar/baz/.config/nvidia-container-runtime/config.toml" ]; then
+	echo "nvidia toolkit config /foo/bar/baz/.config/nvidia-container-runtime/config.toml is missing, invoking runc directly" >&2
 	exec runc "$@"
 fi
 NVIDIA_CTK_CONFIG_FILE_PATH=/foo/bar/baz/.config/nvidia-container-runtime/config.toml \


### PR DESCRIPTION
### What happens today

The generated runtime wrapper has one guard: it checks whether the NVIDIA driver modules are
loaded, and falls back to the default low-level runtime if they are not. It never checks
whether its own configuration file is present.

When the NVIDIA runtime is containerd's default runtime, **every** container on the node is
routed through that wrapper, not only GPU containers. If the driver is loaded but
`.config/nvidia-container-runtime/config.toml` is absent, the module guard passes,
`nvidia-container-runtime.real` runs, and it fails with `couldn't open required configuration
file`. Sandbox creation then fails for every pod on the node — **including the
nvidia-container-toolkit DaemonSet that would rewrite the file.**

The node reports `Ready` with clean conditions and zero allocatable GPUs. Kubernetes cannot
repair it, because every tool it has is a container. Recovery requires host access.

We hit this in production on 2026-08-23. A reboot interrupted a toolkit reinstall after the
executables were written and before `config.toml` was. Restoring that single 1122-byte file
released the node completely: the toolkit pod went `Pending` to `Running` within 46 seconds,
allocatable GPUs returned, and the node recovered with no other change. A sibling node with
the same toolkit build and its config file intact was healthy throughout.

### What this changes

One additional guard, in the same shape and with the same fallback target as the existing
module check. A missing configuration file becomes a reason to invoke the default runtime
rather than a reason to fail.

The node degrades to "GPU containers start without GPU access" instead of "nothing starts at
all" — and because the toolkit DaemonSet can now start, it repairs the node itself.

`collectExecutables` already computes this path and already passes it to the wrapper as
`NVIDIA_CTK_CONFIG_FILE_PATH`, so no new plumbing is required.

### Why the guard is gated on `CheckModules` as well

`nvidia-container-runtime-hook` also receives a config path but is **not** a runtime, so it
must not be given a low-level runtime fallback. Gating on `.ConfigFilePath` alone would inject
`exec runc "$@"` into the hook's wrapper. The condition is therefore
`{{- if and .CheckModules .ConfigFilePath }}`, reusing the flag that already means "this is a
runtime".

### Tests

Three cases were added to the existing `TestWrapperRender` table:

| case | CheckModules | ConfigFilePath | expected |
|------|--------------|----------------|----------|
| `config check is added when a config path is set` | true | set | both guards |
| `config check is not added without the module check` | false | set | **neither guard** |
| `config check is not added without a config path` | true | empty | module guard only |

Each was confirmed to fail when the implementation is wrong, not merely to pass when it is
right:

- with the guard written as `{{- if .ConfigFilePath }}`, exactly one case fails, and it is
  `config check is not added without the module check`;
- with the guard removed entirely, exactly one case fails, and it is
  `config check is added when a config path is set`.

`TestToolkitInstaller` fixtures were updated for the three runtime wrappers. The
`nvidia-container-runtime-hook` and `nvidia-container-cli` fixtures are deliberately
unchanged, which is an independent check that the guard scopes correctly.

`gofmt`, `go vet`, `go build ./...` and `go test ./cmd/nvidia-ctk-installer/...` are clean.

### The trade-off, stated up front

**This fails open.** During the window a GPU container may start believing it has a GPU and not
have one. That is a real cost, and it is a policy decision that belongs to you. Two things
bound it: the window ends when the DaemonSet rewrites the file, and the state is externally
visible as a `Ready` node with zero allocatable GPUs.

For non-GPU containers the change is strictly an improvement — today they are taken down by a
GPU-specific configuration file with which they have no relationship.

**If you would rather fail closed, or fix the install sequence so that the wrapper cannot
become active before its configuration exists, we would be glad to take that instead.** The
reproduction stands either way, and the outcome we care about is that a reboot cannot strand a
node with no automated recovery.

### Versions

Reproduced in production on v1.17.8. Confirmed still present on `main` and in v1.20.0 by source
inspection: the generator moved from `tools/container/toolkit/runtime.go` to
`cmd/nvidia-ctk-installer/toolkit/installer/executables.go` and became a template, but no
configuration check was added. Upgrading does not resolve this.

### Related

- #1365 introduced `DefaultRuntimeExecutablePath`, which this change reuses as its fallback
  target.
- NVIDIA/gpu-operator#594 describes the install-time containerd restart that we believe can
  interrupt the install. A maintainer noted in 2023 that unnecessary restarts were worth
  avoiding; that issue was closed for inactivity in 2026 without resolution. We are not
  claiming this proves our sequence, only that the behaviour is known.

### Open questions

1. Could the install-time containerd restart interrupt the installer between writing the
   executables and writing `config.toml`?
2. Is there an existing ordering or atomic-install guarantee intended to prevent a generated
   wrapper from becoming active before its required configuration file is present?
3. Should the fallback be unconditional for generated runtime wrappers, or controlled by a
   setting?
