### PR TITLE
internal/dxcore: Fix build on 32-bit targets

### DIFF
--- a/internal/dxcore/dxcore.go
+++ b/internal/dxcore/dxcore.go
@@ -52,8 +52,8 @@ func (c context) getAdapterCount() int {
 }
 
 func (c context) getAdapter(index int) adapter {
-	arrayPointer := (*[1 << 30]C.struct_dxcore_adapter)(unsafe.Pointer(c.adapterList))
-	return adapter(arrayPointer[index])
+	adapters := unsafe.Slice(c.adapterList, c.adapterCount)
+	return adapter(adapters[index])
 }
 
 func (a adapter) getDriverStorePath() string {


### PR DESCRIPTION
## Description

`dxcore.getAdapter()` reinterprets the C adapter list through a
`(*[1 << 30]C.struct_dxcore_adapter)` array pointer. On ILP32 targets the
struct is 76 bytes, so that array type is larger than the whole address
space and the compiler rejects the type itself:

internal/dxcore/dxcore.go:55:2: type [1073741824]_Ctype_struct_dxcore_adapter larger than address space
internal/dxcore/dxcore.go:55:2: type [1073741824]_Ctype_struct_dxcore_adapter too large

This breaks every consumer that imports `pkg/nvcdi` on `GOARCH=386` or
`GOARCH=arm`. We hit it packaging LXD 6.9, which vendors
nvidia-container-toolkit v1.19.1, for the i586 architecture of ALT Linux.

The fix indexes the C array through `unsafe.Slice()` bounded by
`adapterCount`, which is the modern replacement for the huge-array idiom
and works on every pointer size. No behaviour change on 64-bit targets.

## Checklist

- [x] No secrets, sensitive information, or unrelated changes
- [x] Unit tests passing (`make test`)
- [x] Lint checks passing (`make lint`)
- [ ] Test cases are added for new code paths — no new code path; this is a
compile-time fix with no runtime behaviour change
- [x] Commits are signed-off and cryptographically signed

## Testing

- `GOARCH=386 CGO_ENABLED=1 go build ./internal/dxcore/` fails on `main`
  with the diagnostic above and passes with this change.
- `go build ./internal/dxcore/ ./pkg/nvcdi/` and `make test` pass on amd64.
- LXD 6.9 with this change applied to its vendored copy builds and passes
  its packaging checks in a clean i586 chroot on ALT Linux Sisyphus.