### PR TITLE
Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# General approvers for NVIDIA Container Toolkit repository
+@cdesiniotis @tariq1890 @henry118

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Before beginning implementation or opening a Pull Request for a significant chan
 issue describing the problem or proposal. A significant change includes, but is not limited to,
 architectural changes, new features, breaking changes to API or behavior, and non-trivial bug fixes.
 
+Reviewers are automatically assigned to Pull Requests from the [OWNERS](CODEOWNERS) file.
+The approval / decision-making process is documented in [GOVERNANCE.md](GOVERNANCE.md)
+
 All contributions must adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Sign your work


### PR DESCRIPTION
## Description

This addresses SIG-CON-10 and SIG-BP-06 from OSS Scorecard.

This builds on top of https://github.com/NVIDIA/nvidia-container-toolkit/pull/2052.

## Checklist

- [ ] No secrets, sensitive information, or unrelated changes
- [ ] Unit tests passing (`make test`)
- [ ] Lint checks passing (`make lint`)
- [ ] Test cases are added for new code paths
- [ ] Commits are signed-off and [cryptographically signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

## Testing

OSS Scorecard was run with and without this change.