### PR TITLE
wsl: honor none value for NVIDIA_VISIBLE_DEVICES envvar

### DIFF
--- a/pkg/nvcdi/lib-wsl.go
+++ b/pkg/nvcdi/lib-wsl.go
@@ -18,6 +18,7 @@ package nvcdi
 
 import (
 	"fmt"
+	"slices"
 
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 	"tags.cncf.io/container-device-interface/specs-go"
@@ -27,7 +28,10 @@ type wsllib nvcdilib
 
 var _ deviceSpecGeneratorFactory = (*wsllib)(nil)
 
-func (l *wsllib) DeviceSpecGenerators(...string) (DeviceSpecGenerator, error) {
+func (l *wsllib) DeviceSpecGenerators(ids ...string) (DeviceSpecGenerator, error) {
+	if slices.Contains(ids, "none") {
+		return emptyDeviceSpecGenerator("none"), nil
+	}
 	return l, nil
 }
 


### PR DESCRIPTION
Fix WSL mode to honor `NVIDIA_VISIBLE_DEVICES=none`.

Before:
<img width="914" height="549" alt="image" src="https://github.com/user-attachments/assets/55067b93-4e1a-4879-b0f0-e4b23947133f" />

After:
<img width="941" height="553" alt="image" src="https://github.com/user-attachments/assets/790acc04-d925-47b8-8ea0-4bd88546f1f3" />

Closes: https://github.com/NVIDIA/cloud-native-team/issues/485