### PR TITLE
fix malformed hookscratch dir names

### DIFF
--- a/cmd/nvidia-cdi-hook/disable-device-node-modification/params_linux.go
+++ b/cmd/nvidia-cdi-hook/disable-device-node-modification/params_linux.go
@@ -32,7 +32,7 @@ import (
 
 func createParamsFileInContainer(containerRoot *os.Root, contents []byte) error {
 
-	hookScratchDirPath := "/run/nvidia-ctk-hook" + uuid.NewString()
+	hookScratchDirPath := filepath.Join("/run/nvidia-ctk-hook", uuid.NewString())
 	if err := containerRoot.MkdirAll(hookScratchDirPath[1:], 0755); err != nil {
 		return fmt.Errorf("error creating hook scratch folder: %w", err)
 	}

--- a/internal/ldconfig/ldconfig_linux.go
+++ b/internal/ldconfig/ldconfig_linux.go
@@ -191,7 +191,7 @@ func mountLdConfig(hostLdconfigPath string, containerRoot *os.Root) (string, err
 		return "", fmt.Errorf("error reading host ldconfig: %w", err)
 	}
 
-	hookScratchDirPath := "/run/nvidia-ctk-hook/" + uuid.NewString()
+	hookScratchDirPath := filepath.Join("/run/nvidia-ctk-hook", uuid.NewString())
 	ldconfigPath := filepath.Join(hookScratchDirPath, "ldconfig")
 	if err := containerRoot.MkdirAll(hookScratchDirPath[1:], 0755); err != nil {
 		return "", fmt.Errorf("error creating hook scratch folder: %w", err)


### PR DESCRIPTION
This was created in response to a review comment in PR #2040.

- `params_linux` and `ldconfig_linux` are now aligned in how they generate the hook scratch directory
- uses `filepath.Join` so it's more idiomatic 