### PR TITLE
Apply read-only and nodev flags in a separate remount

### DIFF
--- a/cmd/nvidia-cdi-hook/disable-device-node-modification/params_linux.go
+++ b/cmd/nvidia-cdi-hook/disable-device-node-modification/params_linux.go
@@ -63,9 +63,20 @@ func createParamsFileInContainer(containerRoot *os.Root, contents []byte) error 
 	}
 	defer nvidiaDriverParamsFile.Close()
 
-	if err := unix.Mount(utils.GetProcFdPath(modifiedParamsFile), utils.GetProcFdPath(nvidiaDriverParamsFile), "",
-		unix.MS_BIND|unix.MS_RDONLY|unix.MS_NODEV|unix.MS_PRIVATE|unix.MS_NOSYMFOLLOW, ""); err != nil {
+	// The MS_RDONLY, MS_NODEV and MS_NOSYMFOLLOW flags are ignored by mount(2) when
+	// they are supplied alongside MS_BIND; they only take effect on a subsequent
+	// MS_REMOUNT. MS_PRIVATE likewise has to be applied in its own call. Without
+	// these follow-up calls the bind mount is created read-write.
+	target := utils.GetProcFdPath(nvidiaDriverParamsFile)
+	if err := unix.Mount(utils.GetProcFdPath(modifiedParamsFile), target, "", unix.MS_BIND, ""); err != nil {
 		return fmt.Errorf("failed to mount modified params file: %w", err)
+	}
+	if err := unix.Mount("", target, "",
+		unix.MS_REMOUNT|unix.MS_BIND|unix.MS_RDONLY|unix.MS_NODEV|unix.MS_NOSYMFOLLOW, ""); err != nil {
+		return fmt.Errorf("failed to remount modified params file as read-only: %w", err)
+	}
+	if err := unix.Mount("", target, "", unix.MS_PRIVATE, ""); err != nil {
+		return fmt.Errorf("failed to make modified params file mount private: %w", err)
 	}
 
 	return nil

--- a/internal/ldconfig/ldconfig_linux.go
+++ b/internal/ldconfig/ldconfig_linux.go
@@ -213,9 +213,20 @@ func mountLdConfig(hostLdconfigPath string, containerRoot *os.Root) (string, err
 	}
 	defer ldconfigFile.Close()
 
-	if err := unix.Mount(hostLdconfigPath, utils.GetProcFdPath(ldconfigFile), "",
-		unix.MS_BIND|unix.MS_RDONLY|unix.MS_NODEV|unix.MS_PRIVATE|unix.MS_NOSYMFOLLOW, ""); err != nil {
+	// The MS_RDONLY, MS_NODEV and MS_NOSYMFOLLOW flags are ignored by mount(2) when
+	// they are supplied alongside MS_BIND; they only take effect on a subsequent
+	// MS_REMOUNT. MS_PRIVATE likewise has to be applied in its own call. Without
+	// these follow-up calls the bind mount is created read-write.
+	target := utils.GetProcFdPath(ldconfigFile)
+	if err := unix.Mount(hostLdconfigPath, target, "", unix.MS_BIND, ""); err != nil {
 		return "", fmt.Errorf("error bind mounting host ldconfig: %w", err)
+	}
+	if err := unix.Mount("", target, "",
+		unix.MS_REMOUNT|unix.MS_BIND|unix.MS_RDONLY|unix.MS_NODEV|unix.MS_NOSYMFOLLOW, ""); err != nil {
+		return "", fmt.Errorf("error remounting host ldconfig as read-only: %w", err)
+	}
+	if err := unix.Mount("", target, "", unix.MS_PRIVATE, ""); err != nil {
+		return "", fmt.Errorf("error making host ldconfig mount private: %w", err)
 	}
 
 	return ldconfigPath, nil


### PR DESCRIPTION
## Description

mount(2) silently ignores MS_RDONLY, MS_NODEV and MS_NOSYMFOLLOW when they are supplied alongside MS_BIND in a single call. Per the mount(2) man page, a bind mount takes its mount options from the source mount; the requested flags only take effect on a subsequent MS_REMOUNT | MS_BIND call. MS_PRIVATE is a propagation-type change and likewise cannot be combined with MS_BIND — it needs its own call.

Two bind mounts in the toolkit pass all of these flags in one call, so the resulting mounts are created read-write, with none of the four flags applied:

- cmd/nvidia-cdi-hook/disable-device-node-modification/params_linux.go
- internal/ldconfig/ldconfig_linux.go

This change splits each into the three calls the kernel actually requires: the bind, then an MS_REMOUNT | MS_BIND carrying the restrictive flags, then MS_PRIVATE.

Observed on /proc/self/mountinfo for the affected mount:

before:  rw,relatime
after:   ro,nodev,relatime,nosymfollow

Note on impact. This is a correctness fix, not a security fix, and I don't think it warrants an advisory. For disable-device-node-modification in particular, access to devices the container was not assigned is independently enforced by the devices cgroup: a container that restores its own view of ModifyDeviceFiles: 1 can create a device node but still cannot open it (Operation not permitted). These flags are defence in depth — this change makes them actually apply rather than being silently dropped.

## Checklist

- [ x ] No secrets, sensitive information, or unrelated changes
- [ x ] Unit tests passing (`make test`)
- [ x ] Lint checks passing (`make lint`)
- [ x ] Test cases are added for new code paths
- [ x ] Commits are signed-off and [cryptographically signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

## Testing

- make test — passes, no failures. Both affected packages included:
  - ok  .../cmd/nvidia-cdi-hook/disable-device-node-modification  coverage: 20.3% of statements
  - ok  .../internal/ldconfig  coverage: 26.4% of statements
- make lint — passes, no issues reported in either changed file.
- make fmt reports no changes for the two files touched here.
- Manually verified the flag behaviour by inspecting /proc/self/mountinfo for the affected mount before and after the change (see above).
