### PR TITLE
chore:[dependabot] exclude nvidia dependencies in cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     - "tests"
     schedule:
       interval: "daily"
+    cooldown:
+      exclude:
+      - github.com/NVIDIA/*
     open-pull-requests-limit: 10
     labels:
     - dependencies


### PR DESCRIPTION
We exclude NVIDIA-owned go modules from the dependabot cooldowns as these dependencies are managed by us and can be updated with high confidence.

This unblocks the automatication PR creation for bumping go-nvml