### PR TITLE
fix(cdi): Include 32-bit libraries in discovery

### DIFF
--- a/cmd/nvidia-cdi-hook/update-ldcache/update-ldcache.go
+++ b/cmd/nvidia-cdi-hook/update-ldcache/update-ldcache.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/sys/reexec"
 	"github.com/urfave/cli/v3"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/config/image"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/ldconfig"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/oci"
@@ -119,12 +120,33 @@ func (m command) run(_ *cli.Command, cfg *options) error {
 		reexecUpdateLdCacheCommandName,
 		cfg.ldconfigPath,
 		containerRootDir,
+		m.compat32Requested(s),
 		cfg.folders...,
 	)
 	if err != nil {
 		return err
 	}
 	return runner.Run()
+}
+
+// compat32Requested checks whether the container requested the compat32
+// driver capability. This mirrors the nvidia-container-cli, where the 32-bit
+// libraries are associated with this capability.
+// Note that the environment of the container is read from its OCI spec, which
+// is not always accessible, and a container whose capabilities cannot be
+// determined is treated as not having requested this one.
+func (m command) compat32Requested(s *oci.State) bool {
+	env, err := s.GetEnv()
+	if err != nil {
+		m.logger.Debugf("Failed to get the container environment: %v", err)
+		return false
+	}
+	containerImage, err := image.New(image.WithEnv(env))
+	if err != nil {
+		m.logger.Debugf("Failed to construct image from the container environment: %v", err)
+		return false
+	}
+	return containerImage.GetDriverCapabilities().Has(image.DriverCapabilityCompat32)
 }
 
 // updateLdCacheHandler wraps updateLdCache with error handling.

--- a/cmd/nvidia-ctk/cdi/generate/generate.go
+++ b/cmd/nvidia-ctk/cdi/generate/generate.go
@@ -67,7 +67,8 @@ type options struct {
 	disabledHooks      []string
 	enabledHooks       []string
 
-	featureFlags []string
+	disableCompat32 bool
+	featureFlags    []string
 
 	csv struct {
 		files               []string
@@ -236,6 +237,16 @@ func (m command) build() *cli.Command {
 				Destination: &opts.enabledHooks,
 				Sources:     cli.EnvVars("NVIDIA_CTK_CDI_GENERATE_ENABLED_HOOKS"),
 			},
+			&cli.BoolFlag{
+				Name: "disable-compat32",
+				Usage: "Exclude the 32-bit compatibility driver libraries installed on the host from the " +
+					"generated CDI specification. These are included by default and are only exposed to a " +
+					"container that can run 32-bit applications: one that requests the 'compat32' driver " +
+					"capability or ships a 32-bit dynamic linker, and never a container that uses musl. " +
+					"This is equivalent to specifying the '" + string(nvcdi.FeatureDisableCompat32Libraries) + "' feature flag.",
+				Destination: &opts.disableCompat32,
+				Sources:     cli.EnvVars("NVIDIA_CTK_CDI_GENERATE_DISABLE_COMPAT32"),
+			},
 			&cli.StringSliceFlag{
 				Name:        "feature-flag",
 				Aliases:     []string{"feature-flags"},
@@ -397,6 +408,10 @@ func (m command) generateSpecs(opts *options) ([]generatedSpecs, error) {
 		nvcdi.WithFeatureFlags(opts.featureFlags...),
 		// We set the following to allow for dependency injection:
 		nvcdi.WithNvmlLib(opts.nvmllib),
+	}
+
+	if opts.disableCompat32 {
+		cdiOptions = append(cdiOptions, nvcdi.WithFeatureFlags(nvcdi.FeatureDisableCompat32Libraries))
 	}
 
 	cdilib, err := nvcdi.New(cdiOptions...)

--- a/deployments/systemd/nvidia-cdi-refresh.env
+++ b/deployments/systemd/nvidia-cdi-refresh.env
@@ -19,6 +19,11 @@
 # uncomment the following line:
 # NVIDIA_CTK_CDI_OUTPUT_FILE_PATH=/var/run/cdi/nvidia.yaml
 
+# The 32-bit compatibility driver libraries installed on the host are included
+# in the generated CDI specification. To leave these out, uncomment the
+# following line:
+# NVIDIA_CTK_CDI_GENERATE_DISABLE_COMPAT32=true
+
 # The service also runs
 #   nvidia-ctk system create-device-nodes --control-devices --load-kernel-modules
 # before generating the CDI specification. Its driver and device roots can be

--- a/internal/ldconfig/compat32.go
+++ b/internal/ldconfig/compat32.go
@@ -1,0 +1,93 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package ldconfig
+
+import (
+	"debug/elf"
+	"path/filepath"
+	"runtime"
+)
+
+// compat32Loaders maps the platform to the paths of the dynamic linkers that a
+// container uses to run 32-bit applications.
+var compat32Loaders = map[string][]string{
+	"amd64": {"/lib/ld-linux.so.2", "/lib32/ld-linux.so.2"},
+	"arm64": {"/lib/ld-linux-armhf.so.3", "/lib/ld-linux.so.3"},
+}
+
+// allowsCompat32 checks whether the 32-bit driver libraries are of use in the
+// specified root.
+//
+// A container that uses musl never sees these. A musl .path file carries no
+// architecture information and musl has no notion of a multiarch layout: it
+// loads the first file matching the requested name and fails instead of
+// searching on if that file is of another ELF class.
+//
+// Other containers see the 32-bit libraries if they requested the compat32
+// driver capability -- as is the case for the nvidia-container-cli -- or if
+// they ship a dynamic linker for 32-bit applications.
+func allowsCompat32(root string, requested bool) bool {
+	if arch, ok := muslArchs[runtime.GOARCH]; ok && isMusl(root, arch) {
+		return false
+	}
+	if requested {
+		return true
+	}
+	for _, loader := range compat32Loaders[runtime.GOARCH] {
+		if isFile(filepath.Join(root, loader)) {
+			return true
+		}
+	}
+	return false
+}
+
+// excludeCompat32Directories returns the specified directories with those that
+// hold 32-bit libraries removed. The directories are resolved relative to the
+// specified root.
+func excludeCompat32Directories(root string, dirs []string) []string {
+	var filtered []string
+	for _, dir := range dirs {
+		if isCompat32Dir(filepath.Join(root, dir)) {
+			continue
+		}
+		filtered = append(filtered, dir)
+	}
+	return filtered
+}
+
+// isCompat32Dir checks whether the specified directory holds 32-bit libraries
+// and no 64-bit ones. Files that are not ELF files are ignored, as are
+// directories that hold no libraries at all.
+// Note that both supported platforms are 64-bit.
+func isCompat32Dir(dir string) bool {
+	var compat32 bool
+	libraries, _ := filepath.Glob(filepath.Join(dir, "lib?*.so*"))
+	for _, library := range libraries {
+		f, err := elf.Open(library)
+		if err != nil {
+			continue
+		}
+		class := f.Class
+		_ = f.Close()
+		if class == elf.ELFCLASS64 {
+			return false
+		}
+		compat32 = compat32 || class == elf.ELFCLASS32
+	}
+	return compat32
+}

--- a/internal/ldconfig/compat32_test.go
+++ b/internal/ldconfig/compat32_test.go
@@ -1,0 +1,191 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package ldconfig
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowsCompat32(t *testing.T) {
+	loaders, ok := compat32Loaders[runtime.GOARCH]
+	if !ok {
+		t.Skip("32-bit libraries are not handled on this platform")
+	}
+	muslArch := muslArchs[runtime.GOARCH]
+
+	testCases := []struct {
+		description string
+		// compat32Loader adds a dynamic linker for 32-bit applications.
+		compat32Loader string
+		// isMusl adds the musl dynamic linker.
+		isMusl bool
+		// requested indicates that the compat32 driver capability was requested.
+		requested bool
+		expected  bool
+	}{
+		{
+			description: "64-bit-only container is skipped",
+		},
+		{
+			description:    "container with a 32-bit loader is allowed",
+			compat32Loader: loaders[0],
+			expected:       true,
+		},
+		{
+			description: "container that requested the capability is allowed",
+			requested:   true,
+			expected:    true,
+		},
+		{
+			description: "musl container is skipped",
+			isMusl:      true,
+		},
+		{
+			description: "musl container that requested the capability is skipped",
+			isMusl:      true,
+			requested:   true,
+		},
+		{
+			description:    "musl container with a 32-bit loader is skipped",
+			isMusl:         true,
+			compat32Loader: loaders[0],
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			root := t.TempDir()
+			if tc.compat32Loader != "" {
+				makeFile(t, filepath.Join(root, tc.compat32Loader))
+			}
+			if tc.isMusl {
+				makeMuslLoader(t, root, muslArch)
+			}
+
+			require.Equal(t, tc.expected, allowsCompat32(root, tc.requested))
+		})
+	}
+}
+
+func TestAllowsCompat32DetectsAllLoaders(t *testing.T) {
+	for _, loader := range compat32Loaders[runtime.GOARCH] {
+		t.Run(loader, func(t *testing.T) {
+			root := t.TempDir()
+			makeFile(t, filepath.Join(root, loader))
+
+			require.True(t, allowsCompat32(root, false))
+		})
+	}
+}
+
+func TestExcludeCompat32Directories(t *testing.T) {
+	root := t.TempDir()
+	makeLibDir(t, root, "/native", elf.ELFCLASS64)
+	makeLibDir(t, root, "/compat32", elf.ELFCLASS32)
+	makeLibDir(t, root, "/mixed", elf.ELFCLASS64, elf.ELFCLASS32)
+	makeLibDir(t, root, "/empty")
+	notALib := makeLibDir(t, root, "/not-a-lib")
+	require.NoError(t, os.WriteFile(filepath.Join(notALib, "libnotelf.so.1"), []byte("#!/bin/sh\n"), 0o600))
+
+	testCases := []struct {
+		description string
+		dirs        []string
+		expected    []string
+	}{
+		{
+			description: "32-bit dirs are removed",
+			dirs:        []string{"/native", "/compat32"},
+			expected:    []string{"/native"},
+		},
+		{
+			description: "dirs with libraries of both classes are kept",
+			dirs:        []string{"/mixed"},
+			expected:    []string{"/mixed"},
+		},
+		{
+			description: "dirs without libraries are kept",
+			dirs:        []string{"/empty", "/not-a-lib", "/does-not-exist"},
+			expected:    []string{"/empty", "/not-a-lib", "/does-not-exist"},
+		},
+		{
+			description: "the order of the remaining dirs is maintained",
+			dirs:        []string{"/compat32", "/mixed", "/native"},
+			expected:    []string{"/mixed", "/native"},
+		},
+		{
+			description: "32-bit dirs alone leave no dirs",
+			dirs:        []string{"/compat32"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			require.Equal(t, tc.expected, excludeCompat32Directories(root, tc.dirs))
+		})
+	}
+}
+
+// makeLibDir creates a directory in the specified root holding a library of
+// each of the specified ELF classes.
+func makeLibDir(t *testing.T, root string, dir string, classes ...elf.Class) string {
+	t.Helper()
+
+	path := filepath.Join(root, dir)
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	for _, class := range classes {
+		name := "libnvidia-" + class.String() + ".so.999.88.77"
+		require.NoError(t, os.WriteFile(filepath.Join(path, name), elfFile(t, class), 0o600))
+	}
+	return path
+}
+
+// makeFile creates an empty file at the specified path.
+func makeFile(t *testing.T, path string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+}
+
+// elfFile returns a minimal ELF file of the specified class: a header without
+// program or section headers.
+func elfFile(t *testing.T, class elf.Class) []byte {
+	t.Helper()
+
+	var ident [elf.EI_NIDENT]byte
+	copy(ident[:], elf.ELFMAG)
+	ident[elf.EI_CLASS] = byte(class)
+	ident[elf.EI_DATA] = byte(elf.ELFDATA2LSB)
+	ident[elf.EI_VERSION] = byte(elf.EV_CURRENT)
+
+	var header any = elf.Header64{Ident: ident, Version: uint32(elf.EV_CURRENT)}
+	if class == elf.ELFCLASS32 {
+		header = elf.Header32{Ident: ident, Version: uint32(elf.EV_CURRENT)}
+	}
+	var contents bytes.Buffer
+	require.NoError(t, binary.Write(&contents, binary.LittleEndian, header))
+	return contents.Bytes()
+}

--- a/internal/ldconfig/ldconfig.go
+++ b/internal/ldconfig/ldconfig.go
@@ -182,8 +182,11 @@ func (l *Ldconfig) UpdateLDCache() error {
 		return fmt.Errorf("failed to write %s drop-in: %w", ldsoconfdSystemDirsFilenamePattern, err)
 	}
 
-	// Also output the folders to the alpine .path file as required.
-	if err := createMuslPathFileIfRequired(append(filteredDirectories, systemSearchPaths...)...); err != nil {
+	// Also output the folders to the musl .path files as required.
+	// Note that musl does not process the ld.so.conf files and the unfiltered
+	// list of directories is therefore used here. Since we have pivoted to the
+	// container root, these paths are resolved relative to "/".
+	if err := createMuslPathFilesIfRequired("/", l.directories, systemSearchPaths); err != nil {
 		return fmt.Errorf("failed to update .path file for musl: %w", err)
 	}
 
@@ -372,45 +375,6 @@ func processLdsoconfFile(ldsoconfFilename string) ([]string, []string, error) {
 		}
 	}
 	return directories, includedFilenames, nil
-}
-
-// createMuslPathFileIfRequired creates a musl .path file that allows libraries
-// from the specified directories to be discovered on the system.
-// This is required because systems that use musl do not rely on the ldcache to
-// discover libraries.
-func createMuslPathFileIfRequired(dirs ...string) error {
-	if len(dirs) == 0 || !isMusl() {
-		return nil
-	}
-
-	var pathFileName string
-	switch runtime.GOARCH {
-	case "amd64":
-		pathFileName = "/etc/ld-musl-x86_64.path"
-	case "arm64":
-		pathFileName = "/etc/ld-musl-aarch64.path"
-	}
-
-	pathFile, err := os.OpenFile(pathFileName, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
-	if err != nil {
-		return fmt.Errorf("could not open .path file: %w", err)
-	}
-	defer func() {
-		_ = pathFile.Close()
-	}()
-
-	return outputListToFile(pathFile, dirs...)
-}
-
-// isMusl checks whether the container is running musl instead of glibc.
-// Note that for the time being we only check whether `/etc/alpine-release` is
-// present in the container.
-func isMusl() bool {
-	info, err := os.Stat("/etc/alpine-release")
-	if err != nil {
-		return false
-	}
-	return !info.IsDir()
 }
 
 // isDebianLike returns true if a Debian-like distribution is detected.

--- a/internal/ldconfig/ldconfig.go
+++ b/internal/ldconfig/ldconfig.go
@@ -63,11 +63,14 @@ type Ldconfig struct {
 	isDebianLikeHost      bool
 	isDebianLikeContainer bool
 	noPivotRoot           bool
+	compat32Requested     bool
 	directories           []string
 }
 
 // NewRunner creates an exec.Cmd that can be used to run ldconfig.
-func NewRunner(id string, ldconfigPath string, containerRoot string, additionalargs ...string) (*exec.Cmd, error) {
+// The compat32Requested argument indicates that the container requested the
+// compat32 driver capability.
+func NewRunner(id string, ldconfigPath string, containerRoot string, compat32Requested bool, additionalargs ...string) (*exec.Cmd, error) {
 	args := []string{
 		id,
 		"--ldconfig-path", strings.TrimPrefix(config.NormalizeLDConfigPath("@"+ldconfigPath), "@"),
@@ -79,6 +82,10 @@ func NewRunner(id string, ldconfigPath string, containerRoot string, additionala
 
 	if noPivotRoot() {
 		args = append(args, "--no-pivot")
+	}
+
+	if compat32Requested {
+		args = append(args, "--compat32")
 	}
 
 	args = append(args, additionalargs...)
@@ -104,6 +111,7 @@ func NewRunner(id string, ldconfigPath string, containerRoot string, additionala
 //	                     	as opposed to non-Debian-like (e.g. RHEL, Fedora)
 //	                     	See https://github.com/NVIDIA/nvidia-container-toolkit/pull/1444
 //	--no-pivot           	pivot_root should not be used to provide process isolation.
+//	--compat32           	the container requested the compat32 driver capability.
 //
 // The remaining args are folders where soname symlinks need to be created.
 func NewFromArgs(args ...string) (*Ldconfig, error) {
@@ -118,6 +126,7 @@ This allows us to handle the case where there are  differences in behavior
 between the ldconfig from the host (as executed from an update-ldcache hook) and
 ldconfig in the container. Such differences include system search paths.`)
 	noPivot := fs.Bool("no-pivot", false, "don't use pivot_root to perform isolation")
+	compat32 := fs.Bool("compat32", false, "the container requested the compat32 driver capability")
 	if err := fs.Parse(args[1:]); err != nil {
 		return nil, err
 	}
@@ -130,11 +139,12 @@ ldconfig in the container. Such differences include system search paths.`)
 	}
 
 	l := &Ldconfig{
-		ldconfigPath:     *ldconfigPath,
-		inRoot:           *containerRoot,
-		isDebianLikeHost: *isDebianLikeHost,
-		noPivotRoot:      *noPivot,
-		directories:      fs.Args(),
+		ldconfigPath:      *ldconfigPath,
+		inRoot:            *containerRoot,
+		isDebianLikeHost:  *isDebianLikeHost,
+		noPivotRoot:       *noPivot,
+		compat32Requested: *compat32,
+		directories:       fs.Args(),
 	}
 	return l, nil
 }
@@ -154,7 +164,16 @@ func (l *Ldconfig) UpdateLDCache() error {
 		return fmt.Errorf("failed to ensure ld.so.conf file: %w", err)
 	}
 
-	filteredDirectories, err := l.filterDirectories(defaultTopLevelLdsoconfFilePath, l.directories...)
+	// The 32-bit libraries are only of use to a container that can run 32-bit
+	// applications and are left out of the search paths of the others. Since
+	// we have pivoted to the container root, these paths are resolved
+	// relative to "/".
+	directories := l.directories
+	if !allowsCompat32("/", l.compat32Requested) {
+		directories = excludeCompat32Directories("/", directories)
+	}
+
+	filteredDirectories, err := l.filterDirectories(defaultTopLevelLdsoconfFilePath, directories...)
 	if err != nil {
 		return err
 	}
@@ -182,11 +201,10 @@ func (l *Ldconfig) UpdateLDCache() error {
 		return fmt.Errorf("failed to write %s drop-in: %w", ldsoconfdSystemDirsFilenamePattern, err)
 	}
 
-	// Also output the folders to the musl .path files as required.
-	// Note that musl does not process the ld.so.conf files and the unfiltered
-	// list of directories is therefore used here. Since we have pivoted to the
-	// container root, these paths are resolved relative to "/".
-	if err := createMuslPathFilesIfRequired("/", l.directories, systemSearchPaths); err != nil {
+	// Also output the folders to the musl .path file as required.
+	// Note that musl does not process the ld.so.conf files and the directories
+	// that were filtered against these are therefore included here too.
+	if err := createMuslPathFileIfRequired("/", directories, systemSearchPaths); err != nil {
 		return fmt.Errorf("failed to update .path file for musl: %w", err)
 	}
 

--- a/internal/ldconfig/ldconfig_test.go
+++ b/internal/ldconfig/ldconfig_test.go
@@ -26,6 +26,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewFromArgs(t *testing.T) {
+	requiredArgs := []string{
+		"reexec-update-ldcache",
+		"--ldconfig-path", "/sbin/ldconfig",
+		"--container-root", "/container/root",
+	}
+
+	testCases := []struct {
+		description               string
+		args                      []string
+		expectedCompat32Requested bool
+		expectedDirectories       []string
+	}{
+		{
+			description:         "folders are parsed",
+			args:                []string{"/usr/lib/x86_64-linux-gnu", "/usr/lib/i386-linux-gnu"},
+			expectedDirectories: []string{"/usr/lib/x86_64-linux-gnu", "/usr/lib/i386-linux-gnu"},
+		},
+		{
+			description:               "compat32 is requested",
+			args:                      []string{"--compat32", "/usr/lib/i386-linux-gnu"},
+			expectedCompat32Requested: true,
+			expectedDirectories:       []string{"/usr/lib/i386-linux-gnu"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			l, err := NewFromArgs(append(requiredArgs, tc.args...)...)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedCompat32Requested, l.compat32Requested)
+			require.Equal(t, tc.expectedDirectories, l.directories)
+		})
+	}
+}
+
 func TestFilterDirectories(t *testing.T) {
 	const topLevelConf = "TOPLEVEL.conf"
 

--- a/internal/ldconfig/musl.go
+++ b/internal/ldconfig/musl.go
@@ -1,0 +1,150 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package ldconfig
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+// muslArchs maps the platform to the musl architecture names of the native
+// dynamic linker and of the 32-bit dynamic linker the platform can also run.
+// These name the linker, /lib/ld-musl-<arch>.so.1, and its .path file,
+// /etc/ld-musl-<arch>.path.
+var muslArchs = map[string]struct{ native, compat32 string }{
+	"amd64": {"x86_64", "i386"},
+	"arm64": {"aarch64", "armhf"},
+}
+
+// muslDefaultSearchPath is searched by musl when no .path file exists.
+// Creating the file replaces it, so it is written out explicitly.
+var muslDefaultSearchPath = []string{"/lib", "/usr/local/lib", "/usr/lib"}
+
+func muslLoader(root, arch string) string {
+	return filepath.Join(root, "/lib/ld-musl-"+arch+".so.1")
+}
+
+func muslPathFile(root, arch string) string {
+	return filepath.Join(root, "/etc/ld-musl-"+arch+".path")
+}
+
+// createMuslPathFilesIfRequired adds the specified directories to the musl
+// .path files in the specified root, which musl searches instead of an ldcache.
+//
+// Unlike the ldcache, a .path file carries no architecture information: musl
+// loads the first file matching the requested name and fails instead of
+// searching on if that file is of another ELF class. Each directory is
+// therefore added only to the .path file of the class of its libraries, and
+// the driver directories are searched before the directories that may hold
+// files of the same names for another class.
+func createMuslPathFilesIfRequired(root string, driverDirs []string, systemDirs []string) error {
+	archs, ok := muslArchs[runtime.GOARCH]
+	if !ok || !isMusl(root, archs.native) {
+		return nil
+	}
+
+	// Both supported platforms are 64-bit. Directories holding no libraries
+	// are added to the native .path file.
+	var nativeDirs, compat32Dirs []string
+	for _, dir := range driverDirs {
+		classes := libraryClasses(filepath.Join(root, dir))
+		if len(classes) == 0 || classes[elf.ELFCLASS64] {
+			nativeDirs = append(nativeDirs, dir)
+		}
+		if classes[elf.ELFCLASS32] {
+			compat32Dirs = append(compat32Dirs, dir)
+		}
+	}
+
+	if err := updateMuslPathFile(muslPathFile(root, archs.native), nativeDirs, systemDirs); err != nil {
+		return err
+	}
+	// 32-bit libraries are only of use to a 32-bit dynamic linker.
+	if len(compat32Dirs) == 0 || !isFile(muslLoader(root, archs.compat32)) {
+		return nil
+	}
+	return updateMuslPathFile(muslPathFile(root, archs.compat32), compat32Dirs, nil)
+}
+
+// updateMuslPathFile writes the driver directories that are not searched
+// already, then the existing entries, then the system directories to the
+// specified .path file. The default search path stands in for a missing file.
+func updateMuslPathFile(path string, driverDirs []string, systemDirs []string) error {
+	if len(driverDirs) == 0 && len(systemDirs) == 0 {
+		return nil
+	}
+
+	existing := muslDefaultSearchPath
+	if contents, err := os.ReadFile(path); err == nil {
+		// musl splits the file on colons and newlines.
+		existing = strings.FieldsFunc(string(contents), func(r rune) bool { return r == ':' || r == '\n' })
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("could not read .path file: %w", err)
+	}
+
+	var dirs []string
+	for _, dir := range driverDirs {
+		if !slices.Contains(existing, dir) {
+			dirs = append(dirs, dir)
+		}
+	}
+	dirs = append(append(dirs, existing...), systemDirs...)
+
+	pathFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("could not open .path file: %w", err)
+	}
+	defer func() {
+		_ = pathFile.Close()
+	}()
+
+	return outputListToFile(pathFile, dirs...)
+}
+
+// libraryClasses returns the ELF classes of the libraries in the specified
+// directory. Files that are not ELF files are ignored.
+func libraryClasses(dir string) map[elf.Class]bool {
+	classes := make(map[elf.Class]bool)
+	libraries, _ := filepath.Glob(filepath.Join(dir, "lib?*.so*"))
+	for _, library := range libraries {
+		f, err := elf.Open(library)
+		if err != nil {
+			continue
+		}
+		classes[f.Class] = true
+		_ = f.Close()
+	}
+	return classes
+}
+
+// isMusl checks whether the container is running musl instead of glibc: its
+// dynamic linker is present or, failing that, the container is Alpine-based.
+func isMusl(root string, arch string) bool {
+	return isFile(muslLoader(root, arch)) || isFile(filepath.Join(root, "/etc/alpine-release"))
+}
+
+// isFile checks whether the specified path exists and is not a directory.
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/ldconfig/musl.go
+++ b/internal/ldconfig/musl.go
@@ -18,7 +18,6 @@
 package ldconfig
 
 import (
-	"debug/elf"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,13 +26,12 @@ import (
 	"strings"
 )
 
-// muslArchs maps the platform to the musl architecture names of the native
-// dynamic linker and of the 32-bit dynamic linker the platform can also run.
-// These name the linker, /lib/ld-musl-<arch>.so.1, and its .path file,
+// muslArchs maps the platform to the musl architecture name, which names the
+// dynamic linker, /lib/ld-musl-<arch>.so.1, and its .path file,
 // /etc/ld-musl-<arch>.path.
-var muslArchs = map[string]struct{ native, compat32 string }{
-	"amd64": {"x86_64", "i386"},
-	"arm64": {"aarch64", "armhf"},
+var muslArchs = map[string]string{
+	"amd64": "x86_64",
+	"arm64": "aarch64",
 }
 
 // muslDefaultSearchPath is searched by musl when no .path file exists.
@@ -48,47 +46,25 @@ func muslPathFile(root, arch string) string {
 	return filepath.Join(root, "/etc/ld-musl-"+arch+".path")
 }
 
-// createMuslPathFilesIfRequired adds the specified directories to the musl
-// .path files in the specified root, which musl searches instead of an ldcache.
-//
-// Unlike the ldcache, a .path file carries no architecture information: musl
-// loads the first file matching the requested name and fails instead of
-// searching on if that file is of another ELF class. Each directory is
-// therefore added only to the .path file of the class of its libraries, and
-// the driver directories are searched before the directories that may hold
-// files of the same names for another class.
-func createMuslPathFilesIfRequired(root string, driverDirs []string, systemDirs []string) error {
-	archs, ok := muslArchs[runtime.GOARCH]
-	if !ok || !isMusl(root, archs.native) {
+// createMuslPathFileIfRequired adds the specified directories to the musl
+// .path file in the specified root, which musl searches instead of an ldcache.
+func createMuslPathFileIfRequired(root string, driverDirs []string, systemDirs []string) error {
+	arch, ok := muslArchs[runtime.GOARCH]
+	if !ok || !isMusl(root, arch) {
 		return nil
 	}
 
-	// Both supported platforms are 64-bit. Directories holding no libraries
-	// are added to the native .path file.
-	var nativeDirs, compat32Dirs []string
-	for _, dir := range driverDirs {
-		classes := libraryClasses(filepath.Join(root, dir))
-		if len(classes) == 0 || classes[elf.ELFCLASS64] {
-			nativeDirs = append(nativeDirs, dir)
-		}
-		if classes[elf.ELFCLASS32] {
-			compat32Dirs = append(compat32Dirs, dir)
-		}
-	}
-
-	if err := updateMuslPathFile(muslPathFile(root, archs.native), nativeDirs, systemDirs); err != nil {
-		return err
-	}
-	// 32-bit libraries are only of use to a 32-bit dynamic linker.
-	if len(compat32Dirs) == 0 || !isFile(muslLoader(root, archs.compat32)) {
-		return nil
-	}
-	return updateMuslPathFile(muslPathFile(root, archs.compat32), compat32Dirs, nil)
+	return updateMuslPathFile(muslPathFile(root, arch), driverDirs, systemDirs)
 }
 
 // updateMuslPathFile writes the driver directories that are not searched
 // already, then the existing entries, then the system directories to the
 // specified .path file. The default search path stands in for a missing file.
+//
+// The driver directories are searched first so that an injected library wins a
+// name lookup against a file of the same name that happens to sit in a
+// directory that is searched already. This is the precedence that the glibc
+// path gives these directories through the 00-nvcr-*.conf drop-in.
 func updateMuslPathFile(path string, driverDirs []string, systemDirs []string) error {
 	if len(driverDirs) == 0 && len(systemDirs) == 0 {
 		return nil
@@ -119,22 +95,6 @@ func updateMuslPathFile(path string, driverDirs []string, systemDirs []string) e
 	}()
 
 	return outputListToFile(pathFile, dirs...)
-}
-
-// libraryClasses returns the ELF classes of the libraries in the specified
-// directory. Files that are not ELF files are ignored.
-func libraryClasses(dir string) map[elf.Class]bool {
-	classes := make(map[elf.Class]bool)
-	libraries, _ := filepath.Glob(filepath.Join(dir, "lib?*.so*"))
-	for _, library := range libraries {
-		f, err := elf.Open(library)
-		if err != nil {
-			continue
-		}
-		classes[f.Class] = true
-		_ = f.Close()
-	}
-	return classes
 }
 
 // isMusl checks whether the container is running musl instead of glibc: its

--- a/internal/ldconfig/musl_test.go
+++ b/internal/ldconfig/musl_test.go
@@ -1,0 +1,250 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package ldconfig
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateMuslPathFilesIfRequired(t *testing.T) {
+	archs, ok := muslArchs[runtime.GOARCH]
+	if !ok {
+		t.Skip("musl .path files are not handled on this platform")
+	}
+
+	testCases := []struct {
+		description string
+		// isMusl adds the native musl dynamic linker.
+		isMusl bool
+		// hasCompat32Loader adds the 32-bit musl dynamic linker.
+		hasCompat32Loader bool
+		// pathFileContents is the contents of the native .path file before the update.
+		pathFileContents *string
+		driverDirs       []string
+		systemDirs       []string
+		expectedNative   *string
+		expectedCompat32 *string
+	}{
+		{
+			description: "glibc container is not modified",
+			driverDirs:  []string{"/native"},
+			systemDirs:  []string{"/lib", "/usr/lib"},
+		},
+		{
+			description:    "path file is created with the default search path preserved",
+			isMusl:         true,
+			driverDirs:     []string{"/native"},
+			systemDirs:     []string{"/lib", "/usr/lib"},
+			expectedNative: ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:      "driver dirs are prepended to the existing contents",
+			isMusl:           true,
+			pathFileContents: ptr("/lib:/usr/local/lib:/usr/lib"),
+			driverDirs:       []string{"/native"},
+			systemDirs:       []string{"/lib", "/usr/lib"},
+			expectedNative:   ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:      "dirs that are searched already are not reordered",
+			isMusl:           true,
+			pathFileContents: ptr("/lib\n/usr/local/lib\n/native\n"),
+			driverDirs:       []string{"/native"},
+			expectedNative:   ptr("/lib\n/usr/local/lib\n/native\n"),
+		},
+		{
+			description:      "32-bit dirs are not added to the native path file",
+			isMusl:           true,
+			pathFileContents: ptr("/lib:/usr/local/lib:/usr/lib"),
+			driverDirs:       []string{"/native", "/compat32"},
+			systemDirs:       []string{"/lib", "/usr/lib"},
+			expectedNative:   ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:       "32-bit dirs are added to the 32-bit path file if a loader is present",
+			isMusl:            true,
+			hasCompat32Loader: true,
+			pathFileContents:  ptr("/lib:/usr/local/lib:/usr/lib"),
+			driverDirs:        []string{"/native", "/compat32"},
+			systemDirs:        []string{"/lib", "/usr/lib"},
+			expectedNative:    ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			expectedCompat32:  ptr("/compat32\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:       "dirs with libraries of both classes are added to both path files",
+			isMusl:            true,
+			hasCompat32Loader: true,
+			driverDirs:        []string{"/mixed"},
+			expectedNative:    ptr("/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			expectedCompat32:  ptr("/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:    "dirs without libraries are added to the native path file",
+			isMusl:         true,
+			driverDirs:     []string{"/empty", "/not-a-lib", "/does-not-exist"},
+			expectedNative: ptr("/empty\n/not-a-lib\n/does-not-exist\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:       "order is maintained for both classes",
+			isMusl:            true,
+			hasCompat32Loader: true,
+			driverDirs:        []string{"/compat32", "/native", "/mixed"},
+			expectedNative:    ptr("/native\n/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			expectedCompat32:  ptr("/compat32\n/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:      "entries separated by colons and newlines are read",
+			isMusl:           true,
+			pathFileContents: ptr("/lib:/usr/local/lib\n/usr/lib"),
+			driverDirs:       []string{"/native"},
+			expectedNative:   ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description:    "system dirs alone create the path file",
+			isMusl:         true,
+			systemDirs:     []string{"/lib", "/usr/lib"},
+			expectedNative: ptr("/lib\n/usr/local/lib\n/usr/lib\n"),
+		},
+		{
+			description: "no dirs leave the container untouched",
+			isMusl:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			root := t.TempDir()
+			makeLibDir(t, root, "/native", elf.ELFCLASS64)
+			makeLibDir(t, root, "/compat32", elf.ELFCLASS32)
+			makeLibDir(t, root, "/mixed", elf.ELFCLASS64, elf.ELFCLASS32)
+			makeLibDir(t, root, "/empty")
+			notALib := makeLibDir(t, root, "/not-a-lib")
+			require.NoError(t, os.WriteFile(filepath.Join(notALib, "libnotelf.so.1"), []byte("#!/bin/sh\n"), 0o600))
+
+			require.NoError(t, os.MkdirAll(filepath.Join(root, "/etc"), 0o755))
+			if tc.pathFileContents != nil {
+				require.NoError(t, os.WriteFile(muslPathFile(root, archs.native), []byte(*tc.pathFileContents), 0o600))
+			}
+			if tc.isMusl {
+				makeMuslLoader(t, root, archs.native, elf.ELFCLASS64)
+			}
+			if tc.hasCompat32Loader {
+				makeMuslLoader(t, root, archs.compat32, elf.ELFCLASS32)
+			}
+
+			require.NoError(t, createMuslPathFilesIfRequired(root, tc.driverDirs, tc.systemDirs))
+
+			requireFileContents(t, muslPathFile(root, archs.native), tc.expectedNative)
+			requireFileContents(t, muslPathFile(root, archs.compat32), tc.expectedCompat32)
+		})
+	}
+}
+
+func TestIsMusl(t *testing.T) {
+	archs, ok := muslArchs[runtime.GOARCH]
+	if !ok {
+		t.Skip("musl .path files are not handled on this platform")
+	}
+
+	t.Run("glibc container", func(t *testing.T) {
+		require.False(t, isMusl(t.TempDir(), archs.native))
+	})
+
+	t.Run("musl loader", func(t *testing.T) {
+		root := t.TempDir()
+		makeMuslLoader(t, root, archs.native, elf.ELFCLASS64)
+		require.True(t, isMusl(root, archs.native))
+	})
+
+	t.Run("alpine release file", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "/etc"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "/etc/alpine-release"), nil, 0o600))
+		require.True(t, isMusl(root, archs.native))
+	})
+}
+
+// makeLibDir creates a directory in the specified root holding a library of
+// each of the specified ELF classes.
+func makeLibDir(t *testing.T, root string, dir string, classes ...elf.Class) string {
+	t.Helper()
+
+	path := filepath.Join(root, dir)
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	for _, class := range classes {
+		name := "libnvidia-" + class.String() + ".so.999.88.77"
+		require.NoError(t, os.WriteFile(filepath.Join(path, name), elfFile(t, class), 0o600))
+	}
+	return path
+}
+
+// makeMuslLoader creates the musl dynamic linker for the specified
+// architecture in the specified root.
+func makeMuslLoader(t *testing.T, root string, arch string, class elf.Class) {
+	t.Helper()
+
+	path := muslLoader(root, arch)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, elfFile(t, class), 0o600))
+}
+
+// elfFile returns a minimal ELF file of the specified class: a header without
+// program or section headers.
+func elfFile(t *testing.T, class elf.Class) []byte {
+	t.Helper()
+
+	var ident [elf.EI_NIDENT]byte
+	copy(ident[:], elf.ELFMAG)
+	ident[elf.EI_CLASS] = byte(class)
+	ident[elf.EI_DATA] = byte(elf.ELFDATA2LSB)
+	ident[elf.EI_VERSION] = byte(elf.EV_CURRENT)
+
+	var header any = elf.Header64{Ident: ident, Version: uint32(elf.EV_CURRENT)}
+	if class == elf.ELFCLASS32 {
+		header = elf.Header32{Ident: ident, Version: uint32(elf.EV_CURRENT)}
+	}
+	var contents bytes.Buffer
+	require.NoError(t, binary.Write(&contents, binary.LittleEndian, header))
+	return contents.Bytes()
+}
+
+// requireFileContents checks the contents of the specified file.
+// If the expected contents are nil, the file is required to not exist.
+func requireFileContents(t *testing.T, path string, expected *string) {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if expected == nil {
+		require.ErrorIs(t, err, os.ErrNotExist)
+		return
+	}
+	require.NoError(t, err)
+	require.Equal(t, *expected, string(contents))
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/internal/ldconfig/musl_test.go
+++ b/internal/ldconfig/musl_test.go
@@ -18,9 +18,6 @@
 package ldconfig
 
 import (
-	"bytes"
-	"debug/elf"
-	"encoding/binary"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,104 +26,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateMuslPathFilesIfRequired(t *testing.T) {
-	archs, ok := muslArchs[runtime.GOARCH]
+func TestCreateMuslPathFileIfRequired(t *testing.T) {
+	arch, ok := muslArchs[runtime.GOARCH]
 	if !ok {
 		t.Skip("musl .path files are not handled on this platform")
 	}
 
 	testCases := []struct {
 		description string
-		// isMusl adds the native musl dynamic linker.
+		// isMusl adds the musl dynamic linker.
 		isMusl bool
-		// hasCompat32Loader adds the 32-bit musl dynamic linker.
-		hasCompat32Loader bool
-		// pathFileContents is the contents of the native .path file before the update.
+		// pathFileContents is the contents of the .path file before the update.
 		pathFileContents *string
 		driverDirs       []string
 		systemDirs       []string
-		expectedNative   *string
-		expectedCompat32 *string
+		expected         *string
 	}{
 		{
 			description: "glibc container is not modified",
-			driverDirs:  []string{"/native"},
+			driverDirs:  []string{"/driver"},
 			systemDirs:  []string{"/lib", "/usr/lib"},
 		},
 		{
-			description:    "path file is created with the default search path preserved",
-			isMusl:         true,
-			driverDirs:     []string{"/native"},
-			systemDirs:     []string{"/lib", "/usr/lib"},
-			expectedNative: ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			description: "path file is created with the default search path preserved",
+			isMusl:      true,
+			driverDirs:  []string{"/driver"},
+			systemDirs:  []string{"/lib", "/usr/lib"},
+			expected:    ptr("/driver\n/lib\n/usr/local/lib\n/usr/lib\n"),
 		},
 		{
 			description:      "driver dirs are prepended to the existing contents",
 			isMusl:           true,
 			pathFileContents: ptr("/lib:/usr/local/lib:/usr/lib"),
-			driverDirs:       []string{"/native"},
+			driverDirs:       []string{"/driver"},
 			systemDirs:       []string{"/lib", "/usr/lib"},
-			expectedNative:   ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			expected:         ptr("/driver\n/lib\n/usr/local/lib\n/usr/lib\n"),
 		},
 		{
 			description:      "dirs that are searched already are not reordered",
 			isMusl:           true,
-			pathFileContents: ptr("/lib\n/usr/local/lib\n/native\n"),
-			driverDirs:       []string{"/native"},
-			expectedNative:   ptr("/lib\n/usr/local/lib\n/native\n"),
+			pathFileContents: ptr("/lib\n/usr/local/lib\n/driver\n"),
+			driverDirs:       []string{"/driver"},
+			expected:         ptr("/lib\n/usr/local/lib\n/driver\n"),
 		},
 		{
-			description:      "32-bit dirs are not added to the native path file",
-			isMusl:           true,
-			pathFileContents: ptr("/lib:/usr/local/lib:/usr/lib"),
-			driverDirs:       []string{"/native", "/compat32"},
-			systemDirs:       []string{"/lib", "/usr/lib"},
-			expectedNative:   ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
-		},
-		{
-			description:       "32-bit dirs are added to the 32-bit path file if a loader is present",
-			isMusl:            true,
-			hasCompat32Loader: true,
-			pathFileContents:  ptr("/lib:/usr/local/lib:/usr/lib"),
-			driverDirs:        []string{"/native", "/compat32"},
-			systemDirs:        []string{"/lib", "/usr/lib"},
-			expectedNative:    ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
-			expectedCompat32:  ptr("/compat32\n/lib\n/usr/local/lib\n/usr/lib\n"),
-		},
-		{
-			description:       "dirs with libraries of both classes are added to both path files",
-			isMusl:            true,
-			hasCompat32Loader: true,
-			driverDirs:        []string{"/mixed"},
-			expectedNative:    ptr("/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
-			expectedCompat32:  ptr("/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
-		},
-		{
-			description:    "dirs without libraries are added to the native path file",
-			isMusl:         true,
-			driverDirs:     []string{"/empty", "/not-a-lib", "/does-not-exist"},
-			expectedNative: ptr("/empty\n/not-a-lib\n/does-not-exist\n/lib\n/usr/local/lib\n/usr/lib\n"),
-		},
-		{
-			description:       "order is maintained for both classes",
-			isMusl:            true,
-			hasCompat32Loader: true,
-			driverDirs:        []string{"/compat32", "/native", "/mixed"},
-			expectedNative:    ptr("/native\n/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
-			expectedCompat32:  ptr("/compat32\n/mixed\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			description: "the order of the driver dirs is maintained",
+			isMusl:      true,
+			driverDirs:  []string{"/driver-2", "/driver-1"},
+			expected:    ptr("/driver-2\n/driver-1\n/lib\n/usr/local/lib\n/usr/lib\n"),
 		},
 		{
 			description:      "entries separated by colons and newlines are read",
 			isMusl:           true,
 			pathFileContents: ptr("/lib:/usr/local/lib\n/usr/lib"),
-			driverDirs:       []string{"/native"},
-			expectedNative:   ptr("/native\n/lib\n/usr/local/lib\n/usr/lib\n"),
+			driverDirs:       []string{"/driver"},
+			expected:         ptr("/driver\n/lib\n/usr/local/lib\n/usr/lib\n"),
 		},
 		{
-			description:    "system dirs alone create the path file",
-			isMusl:         true,
-			systemDirs:     []string{"/lib", "/usr/lib"},
-			expectedNative: ptr("/lib\n/usr/local/lib\n/usr/lib\n"),
+			description: "system dirs alone create the path file",
+			isMusl:      true,
+			systemDirs:  []string{"/lib", "/usr/lib"},
+			expected:    ptr("/lib\n/usr/local/lib\n/usr/lib\n"),
 		},
 		{
 			description: "no dirs leave the container untouched",
@@ -137,98 +97,50 @@ func TestCreateMuslPathFilesIfRequired(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			root := t.TempDir()
-			makeLibDir(t, root, "/native", elf.ELFCLASS64)
-			makeLibDir(t, root, "/compat32", elf.ELFCLASS32)
-			makeLibDir(t, root, "/mixed", elf.ELFCLASS64, elf.ELFCLASS32)
-			makeLibDir(t, root, "/empty")
-			notALib := makeLibDir(t, root, "/not-a-lib")
-			require.NoError(t, os.WriteFile(filepath.Join(notALib, "libnotelf.so.1"), []byte("#!/bin/sh\n"), 0o600))
-
 			require.NoError(t, os.MkdirAll(filepath.Join(root, "/etc"), 0o755))
 			if tc.pathFileContents != nil {
-				require.NoError(t, os.WriteFile(muslPathFile(root, archs.native), []byte(*tc.pathFileContents), 0o600))
+				require.NoError(t, os.WriteFile(muslPathFile(root, arch), []byte(*tc.pathFileContents), 0o600))
 			}
 			if tc.isMusl {
-				makeMuslLoader(t, root, archs.native, elf.ELFCLASS64)
-			}
-			if tc.hasCompat32Loader {
-				makeMuslLoader(t, root, archs.compat32, elf.ELFCLASS32)
+				makeMuslLoader(t, root, arch)
 			}
 
-			require.NoError(t, createMuslPathFilesIfRequired(root, tc.driverDirs, tc.systemDirs))
+			require.NoError(t, createMuslPathFileIfRequired(root, tc.driverDirs, tc.systemDirs))
 
-			requireFileContents(t, muslPathFile(root, archs.native), tc.expectedNative)
-			requireFileContents(t, muslPathFile(root, archs.compat32), tc.expectedCompat32)
+			requireFileContents(t, muslPathFile(root, arch), tc.expected)
 		})
 	}
 }
 
 func TestIsMusl(t *testing.T) {
-	archs, ok := muslArchs[runtime.GOARCH]
+	arch, ok := muslArchs[runtime.GOARCH]
 	if !ok {
 		t.Skip("musl .path files are not handled on this platform")
 	}
 
 	t.Run("glibc container", func(t *testing.T) {
-		require.False(t, isMusl(t.TempDir(), archs.native))
+		require.False(t, isMusl(t.TempDir(), arch))
 	})
 
 	t.Run("musl loader", func(t *testing.T) {
 		root := t.TempDir()
-		makeMuslLoader(t, root, archs.native, elf.ELFCLASS64)
-		require.True(t, isMusl(root, archs.native))
+		makeMuslLoader(t, root, arch)
+		require.True(t, isMusl(root, arch))
 	})
 
 	t.Run("alpine release file", func(t *testing.T) {
 		root := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(root, "/etc"), 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(root, "/etc/alpine-release"), nil, 0o600))
-		require.True(t, isMusl(root, archs.native))
+		makeFile(t, filepath.Join(root, "/etc/alpine-release"))
+		require.True(t, isMusl(root, arch))
 	})
-}
-
-// makeLibDir creates a directory in the specified root holding a library of
-// each of the specified ELF classes.
-func makeLibDir(t *testing.T, root string, dir string, classes ...elf.Class) string {
-	t.Helper()
-
-	path := filepath.Join(root, dir)
-	require.NoError(t, os.MkdirAll(path, 0o755))
-	for _, class := range classes {
-		name := "libnvidia-" + class.String() + ".so.999.88.77"
-		require.NoError(t, os.WriteFile(filepath.Join(path, name), elfFile(t, class), 0o600))
-	}
-	return path
 }
 
 // makeMuslLoader creates the musl dynamic linker for the specified
 // architecture in the specified root.
-func makeMuslLoader(t *testing.T, root string, arch string, class elf.Class) {
+func makeMuslLoader(t *testing.T, root string, arch string) {
 	t.Helper()
 
-	path := muslLoader(root, arch)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.WriteFile(path, elfFile(t, class), 0o600))
-}
-
-// elfFile returns a minimal ELF file of the specified class: a header without
-// program or section headers.
-func elfFile(t *testing.T, class elf.Class) []byte {
-	t.Helper()
-
-	var ident [elf.EI_NIDENT]byte
-	copy(ident[:], elf.ELFMAG)
-	ident[elf.EI_CLASS] = byte(class)
-	ident[elf.EI_DATA] = byte(elf.ELFDATA2LSB)
-	ident[elf.EI_VERSION] = byte(elf.EV_CURRENT)
-
-	var header any = elf.Header64{Ident: ident, Version: uint32(elf.EV_CURRENT)}
-	if class == elf.ELFCLASS32 {
-		header = elf.Header32{Ident: ident, Version: uint32(elf.EV_CURRENT)}
-	}
-	var contents bytes.Buffer
-	require.NoError(t, binary.Write(&contents, binary.LittleEndian, header))
-	return contents.Bytes()
+	makeFile(t, muslLoader(root, arch))
 }
 
 // requireFileContents checks the contents of the specified file.

--- a/internal/lookup/root/options.go
+++ b/internal/lookup/root/options.go
@@ -28,7 +28,10 @@ type options struct {
 	librarySearchPaths []string
 	// configSearchPaths specified explicit search paths for discovering driver config files.
 	configSearchPaths []string
-	versioner         Versioner
+	// compat32 indicates whether the 32-bit driver libraries are also
+	// discovered.
+	compat32  bool
+	versioner Versioner
 }
 
 type Option func(*options)
@@ -60,6 +63,14 @@ func WithLibrarySearchPaths(paths ...string) Option {
 func WithConfigSearchPaths(paths ...string) Option {
 	return func(o *options) {
 		o.configSearchPaths = paths
+	}
+}
+
+// WithCompat32Libraries controls whether the 32-bit driver libraries are also
+// discovered. These are discovered by default.
+func WithCompat32Libraries(compat32 bool) Option {
+	return func(o *options) {
+		o.compat32 = compat32
 	}
 }
 

--- a/internal/lookup/root/root.go
+++ b/internal/lookup/root/root.go
@@ -41,6 +41,9 @@ type Driver struct {
 	librarySearchPaths []string
 	// configSearchPaths specified explicit search paths for discovering driver config files.
 	configSearchPaths []string
+	// compat32 indicates whether the 32-bit driver libraries are also
+	// discovered.
+	compat32 bool
 
 	// version caches the driver version.
 	version string
@@ -50,7 +53,10 @@ type Driver struct {
 
 // New creates a new Driver root using the specified options.
 func New(opts ...Option) *Driver {
-	o := &options{}
+	// The 32-bit driver libraries are discovered unless a caller opts out.
+	o := &options{
+		compat32: true,
+	}
 	for _, opt := range opts {
 		opt(o)
 	}
@@ -76,6 +82,7 @@ func New(opts ...Option) *Driver {
 		DevRoot:              o.DevRoot,
 		librarySearchPaths:   o.librarySearchPaths,
 		configSearchPaths:    o.configSearchPaths,
+		compat32:             o.compat32,
 		version:              driverVersion,
 		driverLibDirectories: nil,
 	}
@@ -230,6 +237,7 @@ func (r *Driver) Libraries() lookup.Locator {
 		lookup.WithLogger(r.logger),
 		lookup.WithRoot(r.Root),
 		lookup.WithSearchPaths(r.librarySearchPaths...),
+		lookup.WithCompat32Libraries(r.compat32),
 	)
 }
 

--- a/internal/oci/state.go
+++ b/internal/oci/state.go
@@ -77,6 +77,19 @@ func (s *State) getRoot() (string, error) {
 	return "", nil
 }
 
+// GetEnv returns the environment of the container process from the associated
+// spec.
+func (s *State) GetEnv() ([]string, error) {
+	spec, err := s.loadMinimalSpec()
+	if err != nil {
+		return nil, err
+	}
+	if spec.Process == nil {
+		return nil, nil
+	}
+	return spec.Process.Env, nil
+}
+
 // GetContainerRoot returns the root for the container from the associated spec. If the spec is not yet loaded, it is
 // loaded and cached.
 func (s *State) GetContainerRoot() (string, error) {
@@ -114,4 +127,13 @@ func (s *State) loadMinimalSpec() (*minimalSpec, error) {
 type minimalSpec struct {
 	// Root configures the container's root filesystem.
 	Root *specs.Root `json:"root,omitempty"`
+	// Process configures the container process.
+	Process *minimalProcess `json:"process,omitempty"`
+}
+
+// A minimalProcess includes the properties of the container process that are
+// required by container lifecycle hooks.
+type minimalProcess struct {
+	// Env is the environment of the container process.
+	Env []string `json:"env,omitempty"`
 }

--- a/internal/oci/state_test.go
+++ b/internal/oci/state_test.go
@@ -209,6 +209,58 @@ func TestGetContainerRoot(t *testing.T) {
 	}
 }
 
+func TestGetEnv(t *testing.T) {
+	testCases := []struct {
+		description string
+		specJSON    string
+		writeSpec   bool
+		isError     bool
+		expectedEnv []string
+	}{
+		{
+			description: "returns an error when the spec file cannot be loaded",
+			writeSpec:   false,
+			isError:     true,
+		},
+		{
+			description: "returns nil when the spec has no process",
+			writeSpec:   true,
+			specJSON:    `{}`,
+		},
+		{
+			description: "returns nil when the process has no environment",
+			writeSpec:   true,
+			specJSON:    `{"process": {}}`,
+		},
+		{
+			description: "returns the environment of the container process",
+			writeSpec:   true,
+			specJSON:    `{"process": {"env": ["PATH=/usr/bin", "NVIDIA_DRIVER_CAPABILITIES=compute,compat32"]}}`,
+			expectedEnv: []string{"PATH=/usr/bin", "NVIDIA_DRIVER_CAPABILITIES=compute,compat32"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.writeSpec {
+				require.NoError(t, os.WriteFile(GetSpecFilePath(dir), []byte(tc.specJSON), 0600))
+			}
+			s := &State{State: specs.State{Bundle: dir}}
+
+			env, err := s.GetEnv()
+
+			if tc.isError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedEnv, env)
+		})
+	}
+}
+
 func TestLoadMinimalSpec(t *testing.T) {
 	testCases := []struct {
 		description  string

--- a/pkg/lookup/factory.go
+++ b/pkg/lookup/factory.go
@@ -26,12 +26,16 @@ type Factory struct {
 	searchPaths []string
 	filter      func(string) error
 	count       int
+	compat32    bool
 }
 
 type Option func(*Factory)
 
 func NewFactory(opts ...Option) *Factory {
-	o := &Factory{}
+	// The 32-bit libraries on the host are considered unless a caller opts out.
+	o := &Factory{
+		compat32: true,
+	}
 	for _, opt := range opts {
 		opt(o)
 	}
@@ -77,5 +81,13 @@ func WithFilter(assert func(string) error) Option {
 func WithCount(count int) Option {
 	return func(f *Factory) {
 		f.count = count
+	}
+}
+
+// WithCompat32Libraries controls whether 32-bit libraries are also considered
+// when locating libraries. These are included by default.
+func WithCompat32Libraries(compat32 bool) Option {
+	return func(f *Factory) {
+		f.compat32 = compat32
 	}
 }

--- a/pkg/lookup/ldcache.go
+++ b/pkg/lookup/ldcache.go
@@ -43,16 +43,21 @@ func (f *Factory) newLdcacheLocator() Locator {
 		f.logger.Warningf("Failed to load ldcache: %v", err)
 		return notFound
 	}
+	return f.newLdcacheLocatorFrom(cache)
+}
 
+func (f *Factory) newLdcacheLocatorFrom(cache ldcache.LDCache) Locator {
 	var libraries []string
-	_, libs64 := cache.List()
-	for _, library := range libs64 {
-		chain, err := symlinks.ResolveChain(library)
-		if err != nil {
-			f.logger.Warningf("Failed to resolve symlink chain for library %q: %v", library, err)
-			continue
+	libs32, libs64 := cache.List()
+	for _, libs := range [][]string{libs64, libs32} {
+		for _, library := range libs {
+			chain, err := symlinks.ResolveChain(library)
+			if err != nil {
+				f.logger.Warningf("Failed to resolve symlink chain for library %q: %v", library, err)
+				continue
+			}
+			libraries = append(libraries, chain...)
 		}
-		libraries = append(libraries, chain...)
 	}
 
 	l := &ldcacheLocator{

--- a/pkg/lookup/ldcache.go
+++ b/pkg/lookup/ldcache.go
@@ -47,9 +47,16 @@ func (f *Factory) newLdcacheLocator() Locator {
 }
 
 func (f *Factory) newLdcacheLocatorFrom(cache ldcache.LDCache) Locator {
-	var libraries []string
 	libs32, libs64 := cache.List()
-	for _, libs := range [][]string{libs64, libs32} {
+	// The 32-bit libraries are searched after the native ones, and only if
+	// these are not explicitly excluded.
+	libraryLists := [][]string{libs64}
+	if f.compat32 {
+		libraryLists = append(libraryLists, libs32)
+	}
+
+	var libraries []string
+	for _, libs := range libraryLists {
 		for _, library := range libs {
 			chain, err := symlinks.ResolveChain(library)
 			if err != nil {

--- a/pkg/lookup/ldcache_test.go
+++ b/pkg/lookup/ldcache_test.go
@@ -1,12 +1,15 @@
 package lookup
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/ldcache"
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
 )
 
@@ -74,4 +77,33 @@ func TestLDCacheLookup(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestLDCacheLookupIncludes32BitLibraries(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+	root := t.TempDir()
+
+	lib64 := filepath.Join(root, "usr/lib64/libcuda.so.999.88.77")
+	lib32 := filepath.Join(root, "usr/lib/libcuda.so.999.88.77")
+	require.NoError(t, os.MkdirAll(filepath.Dir(lib64), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(lib32), 0o755))
+	require.NoError(t, os.WriteFile(lib64, nil, 0o600))
+	require.NoError(t, os.WriteFile(lib32, nil, 0o600))
+
+	cache := &ldcache.LDCacheMock{
+		ListFunc: func() ([]string, []string) {
+			return []string{lib32}, []string{lib64}
+		},
+	}
+	l := NewFactory(
+		WithLogger(logger),
+		WithRoot(root),
+	).newLdcacheLocatorFrom(cache)
+
+	candidates, err := l.Locate("libcuda.so.*")
+	require.NoError(t, err)
+	for i := range candidates {
+		candidates[i] = strings.TrimPrefix(candidates[i], "/private")
+	}
+	require.Equal(t, []string{lib64, lib32}, candidates)
 }

--- a/pkg/lookup/ldcache_test.go
+++ b/pkg/lookup/ldcache_test.go
@@ -79,7 +79,7 @@ func TestLDCacheLookup(t *testing.T) {
 	}
 }
 
-func TestLDCacheLookupIncludes32BitLibraries(t *testing.T) {
+func TestLDCacheLookup32BitLibraries(t *testing.T) {
 	logger, _ := testlog.NewNullLogger()
 	root := t.TempDir()
 
@@ -90,20 +90,41 @@ func TestLDCacheLookupIncludes32BitLibraries(t *testing.T) {
 	require.NoError(t, os.WriteFile(lib64, nil, 0o600))
 	require.NoError(t, os.WriteFile(lib32, nil, 0o600))
 
-	cache := &ldcache.LDCacheMock{
-		ListFunc: func() ([]string, []string) {
-			return []string{lib32}, []string{lib64}
+	testCases := []struct {
+		description string
+		exclude     bool
+		expected    []string
+	}{
+		{
+			description: "32-bit libraries are included after the 64-bit ones",
+			expected:    []string{lib64, lib32},
+		},
+		{
+			description: "32-bit libraries can be excluded",
+			exclude:     true,
+			expected:    []string{lib64},
 		},
 	}
-	l := NewFactory(
-		WithLogger(logger),
-		WithRoot(root),
-	).newLdcacheLocatorFrom(cache)
 
-	candidates, err := l.Locate("libcuda.so.*")
-	require.NoError(t, err)
-	for i := range candidates {
-		candidates[i] = strings.TrimPrefix(candidates[i], "/private")
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			cache := &ldcache.LDCacheMock{
+				ListFunc: func() ([]string, []string) {
+					return []string{lib32}, []string{lib64}
+				},
+			}
+			l := NewFactory(
+				WithLogger(logger),
+				WithRoot(root),
+				WithCompat32Libraries(!tc.exclude),
+			).newLdcacheLocatorFrom(cache)
+
+			candidates, err := l.Locate("libcuda.so.*")
+			require.NoError(t, err)
+			for i := range candidates {
+				candidates[i] = strings.TrimPrefix(candidates[i], "/private")
+			}
+			require.Equal(t, tc.expected, candidates)
+		})
 	}
-	require.Equal(t, []string{lib64, lib32}, candidates)
 }

--- a/pkg/lookup/library.go
+++ b/pkg/lookup/library.go
@@ -19,8 +19,13 @@ package lookup
 // NewLibraryLocator creates a library locator using the specified options.
 // If search paths (WithSearchPaths(path1, path2, ...)) are explicitly specified
 // a library locator using these as absolute paths are used. Otherwise the
-// library is constructed by combining results from a set of predefined search
-// paths and the ldcache.
+// library locator combines unique matches from the following sources, in
+// precedence order:
+//   - predefined search paths
+//   - 64-bit entries from the ldcache
+//   - 32-bit entries from the ldcache
+//
+// If multiple sources return the same path, the first occurrence is kept.
 func NewLibraryLocator(opts ...Option) Locator {
 	f := NewFactory(opts...)
 

--- a/pkg/lookup/library.go
+++ b/pkg/lookup/library.go
@@ -19,11 +19,8 @@ package lookup
 // NewLibraryLocator creates a library locator using the specified options.
 // If search paths (WithSearchPaths(path1, path2, ...)) are explicitly specified
 // a library locator using these as absolute paths are used. Otherwise the
-// library is constructed using the following ordering, returning the first
-// successful result:
-//   - attempt to locate the library / pattern using dlopen
-//   - attempt to locate the library from a set of predefined search paths.
-//   - attempt to locate the library from the ldcache.
+// library is constructed by combining results from a set of predefined search
+// paths and the ldcache.
 func NewLibraryLocator(opts ...Option) Locator {
 	f := NewFactory(opts...)
 
@@ -50,9 +47,9 @@ func NewLibraryLocator(opts ...Option) Locator {
 			"/lib/aarch64-linux-gnu/nvidia/current",
 		}...),
 	)
-	l := First(
+	l := AsUnique(Merge(
 		NewSymlinkLocator(opts...),
 		f.newLdcacheLocator(),
-	)
+	))
 	return l
 }

--- a/pkg/lookup/library.go
+++ b/pkg/lookup/library.go
@@ -19,13 +19,17 @@ package lookup
 // NewLibraryLocator creates a library locator using the specified options.
 // If search paths (WithSearchPaths(path1, path2, ...)) are explicitly specified
 // a library locator using these as absolute paths are used. Otherwise the
-// library locator combines unique matches from the following sources, in
+// library locator combines the unique matches from the following sources, in
 // precedence order:
-//   - predefined search paths
-//   - 64-bit entries from the ldcache
-//   - 32-bit entries from the ldcache
+//   - a set of predefined search paths
+//   - the 64-bit entries of the ldcache
+//   - the 32-bit entries of the ldcache
 //
-// If multiple sources return the same path, the first occurrence is kept.
+// A 32-bit library is typically in a directory that is not in the predefined
+// search paths, so the ldcache is consulted even if one of these already
+// provided a match. If 32-bit libraries are excluded
+// (WithCompat32Libraries(false)), the first source with a match is used
+// instead.
 func NewLibraryLocator(opts ...Option) Locator {
 	f := NewFactory(opts...)
 
@@ -52,9 +56,15 @@ func NewLibraryLocator(opts ...Option) Locator {
 			"/lib/aarch64-linux-gnu/nvidia/current",
 		}...),
 	)
-	l := AsUnique(Merge(
+	if !f.compat32 {
+		return First(
+			NewSymlinkLocator(opts...),
+			f.newLdcacheLocator(),
+		)
+	}
+
+	return AsUnique(Merge(
 		NewSymlinkLocator(opts...),
 		f.newLdcacheLocator(),
 	))
-	return l
 }

--- a/pkg/lookup/library_test.go
+++ b/pkg/lookup/library_test.go
@@ -24,6 +24,8 @@ import (
 
 	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/internal/test"
 )
 
 func TestLibraryLocator(t *testing.T) {
@@ -126,6 +128,67 @@ func TestLibraryLocator(t *testing.T) {
 
 			candidates, err := lut.Locate(tc.libname)
 			require.ErrorIs(t, err, tc.expectedError)
+
+			var cleanedCandidates []string
+			for _, c := range candidates {
+				// On MacOS /var and /tmp symlink to /private/var and /private/tmp which is included in the resolved path.
+				cleanedCandidates = append(cleanedCandidates, strings.TrimPrefix(c, "/private"))
+			}
+			require.EqualValues(t, tc.expected, cleanedCandidates)
+		})
+	}
+}
+
+func TestLibraryLocatorCompat32(t *testing.T) {
+	logger, _ := testlog.NewNullLogger()
+
+	moduleRoot, err := test.GetModuleRoot()
+	require.NoError(t, err)
+
+	// We construct a root with a library in one of the predefined search paths
+	// and an ldcache -- from the rootfs-2 testdata -- that instead refers to
+	// libraries in /var/lib/nvidia/lib64.
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "/etc"), 0o755))
+	require.NoError(t, os.Symlink(
+		filepath.Join(moduleRoot, "testdata/lookup/rootfs-2/etc/ld.so.cache"),
+		filepath.Join(root, "/etc/ld.so.cache"),
+	))
+
+	inSearchPath := filepath.Join(root, "/usr/lib64/libcuda.so.999.88.77")
+	inLdcache := filepath.Join(root, "/var/lib/nvidia/lib64/libcuda.so.999.88.77")
+	for _, library := range []string{inSearchPath, inLdcache} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(library), 0o755))
+		require.NoError(t, os.WriteFile(library, nil, 0o600))
+		require.NoError(t, os.Symlink(library, filepath.Join(filepath.Dir(library), "libcuda.so.1")))
+	}
+
+	testCases := []struct {
+		description string
+		exclude     bool
+		expected    []string
+	}{
+		{
+			description: "the ldcache is also consulted for 32-bit libraries",
+			expected:    []string{inSearchPath, inLdcache},
+		},
+		{
+			description: "the ldcache is not consulted if a search path matches and 32-bit libraries are excluded",
+			exclude:     true,
+			expected:    []string{inSearchPath},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			lut := NewLibraryLocator(
+				WithLogger(logger),
+				WithRoot(root),
+				WithCompat32Libraries(!tc.exclude),
+			)
+
+			candidates, err := lut.Locate("libcuda.so.1")
+			require.NoError(t, err)
 
 			var cleanedCandidates []string
 			for _, c := range candidates {

--- a/pkg/lookup/merge.go
+++ b/pkg/lookup/merge.go
@@ -21,6 +21,7 @@ import (
 )
 
 type first []Locator
+type merged []Locator
 
 type unique struct {
 	locator Locator
@@ -38,6 +39,18 @@ func First(locators ...Locator) Locator {
 	return f
 }
 
+// Merge returns a locator that combines the matches from all supplied locators.
+func Merge(locators ...Locator) Locator {
+	var m merged
+	for _, l := range locators {
+		if l == nil {
+			continue
+		}
+		m = append(m, l)
+	}
+	return m
+}
+
 // Locate returns the results for the first locator that returns a non-empty non-error result.
 func (f first) Locate(pattern string) ([]string, error) {
 	var allErrors []error
@@ -53,6 +66,26 @@ func (f first) Locate(pattern string) ([]string, error) {
 		if len(candidates) > 0 {
 			return candidates, nil
 		}
+	}
+
+	return nil, errors.Join(allErrors...)
+}
+
+// Locate returns the combined results from all locators that return matches.
+func (m merged) Locate(pattern string) ([]string, error) {
+	var candidates []string
+	var allErrors []error
+	for _, l := range m {
+		matches, err := l.Locate(pattern)
+		if err != nil {
+			allErrors = append(allErrors, err)
+			continue
+		}
+		candidates = append(candidates, matches...)
+	}
+
+	if len(candidates) > 0 {
+		return candidates, nil
 	}
 
 	return nil, errors.Join(allErrors...)

--- a/pkg/lookup/merge.go
+++ b/pkg/lookup/merge.go
@@ -39,7 +39,10 @@ func First(locators ...Locator) Locator {
 	return f
 }
 
-// Merge returns a locator that combines the matches from all supplied locators.
+// Merge returns a locator that combines matches from all supplied locators in
+// argument order. Nil locators are ignored. If at least one locator returns a
+// match, errors from the other locators are ignored; otherwise, all locator
+// errors are joined and returned.
 func Merge(locators ...Locator) Locator {
 	var m merged
 	for _, l := range locators {

--- a/pkg/lookup/merge_test.go
+++ b/pkg/lookup/merge_test.go
@@ -1,0 +1,58 @@
+/**
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package lookup
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	first := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return []string{"first"}, nil
+		},
+	}
+	second := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return []string{"second"}, nil
+		},
+	}
+
+	candidates, err := Merge(first, second).Locate("libcuda.so.*")
+	require.NoError(t, err)
+	require.Equal(t, []string{"first", "second"}, candidates)
+}
+
+func TestMergeReturnsMatchesWhenAnotherLocatorFails(t *testing.T) {
+	failing := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return nil, fmt.Errorf("lookup failed")
+		},
+	}
+	matching := &LocatorMock{
+		LocateFunc: func(string) ([]string, error) {
+			return []string{"match"}, nil
+		},
+	}
+
+	candidates, err := Merge(failing, matching).Locate("libcuda.so.*")
+	require.NoError(t, err)
+	require.Equal(t, []string{"match"}, candidates)
+}

--- a/pkg/nvcdi/api.go
+++ b/pkg/nvcdi/api.go
@@ -100,4 +100,10 @@ const (
 	// FeatureDisableIPCDiscoverer disables the inclusion of IPC sockets
 	// (nvidia-persistenced, nvidia-fabricmanager, MPS) in the CDI spec.
 	FeatureDisableIPCDiscoverer = FeatureFlag("disable-ipc-discoverer")
+
+	// FeatureDisableCompat32Libraries disables the inclusion of the 32-bit
+	// compatibility driver libraries installed on the host.
+	// These are included by default and are only exposed to a container that
+	// can run 32-bit applications. See the update-ldcache hook.
+	FeatureDisableCompat32Libraries = FeatureFlag("disable-compat32-libraries")
 )

--- a/pkg/nvcdi/lib.go
+++ b/pkg/nvcdi/lib.go
@@ -222,6 +222,7 @@ func (o *options) getDriverOptions() []root.Option {
 		root.WithDevRoot(o.devRoot),
 		root.WithLibrarySearchPaths(o.librarySearchPaths...),
 		root.WithConfigSearchPaths(o.configSearchPaths...),
+		root.WithCompat32Libraries(!o.featureFlags[FeatureDisableCompat32Libraries]),
 		root.WithVersioner(
 			root.FirstOf(
 				nvsandboxutilslibWithVersion(o.nvsandboxutilslib),

--- a/pkg/nvcdi/options.go
+++ b/pkg/nvcdi/options.go
@@ -133,6 +133,7 @@ func (o *options) driverLibraryLocator() lookup.Locator {
 		lookup.WithLogger(o.logger),
 		lookup.WithRoot(o.driverRoot),
 		lookup.WithSearchPaths(o.librarySearchPaths...),
+		lookup.WithCompat32Libraries(!o.featureFlags[FeatureDisableCompat32Libraries]),
 	)
 }
 


### PR DESCRIPTION
Superseding and takeover of #1968.

Closes #1968 

Reviewer: @henry118 @cdesiniotis 

Continues #1968 by @elibosley, whose two commits are included here unmodified. The commits that follow address the review on this PR. Related to #563.

## Background

`ldcache.List()` returns the 32-bit and 64-bit library sets separately, and the CDI lookup path discarded the 32-bit one. The default library locator also stopped at the first source that produced a match, so the linker cache could not contribute libraries from a compat32 directory once a library had been found in a predefined native path.

On a multilib host the generated spec therefore exposes the 64-bit driver stack while leaving a 32-bit application — a Steam or Proton title, a 32-bit CUDA or VDPAU consumer — without the matching vendor libraries, even though ELF32 driver libraries are installed and catalogued in the host's linker cache. Such applications fall back to software rendering or fail to start.

## Where the gate is

The review asked for a flag to gate this, and for the 32-bit stack to be kept out of Alpine entirely. The gate is now in two parts, and the part that decides whether a container is affected is the container's own:

- **The host spec carries the 32-bit stack whenever the host has it**, with an opt-out for administrators who would rather it were not there at all.
- **A container only sees it if it can use it.** The `update-ldcache` hook decides this per container, at a point where both the ELF class of every injected library and the container's own userspace are directly observable.
- **A musl container never sees it.** i386 multiarch is not a supported concept in musl.

### Discovery, on the host

The 32-bit set from `ldcache.List()` is no longer discarded, and the default library locator merges the unique matches of its sources instead of stopping at the first one that produces a match, so the linker cache can contribute a compat32 directory even when a predefined native path already matched. The native results keep their position at the front.

This is on by default rather than opt-in because:

- The 32-bit driver stack is already an opt-in at the packaging level. It is a separate, optional install on every distribution: the `.run` installer asks whether to install the 32-bit compatibility libraries, and Debian and Ubuntu ship them as a separate `:i386` package. A host without them produces the same spec as today.
- Whether the libraries are wanted is a property of the workload, not of the host. A spec is generated once, by root or by a systemd unit, and a user who then needs the 32-bit stack cannot regenerate it. Gating discovery on the host fixes the answer for every container on the machine at install time, decided by someone who cannot know the question.
- What a container that does not want them pays is bounded and inert: the additional read-only bind mounts below, and nothing in its search path.

To leave them out of the spec entirely:

```console
$ nvidia-ctk cdi generate --disable-compat32
```

```shell
# also honoured in /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env,
# where it is documented as a commented example
NVIDIA_CTK_CDI_GENERATE_DISABLE_COMPAT32=true
```

```toml
[nvidia-container-runtime.modes.jit-cdi]
nvcdi-feature-flags = ["disable-compat32-libraries"]
```

and `nvcdi.WithFeatureFlags(nvcdi.FeatureDisableCompat32Libraries)` for API consumers such as the device plugin.

### Exposure, in the container

`internal/ldconfig` classifies each injected directory by the ELF class of the libraries it contains (`debug/elf`) and adds a 32-bit directory to the container's search path only when:

- the container does not use musl, **and**
- it requested the `compat32`/`all` driver capability through `NVIDIA_DRIVER_CAPABILITIES` — the capability that drives `--compat32` in `nvidia-container-cli` — **or** it ships a dynamic linker for 32-bit applications (`/lib/ld-linux.so.2` or `/lib32/ld-linux.so.2`; `/lib/ld-linux-armhf.so.3` or `/lib/ld-linux.so.3` on arm64).

Otherwise the 32-bit directories are left out of the `00-nvcr-*.conf` drop-in and of the musl `.path` file, and the dynamic linker never searches them. A stock `ubuntu:24.04` or `alpine` container is therefore unaffected, and a multilib image — the one that has a reason to care — works with nothing set.

Notes on this:

- The capability is read from the container's OCI spec by the hook. Some configurations cannot read it (`--userns=nomap`, #648); a container whose capabilities cannot be determined is treated as not having requested them, and the linker check decides.
- Classification reads the ELF header rather than matching path names such as `i386-linux-gnu` or `lib32`, so it also holds for hosts that do not follow those conventions.
- The mounts themselves are the one thing this cannot gate: CDI container edits are static, so the libraries are bind-mounted into every container that requests the device, searchable or not. Gating those too would mean a separate device or class, which is a larger change than this one.

### musl

`/etc/ld-musl-<arch>.path` carries no architecture information: musl's dynamic linker loads the first file matching the requested name and fails instead of continuing the search, so a wrong-arch match breaks the workload. There is no second `.path` file to route the 32-bit directories to, so they are never written to one. The hook additionally:

- prepends newly added driver directories ahead of the existing entries, so that an injected library wins a name lookup against a file of the same name that already sits in a searched directory. This is the same precedence the glibc path gives these directories through the `00-nvcr-*.conf` drop-in;
- preserves musl's built-in `/lib:/usr/local/lib:/usr/lib` search path when it creates the file. Alpine ships no `.path` file, so the hook creates one, and creating it replaces the default search path. `/usr/local/lib` is silently dropped today; this is a pre-existing bug in the same function;
- splits the file on colons and newlines, exactly as musl's dynamic linker does, so the hook sees the same entries the linker will.

`isMusl` now also detects the musl dynamic linker, falling back to the `/etc/alpine-release` check it used before.

## Verification

Bare-metal x86_64, Ubuntu 26.04, 2x Tesla P100-SXM2-16GB, driver 580.178.04, `libnvidia-gl-580:i386` installed, Docker 29.7.2. Specs generated with `nvidia-ctk cdi generate --mode=nvml` into `/etc/cdi` under distinct vendors and requested with `docker run --runtime=runc --device <vendor>/gpu=all`.

**Discovery.** The generated spec grows from 58 to 83 `hostPath` entries: 25 ELF32 driver libraries under `/usr/lib/i386-linux-gnu`, their soname symlinks, and `--folder /usr/lib/i386-linux-gnu{,/vdpau}` for the `update-ldcache` hook.

**The musl failure that motivates the container-side gate.** With the 32-bit libraries in the spec and a hook that adds every injected directory to the `.path` file, in an Alpine container whose image ships one:

```
# ldd /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0
Error loading shared library libnvidia-glsi.so.580.178.04: Exec format error (needed by /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0)
Error loading shared library libnvidia-tls.so.580.178.04: Exec format error (needed by /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0)
Error loading shared library libnvidia-glcore.so.580.178.04: Exec format error (needed by /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0)
```

**With this PR**, same image and spec:

```
# ldd /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0
	libnvidia-glsi.so.580.178.04 => /usr/lib/x86_64-linux-gnu/libnvidia-glsi.so.580.178.04
	libnvidia-tls.so.580.178.04 => /usr/lib/x86_64-linux-gnu/libnvidia-tls.so.580.178.04
	libnvidia-glcore.so.580.178.04 => /usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.580.178.04
```

`/etc/ld-musl-x86_64.path` holds the native driver directories and no 32-bit entry. In the image above, which ships a `.path` file, the native driver directories are prepended and the existing entries keep their order.

**32-bit workloads.** In multilib images (`ubuntu:26.04` and `debian:trixie` with `libc6:i386`, `libvulkan1{,:i386}`, `libegl1{,:i386}`, `libx11-6{,:i386}` and `libxext6{,:i386}`), a 32-bit process enumerates both P100s through Vulkan (`vkCreateInstance`, `vkEnumeratePhysicalDevices`, `vkGetPhysicalDeviceProperties`, served by the injected 32-bit `libGLX_nvidia.so.0` ICD) and initialises the CUDA driver API (`cuInit` succeeds and reports both devices through the 32-bit `libcuda.so.1`). On `main` the same programs fail with `VK_ERROR_INCOMPATIBLE_DRIVER` and a failed `dlopen`, while their 64-bit builds pass either way. These images carry `libc6:i386`, so the hook exposes the 32-bit directories to them with nothing set. The ICD `dlopen`s glvnd's `libEGL.so.1` and the X11 client libraries of its own architecture, so the image has to provide those; without them it fails identically on `main`.

**Second host, discovery and the gating decision.** x86_64, Tesla V100-SXM2-32GB, driver 580.173.02, `libnvidia-gl-580:i386` installed. `nvidia-ctk cdi generate --mode=nvml` produces 83 mounts where `main` produces 58, the 25 additional entries being the ELF32 driver libraries under `/usr/lib/i386-linux-gnu{,/vdpau}`, which are also passed to the `update-ldcache` hook as `--folder` arguments; `--disable-compat32` produces a spec identical to the one generated on `main`. The hook's decision, run against real filesystems rather than fixtures: that host's own root, which carries `/lib/ld-linux.so.2`, is allowed with nothing set; an unpacked `alpine-minirootfs-3.21.3` is skipped, with and without the `compat32` capability; and the ELF class filter over the four driver directories keeps `/usr/lib/x86_64-linux-gnu{,/vdpau}` and drops `/usr/lib/i386-linux-gnu{,/vdpau}`.

Unit tests cover the locator merge and the ldcache split (from #1968), the discovery opt-out, the ELF class filter, the container-side gate in all of its cases, the `.path` file ordering and default-search-path preservation, musl detection, and the container environment lookup the capability is read from. Tests for the touched packages pass, and `golangci-lint run ./...`, `go vet ./...` and `gofmt` are clean.

## Notes for reviewers

- `NVIDIA_CTK_LIBCUDA_DIR` becomes `/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu` on multilib hosts. The variable already carries a list, and the native directory stays first, but any consumer taking the last entry would now get the 32-bit one.
- Merging in `NewLibraryLocator` widens every lookup that uses it, not only 32-bit ones: the ldcache is now consulted even when a predefined search path already matched. Deduplication and native-first ordering keep version inference, which uses the first result, unchanged. `--disable-compat32` restores the previous first-match behaviour along with the rest.
- The container-side gate lives in the hook, so a spec generated by this version and run against an older `nvidia-cdi-hook` would not be gated. The two ship in the same package.
- Hosts that pass explicit search paths — NixOS drives `nvidia-ctk` with `--library-search-path` — take the early return in `NewLibraryLocator` and are unaffected by the discovery change. Exposing the 32-bit stack there means passing a second search path for the driver's `lib32` output; the hook change classifies those directories correctly, since it does not rely on path naming.
- Prepending in the musl `.path` file only applies to directories that are not searched already, so a driver directory that is also a system directory keeps its position.
