### PR TITLE
Make update-application-profile hook to ignore read-only fs error

### DIFF
--- a/cmd/nvidia-cdi-hook/update-application-profile/update-application-profile.go
+++ b/cmd/nvidia-cdi-hook/update-application-profile/update-application-profile.go
@@ -19,9 +19,11 @@ package updateapplicationprofile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
+	"syscall"
 
 	"github.com/urfave/cli/v3"
 
@@ -125,12 +127,19 @@ func run(_ context.Context, _ *cli.Command, cfg *options, logger logger.Interfac
 		return nil
 	}
 
-	if err := containerRoot.MkdirAll(applicationProfileDir, 0555); err != nil {
-		return fmt.Errorf("failed to create application profiles directory: %w", err)
-	}
-
-	if err := containerRoot.WriteFile(applicationProfileFile, buildApplicationProfileConfig(mask), 0444); err != nil {
-		return fmt.Errorf("failed to write application profile: %w", err)
+	if err = func() error {
+		if err := containerRoot.MkdirAll(applicationProfileDir, 0555); err != nil {
+			return fmt.Errorf("failed to create application profiles directory: %w", err)
+		}
+		if err := containerRoot.WriteFile(applicationProfileFile, buildApplicationProfileConfig(mask), 0444); err != nil {
+			return fmt.Errorf("failed to write application profile: %w", err)
+		}
+		return nil
+	}(); err != nil {
+		if !errors.Is(err, syscall.EROFS) {
+			return err
+		}
+		logger.Warningf("Ignoring read-only filesystem error: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Closes #2026 

#### Before

```
$ docker run --rm -it --runtime=nvidia --gpus=all -v /tmp/etc-nvidia-ro:/etc/nvidia:ro ubuntu nvidia-smi
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running createContainer hook #6: exit status 1, stdout: , stderr: time="2026-08-26T21:50:49Z" level=error msg="failed to create application profiles directory: mkdirat etc/nvidia/nvidia-application-profiles-rc.d: read-only file system"
```

#### After

```
$ docker run --rm -it --runtime=nvidia --gpus=all -v /tmp/etc-nvidia-ro:/etc/nvidia:ro ubuntu nvidia-smi
Wed Aug 26 22:31:45 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.173.02             Driver Version: 580.173.02     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       Off |   00000000:65:00.0 Off |                    0 |
| N/A   35C    P8              9W /   70W |       5MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```