### PR TITLE
Fix intermittent EBADF in create-symlinks hook

### DIFF
--- a/cmd/nvidia-cdi-hook/create-symlinks/container-root_linux.go
+++ b/cmd/nvidia-cdi-hook/create-symlinks/container-root_linux.go
@@ -48,6 +48,9 @@ func (m command) createSymlinkInRoot(containerRootDir string, targetPath string,
 			return fmt.Errorf("failed to open parent dir of link in root: %w", err)
 		}
 	}
+	// Keeps the *os.File alive while its raw fd is in use; otherwise the GC's
+	// finalizer can close it between Symlinkat and Renameat (EBADF).
+	defer linkDirInRoot.Close()
 	linkDirFd := int(linkDirInRoot.Fd())
 
 	m.logger.Infof("Symlinking %v to %v", filepath.Join(linkDirInRoot.Name(), filepath.Base(linkPath)), targetPath)


### PR DESCRIPTION
Fix intermittent container start failures in the `create-symlinks` hook: keep the link's parent directory `*os.File` alive until the symlink is created and renamed, and close it when the function returns.

## Symptom

Since v1.20.0 the `create-symlinks` hook occasionally exits 1 and crun aborts container creation:

```
level=error msg="failed to create link [libnvidia-opticalflow.so.580.126.20 /usr/lib64/nvidia/libnvidia-opticalflow.so.1]: failed to create symlink: bad file descriptor"
Error: OCI runtime error: crun: error executing hook `/usr/bin/nvidia-cdi-hook` (exit code: 1)
```

The failure is rare (about 1 in 1,000–2,000 container starts on busy hosts), does not repeat on the same host, and the link that fails varies. Where many containers must all start (multi-node jobs), that rate makes a start fail on most attempts.

## Context

The Container Device Interface (CDI) spec generated by `nvidia-ctk` lists, besides GPU device nodes and driver libraries, a set of hooks: programs the OCI runtime (for example crun) executes while creating the container, before the container's own command starts. `nvidia-cdi-hook create-symlinks` is one of them. It creates symbolic links inside the container's root filesystem so that driver libraries are reachable under the names applications load (for example `libcuda.so.1 -> libcuda.so.580.126.20`).

For each link, `createSymlinkInRoot` (`cmd/nvidia-cdi-hook/create-symlinks/container-root_linux.go`) opens the link's parent directory inside the container root with `pathrs.OpenatInRoot`, or `pathrs.MkdirAllHandle` when it has to create it. Both return an `*os.File`. The function then takes the raw file descriptor with `linkDirInRoot.Fd()` and only uses that integer afterwards: `unix.Symlinkat` creates the link under a temporary name and `unix.Renameat` moves it to its final name.

In Go, an `*os.File` has a finalizer that closes its descriptor once the object is unreachable. Holding the integer descriptor does not keep the object reachable. After the last use of `linkDirInRoot` (the `.Name()` call in the log line), the garbage collector may finalize it at any time. If that happens before `Renameat` (or before `Symlinkat`), the syscall fails with `EBADF`. The error text above comes from the `Renameat` branch (`failed to create symlink`; the `Symlinkat` branch says `failed to create temporary symlink`). The hook logs the error and exits 1.

The other places in this repository that use a raw descriptor keep the `*os.File` alive with a deferred `Close()` or `runtime.KeepAlive` (`cudacompat/container-root_linux.go`, `internal/ldconfig/ldconfig_linux.go`, `internal/ldcache/ldcache.go`, `disable-device-node-modification/params_linux.go`); this function was the only one that did not.

## History

The function exists in two versions of the same-titled commit "Use cyphar/filepath-securejoin/pathrs-lite in create-symlinks hook" (both dated 2026-05-08, merged 2026-05-21 as "Merge commit from fork", so there is no public PR):

- e62aacfd3f428af77304a459b2f30a7ac99d9a97 on the v1.19 release line (in v1.19.1): **has** `defer linkDirInRoot.Close()` — [v1.19.1 file, line 51](https://github.com/NVIDIA/nvidia-container-toolkit/blob/09ceee5dde66ba9ce25c7cc69b1ebd5e6e3266fa/cmd/nvidia-cdi-hook/create-symlinks/container-root_linux.go#L51)
- ffb2e8f753c8839d6d1f29c46c58c9a44220b990 on `main` (in v1.20.0-rc.1, v1.20.0 and current `main`): the `defer` is **missing** — [v1.20.0 file, line 51](https://github.com/NVIDIA/nvidia-container-toolkit/blob/5505e2f94d9aaa08561490db974ba3cd676af209/cmd/nvidia-cdi-hook/create-symlinks/container-root_linux.go#L51)

```
$ git diff v1.19.1 v1.20.0 -- cmd/nvidia-cdi-hook/create-symlinks/container-root_linux.go
-	defer linkDirInRoot.Close()
-	m.logger.Infof("Symlinking %q to %q", filepath.Join(linkDirInRoot.Name(), filepath.Base(linkPath)), targetPath)
+	m.logger.Infof("Symlinking %v to %v", filepath.Join(linkDirInRoot.Name(), filepath.Base(linkPath)), targetPath)
```

Full compare: https://github.com/NVIDIA/nvidia-container-toolkit/compare/v1.19.1...v1.20.0. v1.19.x is not affected; every release from v1.20.0-rc.1 on is.

## Fix

Restore `defer linkDirInRoot.Close()` right after the handle is obtained. The `*os.File` stays reachable for the whole function, and the descriptor is closed deterministically on both success and error paths.

## Testing

```sh
go build ./cmd/nvidia-cdi-hook/...
go test ./cmd/nvidia-cdi-hook/create-symlinks/
```

Both pass (Go 1.26.5, linux/arm64). The test output:

```
ok  	github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-cdi-hook/create-symlinks	0.009s
```

Reproduction of the bug on v1.20.0: containers were started repeatedly on a set of hosts with the crun annotations `run.oci.hooks.stdout` / `run.oci.hooks.stderr` set, so the hook's own output was captured (crun otherwise discards it). The only error the hook ever logged was the `bad file descriptor` message above, from the `Renameat` step; the same host started fine on its next attempt each time.

Not covered: the existing package tests cannot force a garbage collection between the two syscalls, so they do not exercise the race, and no post-fix soak run of repeated container starts is included here.
